### PR TITLE
feat: implement workflow report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 
 default: all
 
-all: fmt test
+all: fmt lint test
 
 fmt:
 	$(info ******************** checking formatting ********************)
@@ -40,7 +40,8 @@ mocks:
 test: install_deps
 	$(info ******************** running tests ********************)
 	go clean -testcache
-	go test -failfast -race -covermode=atomic -coverprofile coverage.out ./...
+	#go test -failfast -race -covermode=atomic -coverprofile coverage.out ./...
+	richgo test -failfast -race -covermode=atomic -coverprofile coverage.out ./...
 
 .PHONY: coverage
 coverage: test

--- a/README.md
+++ b/README.md
@@ -22,8 +22,106 @@ A report data model can be found in file [reports.go](https://github.com/automa-
 Developers need to populate a Report object in every `Run` and `Rollback` method as shown in the example. 
 
 ## Usage
-See an [example](https://github.com/automa-saga/automa/blob/master/example/example.go) in the example directory. As shown 
-in the example, each step can have its own internal cache to help implementing the rollback mechanism.
+
+1. Add dependency using `go get -u "github.com/automa-saga/automa"`.
+2. Implement workflow steps (implements `automa.AtomicStep` interface) using the pattern as below:
+```go
+type MyStep1 struct {
+	*automa.Step
+	params map[string]string // define any parameter data model as required
+}
+
+// Run implements the automa.AtomicStep interface
+func (s *MyStep1) Run(ctx context.Context, prevSuccess *Success) (*WorkflowReport, error) {
+	report := NewStepReport(s.ID, RunAction)
+	
+	// perform run action
+	// use params or cache as needed
+	
+	// if error happens, invoke rollback using below
+	// return s.Rollback(ctx, NewFailedRun(ctx, prevSuccess, err, report))
+	
+	// if this action needs to be skipped because of a condition, invoke next Run using..
+	// return s.SkippedRun(ctx, prevSuccess, report) 
+	
+	return s.RunNext(ctx, prevSuccess, report)
+}
+
+// Rollback implements the automa.AtomicStep interface
+func (s *MyStep1) Rollback(ctx context.Context, prevFailure *Failure) (*WorkflowReport, error) {
+	report := NewStepReport(s.ID, RollbackAction)
+	
+	// perform rollback action.
+	// use params or local cache as needed
+	
+	// if error happens, invoke previous rollback using below
+	// return s.FailedRollback(ctx, prevFailure, err, report)
+	
+	// if this action needs to be skipped because of a condition, invoke ..
+	// return s.SkippedRollback(ctx, prevFailure, report) 
+	
+	return s.RollbackPrev(ctx, prevFailure, report)
+}
+```
+3. Then create and run a workflow using `automa.StepRegistry` as below:
+```go
+
+func buildWorkflow1(ctx context.Context, params map[string]string) automa.Workflow {
+    workflowID := "workflow-1"
+	
+    step1 := &MyStep1 {
+        Step:  Step{ID: "Step-1"},
+
+        // add parameters as needed
+        params: params
+    }
+
+    step1 := &MyStep2 {
+        Step:  Step{ID: "Step-2"},
+
+        // add parameters as needed
+        params: params
+    }
+
+    // pass custom zap logger if necessary
+    registry := automa.NewStepRegistry(zap.NewNop()).RegisterSteps(map[string]AtomicStep{
+        step1.GetID(): step1,
+        step2.GetID(): step2,
+    })
+
+    // prepare the sequence of steps
+    // Note that you may create different workflows from the same registry if needed.
+    // However, if the same registry is being reused, ensure each step clears its local cache (if it has any)
+    // before executing its action as necessary.
+    workflow1Steps := []string{
+        step1.GetID(),
+        step2.GetID(),
+    }
+	
+    workflow := registry.BuildWorkflow(workflowID, workflow1Steps)
+    return workflow
+}
+
+func runWorkflow(ctx context.Context) error {
+    params := map[string]string{} // add params as necessary
+	
+    workflow := buildWorkflow1(ctx, params)
+    defer workflow1.End(ctx)
+
+    report, err := workflow.Start(context.Background())
+    if err != nil {
+        return err
+    }
+
+    // do something with the report if necessary 
+    // 'report' can be exported as YAML or JSON. See examples directory.
+
+    return nil
+	
+}
+```
+
+See an [example](https://github.com/automa-saga/automa/blob/master/example/example.go) in the example directory. 
 
 ## Development
  - `make test` runs the tests. 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ func buildWorkflow1(ctx context.Context, params map[string]string) automa.Workfl
     workflowID := "workflow-1"
 	
     step1 := &MyStep1 {
-        Step:  Step{ID: "Step-1"},
+        Step:  Step{ID: "step_1"}, // underscore separated string is suitable for IDs
 
         // add parameters as needed
         params: params
     }
 
     step1 := &MyStep2 {
-        Step:  Step{ID: "Step-2"},
+        Step:  Step{ID: "step_2"},
 
         // add parameters as needed
         params: params

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ func buildWorkflow1(ctx context.Context, params map[string]string) automa.Workfl
     // Note that you may create different workflows from the same registry if needed.
     // However, if the same registry is being reused, ensure each step clears its local cache (if it has any)
     // before executing its action as necessary.
-    workflow1Steps := []string{
+    workflow1Steps := StepIDs{
         step1.GetID(),
         step2.GetID(),
     }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Developers need to populate a Report object in every `Run` and `Rollback` method
 ## Usage
 
 1. Add dependency using `go get -u "github.com/automa-saga/automa"`.
-2. Implement workflow steps (implements `automa.AtomicStep` interface) using the pattern as below:
+2. Implement workflow steps (that implement `automa.AtomicStep` interface) using the pattern as below:
 ```go
 
 // MyStep1 is an example AtomicStep that does not implement AtomicStep interface directly and uses the default 
@@ -35,7 +35,7 @@ type MyStep1 struct {
 }
 
 // run implements the SagaRun method interface to leverage default Run control logic that is implemented in automa.Step
-// Note if not provided, Run action will be marked as SKIPPED
+// Note if not provided, Run action will be marked as SKIPPED. See automa Step implementation.
 func (s *MyStep1) run(ctx context.Context) (skipped bool, err error) {
     // perform run action
     // use params or cache as needed
@@ -47,7 +47,7 @@ func (s *MyStep1) run(ctx context.Context) (skipped bool, err error) {
 	return true, nil
 }
 
-// rollback implements the SagaRollback method interface to leverage default Rollback control logic that is implemented in automa.Step
+// rollback implements the SagaUndo method interface to leverage default Rollback control logic that is implemented in automa.Step
 // Note this is optional and if not provided, Rollback action will be marked as SKIPPED
 func (s *MyStep1) rollback(ctx context.Context) (skipped bool, err error) {
     // perform rollback action

--- a/automa.go
+++ b/automa.go
@@ -7,14 +7,14 @@ import (
 // Forward defines the methods to execute business logic of an AtomicStep and move the workflow forward
 type Forward interface {
 	// Run runs the business logic to be performed in the AtomicStep
-	Run(ctx context.Context, prevSuccess *Success) (Reports, error)
+	Run(ctx context.Context, prevSuccess *Success) (*WorkflowReport, error)
 }
 
 // Backward defines the methods to be executed to move the workflow backward on error
 type Backward interface {
 	// Rollback defines the actions compensating the business logic executed in Run method
 	// A step may skip rollback if that makes sense. In that case it would mean the AtomicStep is not Atomic in nature.
-	Rollback(ctx context.Context, prevFailure *Failure) (Reports, error)
+	Rollback(ctx context.Context, prevFailure *Failure) (*WorkflowReport, error)
 }
 
 // Choreographer interface defines the methods to support double link list of states
@@ -29,6 +29,9 @@ type Choreographer interface {
 // AtomicStep provides interface for an atomic state
 // Note that an AtomicStep may skip rollback if that makes sense and in that case it is not Atomic in nature.
 type AtomicStep interface {
+	// GetID returns the step ID
+	GetID() string
+
 	Forward
 	Backward
 	Choreographer
@@ -45,13 +48,16 @@ type AtomicStepRegistry interface {
 	GetStep(id string) AtomicStep
 
 	// BuildWorkflow builds an AtomicWorkflow comprising the list of AtomicStep identified by ids
-	BuildWorkflow(stepIDs []string) (AtomicWorkflow, error)
+	BuildWorkflow(id string, stepIDs []string) (AtomicWorkflow, error)
 }
 
 // AtomicWorkflow defines interface for a Workflow
 type AtomicWorkflow interface {
+	// GetID returns the workflow ID
+	GetID() string
+
 	// Start starts the AtomicWorkflow execution
-	Start(ctx context.Context) (Reports, error)
+	Start(ctx context.Context) (WorkflowReport, error)
 
 	// End performs cleanup after the AtomicWorkflow engine finish its execution
 	End(ctx context.Context)

--- a/automa.go
+++ b/automa.go
@@ -7,14 +7,14 @@ import (
 // Forward defines the methods to execute business logic of an AtomicStep and move the workflow forward
 type Forward interface {
 	// Run runs the business logic to be performed in the AtomicStep
-	Run(ctx context.Context, prevSuccess *Success) (*WorkflowReport, error)
+	Run(ctx context.Context, prevSuccess *Success) (WorkflowReport, error)
 }
 
 // Backward defines the methods to be executed to move the workflow backward on error
 type Backward interface {
 	// Rollback defines the actions compensating the business logic executed in Run method
 	// A step may skip rollback if that makes sense. In that case it would mean the AtomicStep is not Atomic in nature.
-	Rollback(ctx context.Context, prevFailure *Failure) (*WorkflowReport, error)
+	Rollback(ctx context.Context, prevFailure *Failure) (WorkflowReport, error)
 }
 
 // Choreographer interface defines the methods to support double link list of states
@@ -57,7 +57,7 @@ type AtomicWorkflow interface {
 	GetID() string
 
 	// Start starts the AtomicWorkflow execution
-	Start(ctx context.Context) (*WorkflowReport, error)
+	Start(ctx context.Context) (WorkflowReport, error)
 
 	// End performs cleanup after the AtomicWorkflow engine finish its execution
 	End(ctx context.Context)

--- a/automa.go
+++ b/automa.go
@@ -57,7 +57,7 @@ type AtomicWorkflow interface {
 	GetID() string
 
 	// Start starts the AtomicWorkflow execution
-	Start(ctx context.Context) (WorkflowReport, error)
+	Start(ctx context.Context) (*WorkflowReport, error)
 
 	// End performs cleanup after the AtomicWorkflow engine finish its execution
 	End(ctx context.Context)

--- a/automa.go
+++ b/automa.go
@@ -37,6 +37,9 @@ type AtomicStep interface {
 	Choreographer
 }
 
+// StepIDs is just a wrapper definition for a list of string
+type StepIDs []string
+
 // AtomicStepRegistry is a registry of rollbackable steps
 type AtomicStepRegistry interface {
 	// RegisterSteps registers a set of AtomicStep
@@ -48,7 +51,7 @@ type AtomicStepRegistry interface {
 	GetStep(id string) AtomicStep
 
 	// BuildWorkflow builds an AtomicWorkflow comprising the list of AtomicStep identified by ids
-	BuildWorkflow(id string, stepIDs []string) (AtomicWorkflow, error)
+	BuildWorkflow(id string, stepIDs StepIDs) (AtomicWorkflow, error)
 }
 
 // AtomicWorkflow defines interface for a Workflow

--- a/events.go
+++ b/events.go
@@ -7,13 +7,13 @@ import (
 
 // Success defines a success event for a step
 type Success struct {
-	workflowReport *WorkflowReport
+	workflowReport WorkflowReport
 }
 
 // Failure defines a failure event for a step
 type Failure struct {
 	error
-	workflowReport *WorkflowReport
+	workflowReport WorkflowReport
 }
 
 // NewFailedRun returns a Failure event to be used for first Rollback method
@@ -37,7 +37,7 @@ func NewFailedRollback(ctx context.Context, prevFailure *Failure, err error, rep
 
 // NewStartTrigger returns a Success event to be use for Run method
 // It is used by the Workflow to trigger the execution of the first step
-func NewStartTrigger(reports *WorkflowReport) *Success {
+func NewStartTrigger(reports WorkflowReport) *Success {
 	return &Success{
 		workflowReport: reports,
 	}

--- a/events.go
+++ b/events.go
@@ -1,5 +1,10 @@
 package automa
 
+import (
+	"context"
+	"github.com/cockroachdb/errors"
+)
+
 // Success defines a success event for a step
 type Success struct {
 	workflowReport *WorkflowReport
@@ -11,45 +16,56 @@ type Failure struct {
 	workflowReport *WorkflowReport
 }
 
-// NewRollbackTrigger returns a Failure event to be used for Rollback method
-// It sets the step status as StatusFailed
-func NewRollbackTrigger(prevSuccess *Success, err error, report *StepReport) *Failure {
+// NewFailedRun returns a Failure event to be used for first Rollback method
+// It is used by a step to trigger its own rollback action
+// It sets the step's RunAction status as StatusFailed
+func NewFailedRun(ctx context.Context, prevSuccess *Success, err error, report *StepReport) *Failure {
+	report.Actions[RunAction].Error = errors.EncodeError(ctx, err)
 	prevSuccess.workflowReport.Append(report, RunAction, StatusFailed)
 	return &Failure{error: err, workflowReport: prevSuccess.workflowReport}
 }
 
+// NewFailedRollback returns a Failure event when steps rollback action failed
+// It sets the step's RollbackAction status as StatusFailed
+func NewFailedRollback(ctx context.Context, prevFailure *Failure, err error, report *StepReport) *Failure {
+	report.Actions[RollbackAction].Error = errors.EncodeError(ctx, err)
+	prevFailure.workflowReport.Append(report, RollbackAction, StatusFailed)
+	return &Failure{error: err, workflowReport: prevFailure.workflowReport}
+}
+
 // NewStartTrigger returns a Success event to be use for Run method
-// It sets the step status as StatusSuccess
+// It is used by the Workflow to trigger the execution of the first step
 func NewStartTrigger(reports *WorkflowReport) *Success {
 	return &Success{
 		workflowReport: reports,
 	}
 }
 
-// NewFailure creates a Failure event for rollback
-// It sets the step status as StatusFailed
+// NewFailure creates a Failure event for rollback action
+// It is used by a step to trigger rollback action of the previous step when its own run succeeds.
+// It sets the step's RollbackAction status as StatusSuccess.
 func NewFailure(prevFailure *Failure, report *StepReport) *Failure {
 	prevFailure.workflowReport.Append(report, RollbackAction, StatusSuccess)
 	return &Failure{error: prevFailure.error, workflowReport: prevFailure.workflowReport}
 }
 
-// NewSuccess creates a Success event
-// It sets the step status as StatusSuccess
+// NewSuccess creates a Success event for run action
+// It is used by a step to trigger run action of the nex step when its own run succeeds.
+// It sets the step's RunAction status as StatusSuccess.
 func NewSuccess(prevSuccess *Success, report *StepReport) *Success {
 	prevSuccess.workflowReport.Append(report, RunAction, StatusSuccess)
 	return &Success{workflowReport: prevSuccess.workflowReport}
 }
 
-// NewSkippedRun creates a Success event with StatusSkipped
-// It report the step status as StatusSkipped
+// NewSkippedRun creates a Success event with StatusSkipped for RunAction
+// This is a helper method to be used in run action where the action is skipped.
 func NewSkippedRun(prevSuccess *Success, report *StepReport) *Success {
 	prevSuccess.workflowReport.Append(report, RunAction, StatusSkipped)
 	return &Success{workflowReport: prevSuccess.workflowReport}
 }
 
-// NewSkippedRollback creates a Failure event with StatusSkipped
-// It sets the step status as StatusSkipped
-// This is a helper method to be used in Rollback method where rollback is skipped
+// NewSkippedRollback creates a Failure event with StatusSkipped for RollbackAction
+// This is a helper method to be used in rollback action where the action is skipped.
 func NewSkippedRollback(prevFailure *Failure, report *StepReport) *Failure {
 	prevFailure.workflowReport.Append(report, RollbackAction, StatusSkipped)
 	return &Failure{error: prevFailure.error, workflowReport: prevFailure.workflowReport}

--- a/events.go
+++ b/events.go
@@ -20,7 +20,8 @@ type Failure struct {
 // It is used by a step to trigger its own rollback action
 // It sets the step's RunAction status as StatusFailed
 func NewFailedRun(ctx context.Context, prevSuccess *Success, err error, report *StepReport) *Failure {
-	report.Actions[RunAction].Error = errors.EncodeError(ctx, err)
+	report.Action = RunAction
+	report.Error = errors.EncodeError(ctx, err)
 	prevSuccess.workflowReport.Append(report, RunAction, StatusFailed)
 	return &Failure{error: err, workflowReport: prevSuccess.workflowReport}
 }
@@ -28,7 +29,8 @@ func NewFailedRun(ctx context.Context, prevSuccess *Success, err error, report *
 // NewFailedRollback returns a Failure event when steps rollback action failed
 // It sets the step's RollbackAction status as StatusFailed
 func NewFailedRollback(ctx context.Context, prevFailure *Failure, err error, report *StepReport) *Failure {
-	report.Actions[RollbackAction].Error = errors.EncodeError(ctx, err)
+	report.Action = RollbackAction
+	report.Error = errors.EncodeError(ctx, err)
 	prevFailure.workflowReport.Append(report, RollbackAction, StatusFailed)
 	return &Failure{error: err, workflowReport: prevFailure.workflowReport}
 }

--- a/events.go
+++ b/events.go
@@ -2,73 +2,55 @@ package automa
 
 // Success defines a success event for a step
 type Success struct {
-	reports Reports
+	workflowReport *WorkflowReport
 }
 
 // Failure defines a failure event for a step
 type Failure struct {
 	error
-	reports Reports
+	workflowReport *WorkflowReport
 }
 
 // NewRollbackTrigger returns a Failure event to be used for Rollback method
-// It reports the step status as StatusFailed
-func NewRollbackTrigger(prevSuccess *Success, err error, report *Report) *Failure {
-	var reports Reports
-	if report != nil {
-		reports = report.Append(prevSuccess.reports, StatusFailed)
-	}
-	return &Failure{error: err, reports: reports}
+// It sets the step status as StatusFailed
+func NewRollbackTrigger(prevSuccess *Success, err error, report *StepReport) *Failure {
+	prevSuccess.workflowReport.Append(report, RunAction, StatusFailed)
+	return &Failure{error: err, workflowReport: prevSuccess.workflowReport}
 }
 
 // NewStartTrigger returns a Success event to be use for Run method
-// It reports the step status as StatusSuccess
-func NewStartTrigger(reports Reports) *Success {
+// It sets the step status as StatusSuccess
+func NewStartTrigger(reports *WorkflowReport) *Success {
 	return &Success{
-		reports: reports,
+		workflowReport: reports,
 	}
 }
 
 // NewFailure creates a Failure event for rollback
-// It reports the step status as StatusFailed
-func NewFailure(prevFailure *Failure, report *Report) *Failure {
-	var reports Reports
-	if report != nil {
-		reports = report.Append(prevFailure.reports, StatusFailed)
-	}
-
-	return &Failure{error: prevFailure.error, reports: reports}
+// It sets the step status as StatusFailed
+func NewFailure(prevFailure *Failure, report *StepReport) *Failure {
+	prevFailure.workflowReport.Append(report, RollbackAction, StatusSuccess)
+	return &Failure{error: prevFailure.error, workflowReport: prevFailure.workflowReport}
 }
 
 // NewSuccess creates a Success event
-// It reports the step status as StatusSuccess
-func NewSuccess(prevSuccess *Success, report *Report) *Success {
-	var reports Reports
-	if report != nil {
-		reports = report.Append(prevSuccess.reports, StatusSuccess)
-	}
-	return &Success{reports: reports}
+// It sets the step status as StatusSuccess
+func NewSuccess(prevSuccess *Success, report *StepReport) *Success {
+	prevSuccess.workflowReport.Append(report, RunAction, StatusSuccess)
+	return &Success{workflowReport: prevSuccess.workflowReport}
 }
 
 // NewSkippedRun creates a Success event with StatusSkipped
-// It reports the step status as StatusSkipped
-func NewSkippedRun(prevSuccess *Success, report *Report) *Success {
-	var reports Reports
-	if report != nil {
-		reports = report.Append(prevSuccess.reports, StatusSkipped)
-	}
-
-	return &Success{reports: reports}
+// It report the step status as StatusSkipped
+func NewSkippedRun(prevSuccess *Success, report *StepReport) *Success {
+	prevSuccess.workflowReport.Append(report, RunAction, StatusSkipped)
+	return &Success{workflowReport: prevSuccess.workflowReport}
 }
 
 // NewSkippedRollback creates a Failure event with StatusSkipped
-// It reports the step status as StatusSkipped
+// It sets the step status as StatusSkipped
 // This is a helper method to be used in Rollback method where rollback is skipped
-func NewSkippedRollback(prevFailure *Failure, report *Report) *Failure {
-	var reports Reports
-	if report != nil {
-		reports = report.Append(prevFailure.reports, StatusSkipped)
-	}
-
-	return &Failure{error: prevFailure.error, reports: reports}
+func NewSkippedRollback(prevFailure *Failure, report *StepReport) *Failure {
+	prevFailure.workflowReport.Append(report, RollbackAction, StatusSkipped)
+	return &Failure{error: prevFailure.error, workflowReport: prevFailure.workflowReport}
 }

--- a/events.go
+++ b/events.go
@@ -42,7 +42,7 @@ func NewStartTrigger(reports *WorkflowReport) *Success {
 }
 
 // NewFailure creates a Failure event for rollback action
-// It is used by a step to trigger rollback action of the previous step when its own run succeeds.
+// It is used by a step to trigger rollback action of the previous step when its own rollback succeeds.
 // It sets the step's RollbackAction status as StatusSuccess.
 func NewFailure(prevFailure *Failure, report *StepReport) *Failure {
 	prevFailure.workflowReport.Append(report, RollbackAction, StatusSuccess)
@@ -58,14 +58,14 @@ func NewSuccess(prevSuccess *Success, report *StepReport) *Success {
 }
 
 // NewSkippedRun creates a Success event with StatusSkipped for RunAction
-// This is a helper method to be used in run action where the action is skipped.
+// This is a helper method to be used in run action when the run action is skipped.
 func NewSkippedRun(prevSuccess *Success, report *StepReport) *Success {
 	prevSuccess.workflowReport.Append(report, RunAction, StatusSkipped)
 	return &Success{workflowReport: prevSuccess.workflowReport}
 }
 
 // NewSkippedRollback creates a Failure event with StatusSkipped for RollbackAction
-// This is a helper method to be used in rollback action where the action is skipped.
+// This is a helper method to be used in rollback action when the rollback action is skipped.
 func NewSkippedRollback(prevFailure *Failure, report *StepReport) *Failure {
 	prevFailure.workflowReport.Append(report, RollbackAction, StatusSkipped)
 	return &Failure{error: prevFailure.error, workflowReport: prevFailure.workflowReport}

--- a/events_test.go
+++ b/events_test.go
@@ -14,7 +14,7 @@ func TestNewSkippedRun(t *testing.T) {
 		EndTime:      time.Now(),
 		Status:       "",
 		StepSequence: []string{},
-		StepReports:  map[string]*StepReport{},
+		StepReports:  []*StepReport{},
 	}}
 
 	success := NewSkippedRun(prevSuccess, nil)
@@ -38,7 +38,7 @@ func TestNewSkippedRollback(t *testing.T) {
 			EndTime:      time.Now(),
 			Status:       "",
 			StepSequence: []string{},
-			StepReports:  map[string]*StepReport{},
+			StepReports:  []*StepReport{},
 		},
 	}
 	failure := NewSkippedRollback(prevFailure, nil)

--- a/events_test.go
+++ b/events_test.go
@@ -4,30 +4,51 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestNewSkippedRun(t *testing.T) {
-	prevSuccess := &Success{}
+	prevSuccess := &Success{workflowReport: &WorkflowReport{
+		WorkflowID:   "test",
+		StartTime:    time.Now(),
+		EndTime:      time.Now(),
+		Status:       "",
+		StepSequence: []string{},
+		StepReports:  map[string]*StepReport{},
+	}}
+
 	success := NewSkippedRun(prevSuccess, nil)
 	assert.NotNil(t, success)
-	assert.Nil(t, success.reports)
+	assert.NotNil(t, success.workflowReport)
+	assert.Equal(t, 0, len(success.workflowReport.StepReports))
 
-	report := NewReport("TEST")
+	report := NewStepReport("TEST", RunAction)
 	success = NewSkippedRun(prevSuccess, report)
 	assert.NotNil(t, success)
-	assert.NotNil(t, success.reports)
-	assert.Equal(t, 1, len(success.reports))
+	assert.NotNil(t, success.workflowReport)
+	assert.Equal(t, 1, len(success.workflowReport.StepReports))
 }
 
 func TestNewSkippedRollback(t *testing.T) {
-	prevFailure := &Failure{error: errors.New("Test"), reports: map[string]*Report{}}
+	prevFailure := &Failure{
+		error: errors.New("Test"),
+		workflowReport: &WorkflowReport{
+			WorkflowID:   "test",
+			StartTime:    time.Now(),
+			EndTime:      time.Now(),
+			Status:       "",
+			StepSequence: []string{},
+			StepReports:  map[string]*StepReport{},
+		},
+	}
 	failure := NewSkippedRollback(prevFailure, nil)
 	assert.NotNil(t, failure)
-	assert.Nil(t, failure.reports)
+	assert.NotNil(t, failure.workflowReport)
+	assert.Equal(t, 0, len(failure.workflowReport.StepReports))
 
-	report := NewReport("TEST")
+	report := NewStepReport("TEST", RunAction)
 	failure = NewSkippedRollback(prevFailure, report)
 	assert.NotNil(t, failure)
-	assert.NotNil(t, failure.reports)
-	assert.Equal(t, 1, len(failure.reports))
+	assert.NotNil(t, failure.workflowReport)
+	assert.Equal(t, 1, len(failure.workflowReport.StepReports))
 }

--- a/events_test.go
+++ b/events_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNewSkippedRun(t *testing.T) {
-	prevSuccess := &Success{workflowReport: &WorkflowReport{
+	prevSuccess := &Success{workflowReport: WorkflowReport{
 		WorkflowID:   "test",
 		StartTime:    time.Now(),
 		EndTime:      time.Now(),
@@ -32,7 +32,7 @@ func TestNewSkippedRun(t *testing.T) {
 func TestNewSkippedRollback(t *testing.T) {
 	prevFailure := &Failure{
 		error: errors.New("Test"),
-		workflowReport: &WorkflowReport{
+		workflowReport: WorkflowReport{
 			WorkflowID:   "test",
 			StartTime:    time.Now(),
 			EndTime:      time.Now(),

--- a/events_test.go
+++ b/events_test.go
@@ -13,7 +13,7 @@ func TestNewSkippedRun(t *testing.T) {
 		StartTime:    time.Now(),
 		EndTime:      time.Now(),
 		Status:       "",
-		StepSequence: []string{},
+		StepSequence: StepIDs{},
 		StepReports:  []*StepReport{},
 	}}
 
@@ -37,7 +37,7 @@ func TestNewSkippedRollback(t *testing.T) {
 			StartTime:    time.Now(),
 			EndTime:      time.Now(),
 			Status:       "",
-			StepSequence: []string{},
+			StepSequence: StepIDs{},
 			StepReports:  []*StepReport{},
 		},
 	}

--- a/example/example.go
+++ b/example/example.go
@@ -127,7 +127,6 @@ func (s *RestartContainers) Run(ctx context.Context, prevSuccess *automa.Success
 
 	// trigger rollback on error
 	err := errors.New("error running step 3")
-	report.Actions[automa.RunAction].Error = errors.EncodeError(ctx, err)
 	if err != nil {
 		return s.Rollback(ctx, automa.NewFailedRun(ctx, prevSuccess, err, report))
 	}

--- a/example/example.go
+++ b/example/example.go
@@ -63,7 +63,7 @@ type RestartContainers struct {
 	logger *zap.Logger
 }
 
-func (s *StopContainers) Run(ctx context.Context, prevSuccess *automa.Success) (*automa.WorkflowReport, error) {
+func (s *StopContainers) Run(ctx context.Context, prevSuccess *automa.Success) (automa.WorkflowReport, error) {
 	report := automa.NewStepReport(s.ID, automa.RunAction)
 
 	// reset cache
@@ -75,13 +75,13 @@ func (s *StopContainers) Run(ctx context.Context, prevSuccess *automa.Success) (
 	return s.RunNext(ctx, prevSuccess, report)
 }
 
-func (s *StopContainers) Rollback(ctx context.Context, prevFailure *automa.Failure) (*automa.WorkflowReport, error) {
+func (s *StopContainers) Rollback(ctx context.Context, prevFailure *automa.Failure) (automa.WorkflowReport, error) {
 	report := automa.NewStepReport(s.ID, automa.RollbackAction)
 	s.logger.Debug(s.cache.GetString(keyRollbackMsg))
 	return s.RollbackPrev(ctx, prevFailure, report)
 }
 
-func (s *FetchLatest) Run(ctx context.Context, prevSuccess *automa.Success) (*automa.WorkflowReport, error) {
+func (s *FetchLatest) Run(ctx context.Context, prevSuccess *automa.Success) (automa.WorkflowReport, error) {
 	report := automa.NewStepReport(s.ID, automa.RunAction)
 
 	// reset cache
@@ -93,13 +93,13 @@ func (s *FetchLatest) Run(ctx context.Context, prevSuccess *automa.Success) (*au
 	return s.RunNext(ctx, prevSuccess, report)
 }
 
-func (s *FetchLatest) Rollback(ctx context.Context, prevFailure *automa.Failure) (*automa.WorkflowReport, error) {
+func (s *FetchLatest) Rollback(ctx context.Context, prevFailure *automa.Failure) (automa.WorkflowReport, error) {
 	report := automa.NewStepReport(s.ID, automa.RollbackAction)
 	s.logger.Debug(s.cache.GetString(keyRollbackMsg))
 	return s.RollbackPrev(ctx, prevFailure, report)
 }
 
-func (s *NotifyAll) Run(ctx context.Context, prevSuccess *automa.Success) (*automa.WorkflowReport, error) {
+func (s *NotifyAll) Run(ctx context.Context, prevSuccess *automa.Success) (automa.WorkflowReport, error) {
 	report := automa.NewStepReport(s.ID, automa.RunAction)
 
 	// reset cache
@@ -110,13 +110,13 @@ func (s *NotifyAll) Run(ctx context.Context, prevSuccess *automa.Success) (*auto
 	return s.SkippedRun(ctx, prevSuccess, report)
 }
 
-func (s *NotifyAll) Rollback(ctx context.Context, prevFailure *automa.Failure) (*automa.WorkflowReport, error) {
+func (s *NotifyAll) Rollback(ctx context.Context, prevFailure *automa.Failure) (automa.WorkflowReport, error) {
 	report := automa.NewStepReport(s.ID, automa.RollbackAction)
 	s.logger.Debug(s.cache.GetString(keyRollbackMsg))
 	return s.SkippedRollback(ctx, prevFailure, report)
 }
 
-func (s *RestartContainers) Run(ctx context.Context, prevSuccess *automa.Success) (*automa.WorkflowReport, error) {
+func (s *RestartContainers) Run(ctx context.Context, prevSuccess *automa.Success) (automa.WorkflowReport, error) {
 	report := automa.NewStepReport(s.ID, automa.RunAction)
 
 	// reset cache
@@ -134,13 +134,13 @@ func (s *RestartContainers) Run(ctx context.Context, prevSuccess *automa.Success
 	return s.RunNext(ctx, prevSuccess, report)
 }
 
-func (s *RestartContainers) Rollback(ctx context.Context, prevFailure *automa.Failure) (*automa.WorkflowReport, error) {
+func (s *RestartContainers) Rollback(ctx context.Context, prevFailure *automa.Failure) (automa.WorkflowReport, error) {
 	report := automa.NewStepReport(s.ID, automa.RollbackAction)
 	s.logger.Debug(s.cache.GetString(keyRollbackMsg))
 	return s.RollbackPrev(ctx, prevFailure, report)
 }
 
-func buildWorkflow1(ctx context.Context, logger *zap.Logger) (automa.AtomicWorkflow, error) {
+func buildWorkflow1(logger *zap.Logger) (automa.AtomicWorkflow, error) {
 	stop := &StopContainers{
 		Step:   automa.Step{ID: "stop_containers"},
 		cache:  InMemCache{},
@@ -197,7 +197,7 @@ func main() {
 		logger.Fatal("Failed to setup logger", zap.Error(err))
 	}
 
-	workflow, err := buildWorkflow1(ctx, logger)
+	workflow, err := buildWorkflow1(logger)
 	if err != nil {
 		logger.Fatal("Failed to build workflow-1", zap.Error(err))
 	}
@@ -208,7 +208,7 @@ func main() {
 		logger.Error("Was expecting error, no error received")
 	}
 
-	printReport(report, logger)
+	printReport(&report, logger)
 }
 
 func printReport(report *automa.WorkflowReport, logger *zap.Logger) {

--- a/example/example.go
+++ b/example/example.go
@@ -169,7 +169,7 @@ func buildWorkflow1(logger *zap.Logger) (automa.AtomicWorkflow, error) {
 	})
 
 	// a new workflow with notify in the middle
-	workflow, err := registry.BuildWorkflow("workflow_1", []string{
+	workflow, err := registry.BuildWorkflow("workflow_1", automa.StepIDs{
 		stop.ID,
 		fetch.ID,
 		notify.ID,

--- a/example/example.go
+++ b/example/example.go
@@ -143,26 +143,26 @@ func (s *RestartContainers) Rollback(ctx context.Context, prevFailure *automa.Fa
 
 func buildWorkflow1(ctx context.Context, logger *zap.Logger) (automa.AtomicWorkflow, error) {
 	stop := &StopContainers{
-		Step:   automa.Step{ID: "Stop containers"},
+		Step:   automa.Step{ID: "stop_containers"},
 		cache:  InMemCache{},
 		logger: logger,
 	}
 
 	fetch := &FetchLatest{
-		Step:   automa.Step{ID: "Fetch latest images"},
+		Step:   automa.Step{ID: "fetch_latest_images"},
 		cache:  InMemCache{},
 		logger: logger,
 	}
 
 	notify :=
 		&NotifyAll{
-			Step:   automa.Step{ID: "NotifyAll on Slack"},
+			Step:   automa.Step{ID: "notify_all_on_slack"},
 			cache:  InMemCache{},
 			logger: logger,
 		}
 
 	restart := &RestartContainers{
-		Step:   automa.Step{ID: "Restart containers"},
+		Step:   automa.Step{ID: "restart_containers"},
 		cache:  InMemCache{},
 		logger: logger,
 	}
@@ -175,7 +175,7 @@ func buildWorkflow1(ctx context.Context, logger *zap.Logger) (automa.AtomicWorkf
 	})
 
 	// a new workflow with notify in the middle
-	workflow, err := registry.BuildWorkflow("workflow-1", []string{
+	workflow, err := registry.BuildWorkflow("workflow_1", []string{
 		stop.ID,
 		fetch.ID,
 		notify.ID,

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cockroachdb/errors v1.9.1
 	github.com/stretchr/testify v1.8.2
 	go.uber.org/zap v1.24.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -22,5 +23,4 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/registry.go
+++ b/registry.go
@@ -52,7 +52,7 @@ func (r *StepRegistry) GetStep(id string) AtomicStep {
 }
 
 // BuildWorkflow is a helper method to build a Workflow from the given set of AtomicStep IDs
-func (r *StepRegistry) BuildWorkflow(workflowID string, stepIDs []string) (AtomicWorkflow, error) {
+func (r *StepRegistry) BuildWorkflow(workflowID string, stepIDs StepIDs) (AtomicWorkflow, error) {
 	var steps []AtomicStep
 	for _, stepID := range stepIDs {
 		step := r.GetStep(stepID)

--- a/registry.go
+++ b/registry.go
@@ -51,7 +51,7 @@ func (r *StepRegistry) GetStep(id string) AtomicStep {
 }
 
 // BuildWorkflow is a helper method to build a Workflow from the given set of AtomicStep IDs
-func (r *StepRegistry) BuildWorkflow(stepIDs []string) *Workflow {
+func (r *StepRegistry) BuildWorkflow(id string, stepIDs []string) *Workflow {
 	var steps []AtomicStep
 	for _, id := range stepIDs {
 		step := r.GetStep(id)
@@ -60,5 +60,5 @@ func (r *StepRegistry) BuildWorkflow(stepIDs []string) *Workflow {
 		}
 	}
 
-	return NewWorkflow(WithSteps(steps...), WithLogger(r.logger))
+	return NewWorkflow(id, WithSteps(steps...), WithLogger(r.logger))
 }

--- a/registry.go
+++ b/registry.go
@@ -1,6 +1,7 @@
 package automa
 
 import (
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 )
 
@@ -32,7 +33,7 @@ func (r *StepRegistry) registerStep(id string, step AtomicStep) *StepRegistry {
 }
 
 // RegisterSteps is a helper method to register multiple AtomicSteps at a time
-func (r *StepRegistry) RegisterSteps(steps map[string]AtomicStep) *StepRegistry {
+func (r *StepRegistry) RegisterSteps(steps map[string]AtomicStep) AtomicStepRegistry {
 	for id, step := range steps {
 		r.registerStep(id, step)
 	}
@@ -51,14 +52,17 @@ func (r *StepRegistry) GetStep(id string) AtomicStep {
 }
 
 // BuildWorkflow is a helper method to build a Workflow from the given set of AtomicStep IDs
-func (r *StepRegistry) BuildWorkflow(id string, stepIDs []string) *Workflow {
+func (r *StepRegistry) BuildWorkflow(workflowID string, stepIDs []string) (AtomicWorkflow, error) {
 	var steps []AtomicStep
-	for _, id := range stepIDs {
-		step := r.GetStep(id)
+	for _, stepID := range stepIDs {
+		step := r.GetStep(stepID)
 		if step != nil {
 			steps = append(steps, step)
+		} else {
+			return nil, errors.Newf("invalid step: %s", stepID)
 		}
 	}
 
-	return NewWorkflow(id, WithSteps(steps...), WithLogger(r.logger))
+	workflow := NewWorkflow(workflowID, WithSteps(steps...), WithLogger(r.logger))
+	return workflow, nil
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -22,7 +22,9 @@ func TestStepRegistry_GetStep(t *testing.T) {
 	registry := NewStepRegistry(nil)
 	assert.NotNil(t, registry)
 
-	s1 := &mockSuccessStepStep{Step: Step{ID: "test"}}
+	s1 := &mockSuccessStep{Step: Step{ID: "test"}}
+	s1.RegisterSaga(s1.run, s1.run)
+
 	registry.RegisterSteps(map[string]AtomicStep{s1.ID: s1})
 	assert.NotNil(t, registry.GetStep(s1.ID))
 	assert.Nil(t, registry.GetStep("INVALID"))

--- a/reports.go
+++ b/reports.go
@@ -77,7 +77,7 @@ func NewWorkflowReport(id string, steps []string) *WorkflowReport {
 		WorkflowID:   id,
 		StartTime:    time.Now(),
 		EndTime:      time.Now(),
-		Status:       StatusFailed,
+		Status:       StatusUndefined,
 		StepSequence: steps,
 		StepReports:  map[string]*StepReport{},
 	}
@@ -93,7 +93,7 @@ func NewStepReport(id string, action StepActionType) *StepReport {
 	r.Actions[action] = &ActionReport{
 		StartTime: time.Now(),
 		EndTime:   time.Now(),
-		Status:    StatusFailed,
+		Status:    StatusUndefined,
 		Error:     errors.EncodedError{},
 		metadata:  map[string][]byte{},
 	}

--- a/reports.go
+++ b/reports.go
@@ -36,7 +36,7 @@ type ActionReport struct {
 	EndTime   time.Time           `yaml:"end_time" json:"endTime"`
 	Status    Status              `yaml:"status" json:"status"`
 	Error     errors.EncodedError `yaml:"error" json:"error"`
-	metadata  map[string][]byte   `yaml:"metadata" json:"metadata"`
+	Metadata  map[string][]byte   `yaml:"metadata" json:"metadata"`
 }
 
 // Append appends the current report to the previous report
@@ -52,7 +52,7 @@ func (wfr *WorkflowReport) Append(stepReport *StepReport, action StepActionType,
 			EndTime:   time.Now(),
 			Status:    status,
 			Error:     errors.EncodedError{},
-			metadata:  map[string][]byte{},
+			Metadata:  map[string][]byte{},
 		}
 	} else {
 		stepReport.Actions[action].EndTime = time.Now()
@@ -95,7 +95,7 @@ func NewStepReport(id string, action StepActionType) *StepReport {
 		EndTime:   time.Now(),
 		Status:    StatusUndefined,
 		Error:     errors.EncodedError{},
-		metadata:  map[string][]byte{},
+		Metadata:  map[string][]byte{},
 	}
 
 	return r

--- a/reports.go
+++ b/reports.go
@@ -20,7 +20,7 @@ type WorkflowReport struct {
 	StartTime    time.Time     `yaml:"start_time" json:"startTime"`
 	EndTime      time.Time     `yaml:"end_time" json:"endTime"`
 	Status       Status        `yaml:"status" json:"status"`
-	StepSequence []string      `yaml:"step_sequence" json:"stepSequence"`
+	StepSequence StepIDs       `yaml:"step_sequence" json:"stepSequence"`
 	StepReports  []*StepReport `yaml:"step_reports" json:"stepReports"`
 }
 
@@ -49,7 +49,7 @@ func (wfr *WorkflowReport) Append(stepReport *StepReport, action StepActionType,
 }
 
 // NewWorkflowReport returns an instance of WorkflowReport
-func NewWorkflowReport(id string, steps []string) *WorkflowReport {
+func NewWorkflowReport(id string, steps StepIDs) *WorkflowReport {
 	return &WorkflowReport{
 		WorkflowID:   id,
 		StartTime:    time.Now(),

--- a/reports.go
+++ b/reports.go
@@ -47,13 +47,7 @@ func (wfr *WorkflowReport) Append(stepReport *StepReport, action StepActionType,
 	}
 
 	if _, ok := stepReport.Actions[action]; !ok {
-		stepReport.Actions[action] = &ActionReport{
-			StartTime: time.Now(),
-			EndTime:   time.Now(),
-			Status:    status,
-			Error:     errors.EncodedError{},
-			Metadata:  map[string][]byte{},
-		}
+		stepReport.Actions[action] = NewActionReport()
 	} else {
 		stepReport.Actions[action].EndTime = time.Now()
 		stepReport.Actions[action].Status = status
@@ -90,13 +84,18 @@ func NewStepReport(id string, action StepActionType) *StepReport {
 		Actions: map[StepActionType]*ActionReport{},
 	}
 
-	r.Actions[action] = &ActionReport{
+	r.Actions[action] = NewActionReport()
+
+	return r
+}
+
+// NewActionReport returns an instance of ActionReport
+func NewActionReport() *ActionReport {
+	return &ActionReport{
 		StartTime: time.Now(),
 		EndTime:   time.Now(),
 		Status:    StatusUndefined,
 		Error:     errors.EncodedError{},
 		Metadata:  map[string][]byte{},
 	}
-
-	return r
 }

--- a/reports.go
+++ b/reports.go
@@ -16,22 +16,18 @@ const (
 
 // WorkflowReport defines a map of StepReport with key as the step ID
 type WorkflowReport struct {
-	WorkflowID   string                 `yaml:"workflow_id" json:"workflowID"`
-	StartTime    time.Time              `yaml:"start_time" json:"startTime"`
-	EndTime      time.Time              `yaml:"end_time" json:"endTime"`
-	Status       Status                 `yaml:"status" json:"status"`
-	StepSequence []string               `yaml:"step_sequence" json:"stepSequence"`
-	StepReports  map[string]*StepReport `yaml:"step_reports" json:"stepReports"`
+	WorkflowID   string        `yaml:"workflow_id" json:"workflowID"`
+	StartTime    time.Time     `yaml:"start_time" json:"startTime"`
+	EndTime      time.Time     `yaml:"end_time" json:"endTime"`
+	Status       Status        `yaml:"status" json:"status"`
+	StepSequence []string      `yaml:"step_sequence" json:"stepSequence"`
+	StepReports  []*StepReport `yaml:"step_reports" json:"stepReports"`
 }
 
 // StepReport defines the report data model for each AtomicStep execution
 type StepReport struct {
-	StepID  string                           `yaml:"step_id" json:"stepID"`
-	Actions map[StepActionType]*ActionReport `yaml:"actions" json:"actions"`
-}
-
-// ActionReport defines the report data model for each AtomicStep's Run and Rollback execution
-type ActionReport struct {
+	StepID    string              `yaml:"step_id" json:"stepID"`
+	Action    StepActionType      `yaml:"action" json:"action"`
 	StartTime time.Time           `yaml:"start_time" json:"startTime"`
 	EndTime   time.Time           `yaml:"end_time" json:"endTime"`
 	Status    Status              `yaml:"status" json:"status"`
@@ -46,23 +42,10 @@ func (wfr *WorkflowReport) Append(stepReport *StepReport, action StepActionType,
 		return
 	}
 
-	if _, ok := stepReport.Actions[action]; !ok {
-		stepReport.Actions[action] = NewActionReport()
-	} else {
-		stepReport.Actions[action].EndTime = time.Now()
-		stepReport.Actions[action].Status = status
-
-	}
-
-	if wfr.StepReports == nil {
-		wfr.StepReports = map[string]*StepReport{}
-	}
-
-	if _, ok := wfr.StepReports[stepReport.StepID]; !ok {
-		wfr.StepReports[stepReport.StepID] = stepReport
-	} else {
-		wfr.StepReports[stepReport.StepID].Actions[action] = stepReport.Actions[action]
-	}
+	stepReport.Action = action
+	stepReport.EndTime = time.Now()
+	stepReport.Status = status
+	wfr.StepReports = append(wfr.StepReports, stepReport)
 }
 
 // NewWorkflowReport returns an instance of WorkflowReport
@@ -73,29 +56,20 @@ func NewWorkflowReport(id string, steps []string) *WorkflowReport {
 		EndTime:      time.Now(),
 		Status:       StatusUndefined,
 		StepSequence: steps,
-		StepReports:  map[string]*StepReport{},
+		StepReports:  []*StepReport{},
 	}
 }
 
 // NewStepReport returns a new report with a given stepID
 func NewStepReport(id string, action StepActionType) *StepReport {
 	r := &StepReport{
-		StepID:  id,
-		Actions: map[StepActionType]*ActionReport{},
-	}
-
-	r.Actions[action] = NewActionReport()
-
-	return r
-}
-
-// NewActionReport returns an instance of ActionReport
-func NewActionReport() *ActionReport {
-	return &ActionReport{
+		StepID:    id,
 		StartTime: time.Now(),
 		EndTime:   time.Now(),
 		Status:    StatusUndefined,
 		Error:     errors.EncodedError{},
 		Metadata:  map[string][]byte{},
 	}
+
+	return r
 }

--- a/reports.go
+++ b/reports.go
@@ -5,43 +5,98 @@ import (
 	"time"
 )
 
-// Reports defines a map of Report with key as the step ID
-type Reports map[string]*Report
+// StepActionType defines the action taken by a step
+// It is used as key for StepReport.Actions
+type StepActionType string
 
-// Report defines the report data model for each AtomicStep execution
-type Report struct {
-	StepID    string
-	StartTime time.Time
-	EndTime   time.Time
-	Status    Status
-	Error     errors.EncodedError
-	metadata  map[string][]byte
+const (
+	RunAction      StepActionType = "run"
+	RollbackAction StepActionType = "rollback"
+)
+
+// WorkflowReport defines a map of StepReport with key as the step ID
+type WorkflowReport struct {
+	WorkflowID   string                 `yaml:"workflow_id" json:"workflowID"`
+	StartTime    time.Time              `yaml:"start_time" json:"startTime"`
+	EndTime      time.Time              `yaml:"end_time" json:"endTime"`
+	Status       Status                 `yaml:"status" json:"status"`
+	StepSequence []string               `yaml:"step_sequence" json:"stepSequence"`
+	StepReports  map[string]*StepReport `yaml:"step_reports" json:"stepReports"`
 }
 
-// Append appends the current report to the previous reports
-// It adds an end time and sets the status for the current report
-func (r *Report) Append(prevReports Reports, status Status) Reports {
-	r.EndTime = time.Now()
-	r.Status = status
+// StepReport defines the report data model for each AtomicStep execution
+type StepReport struct {
+	StepID  string                           `yaml:"step_id" json:"stepID"`
+	Actions map[StepActionType]*ActionReport `yaml:"actions" json:"actions"`
+}
 
-	clone := Reports{}
-	for key, val := range prevReports {
-		clone[key] = val
+// ActionReport defines the report data model for each AtomicStep's Run and Rollback execution
+type ActionReport struct {
+	StartTime time.Time           `yaml:"start_time" json:"startTime"`
+	EndTime   time.Time           `yaml:"end_time" json:"endTime"`
+	Status    Status              `yaml:"status" json:"status"`
+	Error     errors.EncodedError `yaml:"error" json:"error"`
+	metadata  map[string][]byte   `yaml:"metadata" json:"metadata"`
+}
+
+// Append appends the current report to the previous report
+// It adds an end time and sets the status for the current report
+func (wfr *WorkflowReport) Append(stepReport *StepReport, action StepActionType, status Status) {
+	if stepReport == nil {
+		return
 	}
 
-	clone[r.StepID] = r
+	if _, ok := stepReport.Actions[action]; !ok {
+		stepReport.Actions[action] = &ActionReport{
+			StartTime: time.Now(),
+			EndTime:   time.Now(),
+			Status:    status,
+			Error:     errors.EncodedError{},
+			metadata:  map[string][]byte{},
+		}
+	} else {
+		stepReport.Actions[action].EndTime = time.Now()
+		stepReport.Actions[action].Status = status
 
-	return clone
+	}
+
+	if wfr.StepReports == nil {
+		wfr.StepReports = map[string]*StepReport{}
+	}
+
+	if _, ok := wfr.StepReports[stepReport.StepID]; !ok {
+		wfr.StepReports[stepReport.StepID] = stepReport
+	} else {
+		wfr.StepReports[stepReport.StepID].Actions[action] = stepReport.Actions[action]
+	}
 }
 
-// NewReport returns a new report with a given stepID
-func NewReport(stepID string) *Report {
-	return &Report{
-		StepID:    stepID,
+// NewWorkflowReport returns an instance of WorkflowReport
+func NewWorkflowReport(id string, steps []string) *WorkflowReport {
+	return &WorkflowReport{
+		WorkflowID:   id,
+		StartTime:    time.Now(),
+		EndTime:      time.Now(),
+		Status:       StatusFailed,
+		StepSequence: steps,
+		StepReports:  map[string]*StepReport{},
+	}
+}
+
+// NewStepReport returns a new report with a given stepID
+func NewStepReport(id string, action StepActionType) *StepReport {
+	r := &StepReport{
+		StepID:  id,
+		Actions: map[StepActionType]*ActionReport{},
+	}
+
+	r.Actions[action] = &ActionReport{
 		StartTime: time.Now(),
 		EndTime:   time.Now(),
 		Status:    StatusFailed,
 		Error:     errors.EncodedError{},
 		metadata:  map[string][]byte{},
 	}
+
+	return r
 }

--- a/reports_test.go
+++ b/reports_test.go
@@ -1,0 +1,36 @@
+package automa
+
+import (
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+	"testing"
+)
+
+func TestWorkflowReport_Append(t *testing.T) {
+	workflowReport := NewWorkflowReport("test", nil)
+	stepReport := NewStepReport("step-1", RunAction)
+	workflowReport.Append(stepReport, RunAction, StatusSuccess)
+	assert.Equal(t, 1, len(workflowReport.StepReports))
+	assert.Equal(t, 0, len(workflowReport.StepSequence))
+	assert.NotNil(t, workflowReport.StepReports[stepReport.StepID])
+	assert.Equal(t, StatusSuccess, workflowReport.StepReports[stepReport.StepID].Actions[RunAction].Status)
+
+	workflowReport = &WorkflowReport{}
+	workflowReport.Append(stepReport, RunAction, StatusSuccess)
+	assert.Equal(t, 0, len(workflowReport.StepSequence))
+	assert.Equal(t, 1, len(workflowReport.StepReports))
+}
+
+func TestReportYAML(t *testing.T) {
+	stepReport1 := NewStepReport("step-1", RunAction)
+	stepReport2 := NewStepReport("step-2", RunAction)
+	workflowReport := NewWorkflowReport("workflow-id", []string{stepReport1.StepID, stepReport2.StepID})
+	workflowReport.Append(stepReport1, RunAction, StatusSuccess)
+	workflowReport.Append(stepReport2, RunAction, StatusSuccess)
+	workflowReport.Append(stepReport2, RollbackAction, StatusSuccess)
+	workflowReport.Append(stepReport1, RollbackAction, StatusSuccess)
+
+	out, err := yaml.Marshal(workflowReport)
+	assert.NoError(t, err)
+	assert.NotNil(t, out)
+}

--- a/reports_test.go
+++ b/reports_test.go
@@ -23,7 +23,7 @@ func TestReportYAML(t *testing.T) {
 	stepReport1Rollback := NewStepReport("step-1", RollbackAction)
 	stepReport2Run := NewStepReport("step-2", RunAction)
 	stepReport2Rollback := NewStepReport("step-2", RollbackAction)
-	workflowReport := NewWorkflowReport("workflow-id", []string{stepReport1Run.StepID, stepReport2Run.StepID})
+	workflowReport := NewWorkflowReport("workflow-id", StepIDs{stepReport1Run.StepID, stepReport2Run.StepID})
 	workflowReport.Append(stepReport1Run, RunAction, StatusSuccess)
 	workflowReport.Append(stepReport2Run, RunAction, StatusSuccess)
 	workflowReport.Append(stepReport2Rollback, RollbackAction, StatusSuccess)

--- a/reports_test.go
+++ b/reports_test.go
@@ -11,24 +11,23 @@ func TestWorkflowReport_Append(t *testing.T) {
 	stepReport := NewStepReport("step-1", RunAction)
 	workflowReport.Append(stepReport, RunAction, StatusSuccess)
 	assert.Equal(t, 1, len(workflowReport.StepReports))
-	assert.Equal(t, 0, len(workflowReport.StepSequence))
-	assert.NotNil(t, workflowReport.StepReports[stepReport.StepID])
-	assert.Equal(t, StatusSuccess, workflowReport.StepReports[stepReport.StepID].Actions[RunAction].Status)
+	assert.Equal(t, StatusSuccess, workflowReport.StepReports[0].Status)
 
 	workflowReport = &WorkflowReport{}
 	workflowReport.Append(stepReport, RunAction, StatusSuccess)
-	assert.Equal(t, 0, len(workflowReport.StepSequence))
 	assert.Equal(t, 1, len(workflowReport.StepReports))
 }
 
 func TestReportYAML(t *testing.T) {
-	stepReport1 := NewStepReport("step-1", RunAction)
-	stepReport2 := NewStepReport("step-2", RunAction)
-	workflowReport := NewWorkflowReport("workflow-id", []string{stepReport1.StepID, stepReport2.StepID})
-	workflowReport.Append(stepReport1, RunAction, StatusSuccess)
-	workflowReport.Append(stepReport2, RunAction, StatusSuccess)
-	workflowReport.Append(stepReport2, RollbackAction, StatusSuccess)
-	workflowReport.Append(stepReport1, RollbackAction, StatusSuccess)
+	stepReport1Run := NewStepReport("step-1", RunAction)
+	stepReport1Rollback := NewStepReport("step-1", RollbackAction)
+	stepReport2Run := NewStepReport("step-2", RunAction)
+	stepReport2Rollback := NewStepReport("step-2", RollbackAction)
+	workflowReport := NewWorkflowReport("workflow-id", []string{stepReport1Run.StepID, stepReport2Run.StepID})
+	workflowReport.Append(stepReport1Run, RunAction, StatusSuccess)
+	workflowReport.Append(stepReport2Run, RunAction, StatusSuccess)
+	workflowReport.Append(stepReport2Rollback, RollbackAction, StatusSuccess)
+	workflowReport.Append(stepReport1Rollback, RollbackAction, StatusSuccess)
 
 	out, err := yaml.Marshal(workflowReport)
 	assert.NoError(t, err)

--- a/status.go
+++ b/status.go
@@ -4,7 +4,8 @@ package automa
 type Status string
 
 const (
-	StatusSuccess Status = "SUCCESS"
-	StatusFailed  Status = "FAILED"
-	StatusSkipped Status = "SKIPPED"
+	StatusSuccess   Status = "SUCCESS"
+	StatusFailed    Status = "FAILED"
+	StatusSkipped   Status = "SKIPPED"
+	StatusUndefined Status = "UNDEFINED"
 )

--- a/steps.go
+++ b/steps.go
@@ -64,7 +64,8 @@ func (s *Step) SkippedRollback(ctx context.Context, prevFailure *Failure, report
 // FailedRollback is a helper method to report that current step's rollback has failed and trigger previous step's rollback
 // It marks the current step RollbackAction as StatusFailed
 func (s *Step) FailedRollback(ctx context.Context, prevFailure *Failure, err error, report *StepReport) (*WorkflowReport, error) {
-	report.Actions[RollbackAction].Error = errors.EncodeError(ctx, err)
+	report.Action = RollbackAction
+	report.Error = errors.EncodeError(ctx, err)
 
 	if s.Prev != nil {
 		return s.Prev.Rollback(ctx, NewFailedRollback(ctx, prevFailure, err, report))

--- a/steps.go
+++ b/steps.go
@@ -11,6 +11,11 @@ type Step struct {
 	Prev Backward
 }
 
+// GetID returns the step ID
+func (s *Step) GetID() string {
+	return s.ID
+}
+
 // SetNext sets the next step of the Workflow to be able to move in the forward direction on success
 func (s *Step) SetNext(next Forward) {
 	s.Next = next
@@ -33,47 +38,48 @@ func (s *Step) GetPrev() Backward {
 
 // SkippedRun is a helper method to report that current step has been skipped and trigger next step's execution
 // It marks the current step as StatusSkipped
-func (s *Step) SkippedRun(ctx context.Context, prevSuccess *Success, report *Report) (Reports, error) {
+func (s *Step) SkippedRun(ctx context.Context, prevSuccess *Success, report *StepReport) (*WorkflowReport, error) {
 	if s.Next != nil {
 		return s.Next.Run(ctx, NewSkippedRun(prevSuccess, report))
 	}
 
-	var reports Reports
-	if report != nil {
-		reports = report.Append(prevSuccess.reports, StatusSkipped)
+	prevSuccess.workflowReport.Append(report, RunAction, StatusSkipped)
+
+	return prevSuccess.workflowReport, nil
+}
+
+// SkippedRollback is a helper method to report that current step's rollback has been skipped and trigger next step's rollback
+// It marks the current step as StatusSkipped
+func (s *Step) SkippedRollback(ctx context.Context, prevFailure *Failure, report *StepReport) (*WorkflowReport, error) {
+	if s.Prev != nil {
+		return s.Prev.Rollback(ctx, NewSkippedRollback(prevFailure, report))
 	}
 
-	return reports, nil
+	prevFailure.workflowReport.Append(report, RollbackAction, StatusSkipped)
+
+	return prevFailure.workflowReport, nil
 }
 
 // RunNext is a helper method to report that current step has been successful and trigger next step's execution
 // It marks the current step as StatusSuccess
-func (s *Step) RunNext(ctx context.Context, prevSuccess *Success, report *Report) (Reports, error) {
+func (s *Step) RunNext(ctx context.Context, prevSuccess *Success, report *StepReport) (*WorkflowReport, error) {
 	if s.Next != nil {
 		return s.Next.Run(ctx, NewSuccess(prevSuccess, report))
 	}
 
-	var reports Reports
-	if report != nil {
-		reports = report.Append(prevSuccess.reports, StatusSuccess)
-	}
-
-	return reports, nil
+	prevSuccess.workflowReport.Append(report, RunAction, StatusSuccess)
+	return prevSuccess.workflowReport, nil
 }
 
 // RollbackPrev is a helper method to report that current rollback step has been executed and trigger previous step's rollback
 // It marks the current step as StatusFailed
-func (s *Step) RollbackPrev(ctx context.Context, prevFailure *Failure, report *Report) (Reports, error) {
+func (s *Step) RollbackPrev(ctx context.Context, prevFailure *Failure, report *StepReport) (*WorkflowReport, error) {
 	if s.Prev != nil {
 		return s.Prev.Rollback(ctx, NewFailure(prevFailure, report))
 	}
 
-	var reports Reports
-	if report != nil {
-		reports = report.Append(prevFailure.reports, StatusFailed)
-	}
-
-	return reports, nil
+	prevFailure.workflowReport.Append(report, RollbackAction, StatusSuccess)
+	return prevFailure.workflowReport, nil
 }
 
 // failedStep defines the failed state of the Workflow that implements Backward interface only
@@ -87,11 +93,11 @@ type successStep struct {
 }
 
 // Rollback implements Backward interface for failedStep
-func (fs *failedStep) Rollback(ctx context.Context, prevFailure *Failure) (Reports, error) {
-	return prevFailure.reports, prevFailure.error
+func (fs *failedStep) Rollback(ctx context.Context, prevFailure *Failure) (*WorkflowReport, error) {
+	return prevFailure.workflowReport, prevFailure.error
 }
 
 // Run implements the Forward interface for successStep
-func (ss *successStep) Run(ctx context.Context, prevSuccess *Success) (Reports, error) {
-	return prevSuccess.reports, nil
+func (ss *successStep) Run(ctx context.Context, prevSuccess *Success) (*WorkflowReport, error) {
+	return prevSuccess.workflowReport, nil
 }

--- a/steps_test.go
+++ b/steps_test.go
@@ -71,17 +71,17 @@ func TestSkippedRun(t *testing.T) {
 
 func TestRollbackPrev(t *testing.T) {
 	s1 := &mockSuccessStepStep{
-		Step:  Step{ID: "Stop containers"},
+		Step:  Step{ID: "stop_containers"},
 		cache: map[string][]byte{},
 	}
 
 	s2 := &mockFailedStep{
-		Step:  Step{ID: "Fetch latest images"},
+		Step:  Step{ID: "fetch_latest_images"},
 		cache: map[string][]byte{},
 	}
 
 	ctx := context.Background()
-	prevFailure := &Failure{error: errors.New("Test"), workflowReport: NewWorkflowReport("rollback-test", nil)}
+	prevFailure := &Failure{error: errors.New("Test"), workflowReport: NewWorkflowReport("rollback_test", nil)}
 	report := NewStepReport(s1.ID, RollbackAction)
 
 	reports, err := s1.SkippedRollback(ctx, prevFailure, report)
@@ -98,17 +98,17 @@ func TestRollbackPrev(t *testing.T) {
 
 func TestSkippedRollbackPrev(t *testing.T) {
 	s1 := &mockSuccessStepStep{
-		Step:  Step{ID: "Stop containers"},
+		Step:  Step{ID: "stop_containers"},
 		cache: map[string][]byte{},
 	}
 
 	s2 := &mockFailedStep{
-		Step:  Step{ID: "Fetch latest images"},
+		Step:  Step{ID: "fetch_latest_images"},
 		cache: map[string][]byte{},
 	}
 
 	ctx := context.Background()
-	prevFailure := &Failure{error: errors.New("Test"), workflowReport: NewWorkflowReport("rollback-test", nil)}
+	prevFailure := &Failure{error: errors.New("Test"), workflowReport: NewWorkflowReport("rollback_test", nil)}
 	report := NewStepReport(s1.ID, RollbackAction)
 
 	reports, err := s1.RollbackPrev(ctx, prevFailure, report)
@@ -125,17 +125,17 @@ func TestSkippedRollbackPrev(t *testing.T) {
 
 func TestFailedRollback(t *testing.T) {
 	s1 := &mockSuccessStepStep{
-		Step:  Step{ID: "Stop containers"},
+		Step:  Step{ID: "stop_containers"},
 		cache: map[string][]byte{},
 	}
 
 	s2 := &mockFailedStep{
-		Step:  Step{ID: "Fetch latest images"},
+		Step:  Step{ID: "fetch_latest_images"},
 		cache: map[string][]byte{},
 	}
 
 	ctx := context.Background()
-	prevFailure := &Failure{error: errors.New("Test"), workflowReport: NewWorkflowReport("rollback-test", nil)}
+	prevFailure := &Failure{error: errors.New("Test"), workflowReport: NewWorkflowReport("rollback_test", nil)}
 	report := NewStepReport(s1.ID, RollbackAction)
 
 	reports, err := s1.FailedRollback(ctx, prevFailure, errors.New("test"), report)
@@ -152,7 +152,7 @@ func TestFailedRollback(t *testing.T) {
 
 func TestNextPrev(t *testing.T) {
 	s1 := &mockSuccessStepStep{
-		Step:  Step{ID: "Stop containers"},
+		Step:  Step{ID: "stop_containers"},
 		cache: map[string][]byte{},
 	}
 
@@ -160,7 +160,7 @@ func TestNextPrev(t *testing.T) {
 	assert.Nil(t, s1.GetPrev())
 
 	s2 := &mockSuccessStepStep{
-		Step:  Step{ID: "Fetch latest images"},
+		Step:  Step{ID: "fetch_latest_images"},
 		cache: map[string][]byte{},
 	}
 
@@ -185,7 +185,7 @@ func TestRun(t *testing.T) {
 
 	s2 := &successStep{}
 	ctx := context.Background()
-	prevSuccess := &Success{workflowReport: NewWorkflowReport("run-test", nil)}
+	prevSuccess := &Success{workflowReport: NewWorkflowReport("run_test", nil)}
 
 	s1.SetNext(s2)
 

--- a/steps_test.go
+++ b/steps_test.go
@@ -66,7 +66,7 @@ func TestSkippedRun(t *testing.T) {
 	s2.SetPrev(s1)
 	reports, err = s1.SkippedRun(ctx, prevSuccess, report)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(reports.StepReports))
+	assert.Equal(t, 3, len(reports.StepReports))
 }
 
 func TestRollbackPrev(t *testing.T) {
@@ -93,7 +93,7 @@ func TestRollbackPrev(t *testing.T) {
 	report = NewStepReport(s2.ID, RollbackAction)
 	reports, err = s2.SkippedRollback(ctx, prevFailure, report)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(reports.StepReports))
+	assert.Equal(t, 3, len(reports.StepReports))
 }
 
 func TestSkippedRollbackPrev(t *testing.T) {
@@ -120,7 +120,7 @@ func TestSkippedRollbackPrev(t *testing.T) {
 	report = NewStepReport(s2.ID, RollbackAction)
 	reports, err = s2.RollbackPrev(ctx, prevFailure, report)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(reports.StepReports))
+	assert.Equal(t, 3, len(reports.StepReports))
 }
 
 func TestFailedRollback(t *testing.T) {
@@ -147,7 +147,7 @@ func TestFailedRollback(t *testing.T) {
 	report = NewStepReport(s2.ID, RollbackAction)
 	reports, err = s2.FailedRollback(ctx, prevFailure, errors.New("test2"), report)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(reports.StepReports))
+	assert.Equal(t, 3, len(reports.StepReports))
 }
 
 func TestNextPrev(t *testing.T) {

--- a/steps_test.go
+++ b/steps_test.go
@@ -18,28 +18,28 @@ type mockFailedStep struct {
 	cache map[string][]byte
 }
 
-func (s *mockSuccessStepStep) Run(ctx context.Context, prevSuccess *Success) (Reports, error) {
-	report := NewReport(s.ID)
+func (s *mockSuccessStepStep) Run(ctx context.Context, prevSuccess *Success) (*WorkflowReport, error) {
+	report := NewStepReport(s.ID, RunAction)
 	fmt.Printf("RUN - %q", s.ID)
 	s.cache["rollbackMsg"] = []byte(fmt.Sprintf("ROLLBACK - %q", s.ID))
 	return s.RunNext(ctx, prevSuccess, report)
 }
 
-func (s *mockSuccessStepStep) Rollback(ctx context.Context, prevFailure *Failure) (Reports, error) {
-	report := NewReport(s.ID)
+func (s *mockSuccessStepStep) Rollback(ctx context.Context, prevFailure *Failure) (*WorkflowReport, error) {
+	report := NewStepReport(s.ID, RollbackAction)
 	fmt.Println(string(s.cache["rollbackMsg"]))
 	return s.RollbackPrev(ctx, prevFailure, report)
 }
 
-func (s *mockFailedStep) Run(ctx context.Context, prevSuccess *Success) (Reports, error) {
-	report := NewReport(s.ID)
+func (s *mockFailedStep) Run(ctx context.Context, prevSuccess *Success) (*WorkflowReport, error) {
+	report := NewStepReport(s.ID, RunAction)
 	fmt.Printf("SKIP RUN - %q", s.ID)
 	s.cache["rollbackMsg"] = []byte(fmt.Sprintf("SKIP ROLLBACK - %q", s.ID))
 	return s.SkippedRun(ctx, prevSuccess, report)
 }
 
-func (s *mockFailedStep) Rollback(ctx context.Context, prevFailure *Failure) (Reports, error) {
-	report := NewReport(s.ID)
+func (s *mockFailedStep) Rollback(ctx context.Context, prevFailure *Failure) (*WorkflowReport, error) {
+	report := NewStepReport(s.ID, RollbackAction)
 	fmt.Println(string(s.cache["rollbackMsg"]))
 	return s.RollbackPrev(ctx, prevFailure, report)
 }
@@ -55,18 +55,18 @@ func TestSkippedRun(t *testing.T) {
 		cache: map[string][]byte{},
 	}
 	ctx := context.Background()
-	prevSuccess := &Success{reports: map[string]*Report{}}
-	report := NewReport(s1.ID)
+	prevSuccess := &Success{workflowReport: NewWorkflowReport("skipped-run-test", nil)}
+	report := NewStepReport(s1.ID, RunAction)
 
 	reports, err := s1.SkippedRun(ctx, prevSuccess, report)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(reports))
+	assert.Equal(t, 1, len(reports.StepReports))
 
 	s1.SetNext(s2)
 	s2.SetPrev(s1)
 	reports, err = s1.SkippedRun(ctx, prevSuccess, report)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(reports))
+	assert.Equal(t, 2, len(reports.StepReports))
 }
 
 func TestRollbackPrev(t *testing.T) {
@@ -81,19 +81,46 @@ func TestRollbackPrev(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	prevFailure := &Failure{error: errors.New("Test"), reports: map[string]*Report{}}
-	report := NewReport(s1.ID)
+	prevFailure := &Failure{error: errors.New("Test"), workflowReport: NewWorkflowReport("rollback-test", nil)}
+	report := NewStepReport(s1.ID, RollbackAction)
 
-	reports, err := s1.RollbackPrev(ctx, prevFailure, report)
+	reports, err := s1.SkippedRollback(ctx, prevFailure, report)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(reports))
+	assert.Equal(t, 1, len(reports.StepReports))
 
 	s1.SetNext(s2)
 	s2.SetPrev(s1)
-	report = NewReport(s2.ID)
+	report = NewStepReport(s2.ID, RollbackAction)
+	reports, err = s2.SkippedRollback(ctx, prevFailure, report)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(reports.StepReports))
+}
+
+func TestSkippedRollbackPrev(t *testing.T) {
+	s1 := &mockSuccessStepStep{
+		Step:  Step{ID: "Stop containers"},
+		cache: map[string][]byte{},
+	}
+
+	s2 := &mockFailedStep{
+		Step:  Step{ID: "Fetch latest images"},
+		cache: map[string][]byte{},
+	}
+
+	ctx := context.Background()
+	prevFailure := &Failure{error: errors.New("Test"), workflowReport: NewWorkflowReport("rollback-test", nil)}
+	report := NewStepReport(s1.ID, RollbackAction)
+
+	reports, err := s1.RollbackPrev(ctx, prevFailure, report)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(reports.StepReports))
+
+	s1.SetNext(s2)
+	s2.SetPrev(s1)
+	report = NewStepReport(s2.ID, RollbackAction)
 	reports, err = s2.RollbackPrev(ctx, prevFailure, report)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(reports))
+	assert.Equal(t, 2, len(reports.StepReports))
 }
 
 func TestNextPrev(t *testing.T) {
@@ -131,11 +158,11 @@ func TestRun(t *testing.T) {
 
 	s2 := &successStep{}
 	ctx := context.Background()
-	prevSuccess := &Success{reports: map[string]*Report{}}
+	prevSuccess := &Success{workflowReport: NewWorkflowReport("run-test", nil)}
 
 	s1.SetNext(s2)
 
 	reports, err := s1.Run(ctx, prevSuccess)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(reports))
+	assert.Equal(t, 1, len(reports.StepReports))
 }

--- a/workflow.go
+++ b/workflow.go
@@ -28,7 +28,7 @@ type Workflow struct {
 	report WorkflowReport
 
 	logger  *zap.Logger
-	stepIDs []string
+	stepIDs StepIDs
 }
 
 // addStep add an AtomicStep in the internal double linked list of steps

--- a/workflow.go
+++ b/workflow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"go.uber.org/zap"
 	"sync"
+	"time"
 )
 
 // Workflow implements AtomicWorkflow interface
@@ -12,6 +13,7 @@ import (
 // In order to enable Choreography pattern it forms a double linked list of AtomicSteps to traverse 'Forward'
 // on Success and 'Backward' on Failure
 type Workflow struct {
+	id    string
 	mutex sync.Mutex
 
 	successStep *successStep
@@ -21,11 +23,12 @@ type Workflow struct {
 	firstStep AtomicStep
 	lastStep  AtomicStep
 
-	// local cache for accumulating reports from all internal states
-	// this is passed along to accumulate reports from all internal states
-	reports Reports
+	// local cache for accumulating report from all internal states
+	// this is passed along to accumulate report from all internal states
+	report *WorkflowReport
 
-	logger *zap.Logger
+	logger  *zap.Logger
+	stepIDs []string
 }
 
 // addStep add an AtomicStep in the internal double linked list of steps
@@ -50,6 +53,7 @@ func WithSteps(steps ...AtomicStep) WorkflowOption {
 	return func(wf *Workflow) {
 		for _, step := range steps {
 			wf.addStep(step)
+			wf.stepIDs = append(wf.stepIDs, step.GetID())
 		}
 	}
 }
@@ -63,14 +67,15 @@ func WithLogger(logger *zap.Logger) WorkflowOption {
 }
 
 // NewWorkflow returns an instance of WorkFlow that implements AtomicWorkflow interface
-func NewWorkflow(opts ...WorkflowOption) *Workflow {
+func NewWorkflow(id string, opts ...WorkflowOption) *Workflow {
 	fs := &failedStep{}
 	ss := &successStep{}
 
 	wf := &Workflow{
+		id:          id,
 		failedStep:  fs,
 		successStep: ss,
-		reports:     Reports{},
+		report:      NewWorkflowReport(id, nil),
 		logger:      zap.NewNop(),
 	}
 
@@ -81,19 +86,31 @@ func NewWorkflow(opts ...WorkflowOption) *Workflow {
 	return wf
 }
 
-// Start starts the workflow and returns the Reports
-func (wf *Workflow) Start(ctx context.Context) (Reports, error) {
+// GetID returns the id of the Workflow
+func (wf *Workflow) GetID() string {
+	return wf.id
+}
+
+// Start starts the workflow and returns the WorkflowReport
+func (wf *Workflow) Start(ctx context.Context) (*WorkflowReport, error) {
 	wf.mutex.Lock()
 	defer wf.mutex.Unlock()
 
 	var err error
 
 	if wf.firstStep != nil {
-		wf.reports, err = wf.firstStep.Run(ctx, NewStartTrigger(wf.reports))
-		return wf.reports, err
+		wf.report.StepSequence = wf.stepIDs
+		wf.report, err = wf.firstStep.Run(ctx, NewStartTrigger(wf.report))
+		if err != nil {
+			wf.report.Status = StatusFailed
+		}
+
+		wf.report.EndTime = time.Now()
+
+		return wf.report, err
 	}
 
-	return wf.reports, nil
+	return wf.report, nil
 }
 
 // End performs any cleanup after the Workflow execution

--- a/workflow.go
+++ b/workflow.go
@@ -103,6 +103,8 @@ func (wf *Workflow) Start(ctx context.Context) (*WorkflowReport, error) {
 		wf.report, err = wf.firstStep.Run(ctx, NewStartTrigger(wf.report))
 		if err != nil {
 			wf.report.Status = StatusFailed
+		} else {
+			wf.report.Status = StatusSuccess
 		}
 
 		wf.report.EndTime = time.Now()

--- a/workflow.go
+++ b/workflow.go
@@ -25,7 +25,7 @@ type Workflow struct {
 
 	// local cache for accumulating report from all internal states
 	// this is passed along to accumulate report from all internal states
-	report *WorkflowReport
+	report WorkflowReport
 
 	logger  *zap.Logger
 	stepIDs []string
@@ -70,12 +70,13 @@ func WithLogger(logger *zap.Logger) WorkflowOption {
 func NewWorkflow(id string, opts ...WorkflowOption) *Workflow {
 	fs := &failedStep{}
 	ss := &successStep{}
+	report := NewWorkflowReport(id, nil)
 
 	wf := &Workflow{
 		id:          id,
 		failedStep:  fs,
 		successStep: ss,
-		report:      NewWorkflowReport(id, nil),
+		report:      *report,
 		logger:      zap.NewNop(),
 	}
 
@@ -92,7 +93,7 @@ func (wf *Workflow) GetID() string {
 }
 
 // Start starts the workflow and returns the WorkflowReport
-func (wf *Workflow) Start(ctx context.Context) (*WorkflowReport, error) {
+func (wf *Workflow) Start(ctx context.Context) (WorkflowReport, error) {
 	wf.mutex.Lock()
 	defer wf.mutex.Unlock()
 

--- a/workflow.go
+++ b/workflow.go
@@ -100,6 +100,8 @@ func (wf *Workflow) Start(ctx context.Context) (*WorkflowReport, error) {
 
 	if wf.firstStep != nil {
 		wf.report.StepSequence = wf.stepIDs
+		wf.report.Status = StatusUndefined
+
 		wf.report, err = wf.firstStep.Run(ctx, NewStartTrigger(wf.report))
 		if err != nil {
 			wf.report.Status = StatusFailed

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -119,13 +119,13 @@ func TestWorkflowEngine_Start(t *testing.T) {
 		restart.GetID(): restart,
 	})
 
-	_, err := registry.BuildWorkflow("workflow_1", []string{
+	_, err := registry.BuildWorkflow("workflow_1", StepIDs{
 		"INVALID",
 	})
 	assert.Error(t, err)
 
 	// a new workflow with notify in the middle
-	workflow1, err := registry.BuildWorkflow("workflow_1", []string{
+	workflow1, err := registry.BuildWorkflow("workflow_1", StepIDs{
 		stop.GetID(),
 		fetch.GetID(),
 		notify.GetID(),
@@ -141,7 +141,7 @@ func TestWorkflowEngine_Start(t *testing.T) {
 	assert.Equal(t, 8, len(report.StepReports)) // it will reach all steps and rollback
 
 	// a new workflow with notify at the end
-	workflow2, err := registry.BuildWorkflow("workflow_2", []string{
+	workflow2, err := registry.BuildWorkflow("workflow_2", StepIDs{
 		stop.GetID(),
 		fetch.GetID(),
 		restart.GetID(),
@@ -158,7 +158,7 @@ func TestWorkflowEngine_Start(t *testing.T) {
 	assert.NotNil(t, report2.StepReports[5].Error)
 
 	// a new workflow with no failure
-	workflow3, err := registry.BuildWorkflow("workflow_3", []string{
+	workflow3, err := registry.BuildWorkflow("workflow_3", StepIDs{
 		stop.GetID(),
 		fetch.GetID(),
 		notify.GetID(),
@@ -172,7 +172,7 @@ func TestWorkflowEngine_Start(t *testing.T) {
 	assert.NotNil(t, report)
 	assert.Equal(t, 3, len(report3.StepReports))
 	assert.Equal(t, StatusSuccess, report3.Status)
-	assert.Equal(t, []string{stop.GetID(), fetch.GetID(), notify.GetID()}, report3.StepSequence)
+	assert.Equal(t, StepIDs{stop.GetID(), fetch.GetID(), notify.GetID()}, report3.StepSequence)
 	for _, stepReport := range report2.StepReports {
 		if (stepReport.StepID == restart.GetID() && stepReport.Action == RunAction) ||
 			(stepReport.StepID == stop.GetID() && stepReport.Action == RollbackAction) {
@@ -183,7 +183,7 @@ func TestWorkflowEngine_Start(t *testing.T) {
 	}
 
 	// NoOp scenario when first step is null
-	noopWorkflow, err := registry.BuildWorkflow("noop_workflow", []string{})
+	noopWorkflow, err := registry.BuildWorkflow("noop_workflow", StepIDs{})
 	assert.NoError(t, err)
 	report4, err := noopWorkflow.Start(ctx)
 	assert.NotNil(t, report4)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -99,22 +99,22 @@ func TestWorkflowEngine_Start(t *testing.T) {
 	defer cancel()
 
 	stop := &mockStopContainersStep{
-		Step:  Step{ID: "Stop containers"},
+		Step:  Step{ID: "stop_containers"},
 		cache: map[string][]byte{},
 	}
 
 	fetch := &mockFetchLatestStep{
-		Step:  Step{ID: "Fetch latest images"},
+		Step:  Step{ID: "fetch_latest_images"},
 		cache: map[string][]byte{},
 	}
 
 	notify := &mockNotifyStep{
-		Step:  Step{ID: "Notify on Slack"},
+		Step:  Step{ID: "notify_on_slack"},
 		cache: map[string][]byte{},
 	}
 
 	restart := &mockRestartContainersStep{
-		Step:  Step{ID: "Restart containers"},
+		Step:  Step{ID: "restart_containers"},
 		cache: map[string][]byte{},
 	}
 
@@ -125,20 +125,20 @@ func TestWorkflowEngine_Start(t *testing.T) {
 		restart.GetID(): restart,
 	})
 
-	_, err := registry.BuildWorkflow("workflow-1", []string{
+	_, err := registry.BuildWorkflow("workflow_1", []string{
 		"INVALID",
 	})
 	assert.Error(t, err)
 
 	// a new workflow with notify in the middle
-	workflow1, err := registry.BuildWorkflow("workflow-1", []string{
+	workflow1, err := registry.BuildWorkflow("workflow_1", []string{
 		stop.GetID(),
 		fetch.GetID(),
 		notify.GetID(),
 		restart.GetID(),
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "workflow-1", workflow1.GetID())
+	assert.Equal(t, "workflow_1", workflow1.GetID())
 	defer workflow1.End(ctx)
 
 	report, err := workflow1.Start(ctx)
@@ -147,14 +147,14 @@ func TestWorkflowEngine_Start(t *testing.T) {
 	assert.Equal(t, 4, len(report.StepReports)) // it will reach all steps and rollback
 
 	// a new workflow with notify at the end
-	workflow2, err := registry.BuildWorkflow("workflow-2", []string{
+	workflow2, err := registry.BuildWorkflow("workflow_2", []string{
 		stop.GetID(),
 		fetch.GetID(),
 		restart.GetID(),
 		notify.GetID(),
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "workflow-2", workflow2.GetID())
+	assert.Equal(t, "workflow_2", workflow2.GetID())
 	defer workflow2.End(ctx)
 
 	report2, err := workflow2.Start(ctx)
@@ -164,13 +164,13 @@ func TestWorkflowEngine_Start(t *testing.T) {
 	assert.NotNil(t, report2.StepReports[restart.ID].Actions[RunAction].Error)
 
 	// a new workflow with no failure
-	workflow3, err := registry.BuildWorkflow("workflow-3", []string{
+	workflow3, err := registry.BuildWorkflow("workflow_3", []string{
 		stop.GetID(),
 		fetch.GetID(),
 		notify.GetID(),
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "workflow-3", workflow3.GetID())
+	assert.Equal(t, "workflow_3", workflow3.GetID())
 	defer workflow2.End(ctx)
 
 	report3, err := workflow3.Start(ctx)
@@ -186,7 +186,7 @@ func TestWorkflowEngine_Start(t *testing.T) {
 	}
 
 	// NoOp scenario when first step is null
-	noopWorkflow, err := registry.BuildWorkflow("noop-workflow", []string{})
+	noopWorkflow, err := registry.BuildWorkflow("noop_workflow", []string{})
 	assert.NoError(t, err)
 	report4, err := noopWorkflow.Start(ctx)
 	assert.NotNil(t, report4)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -30,14 +30,14 @@ type mockRestartContainersStep struct {
 	cache map[string][]byte
 }
 
-func (s *mockStopContainersStep) Run(ctx context.Context, prevSuccess *Success) (*WorkflowReport, error) {
+func (s *mockStopContainersStep) Run(ctx context.Context, prevSuccess *Success) (WorkflowReport, error) {
 	report := NewStepReport(s.ID, RunAction)
 	fmt.Printf("RUN - %q", s.ID)
 	s.cache["rollbackMsg"] = []byte(fmt.Sprintf("ROLLBACK - %q", s.ID))
 	return s.RunNext(ctx, prevSuccess, report)
 }
 
-func (s *mockStopContainersStep) Rollback(ctx context.Context, prevFailure *Failure) (*WorkflowReport, error) {
+func (s *mockStopContainersStep) Rollback(ctx context.Context, prevFailure *Failure) (WorkflowReport, error) {
 	report := NewStepReport(s.ID, RollbackAction)
 	fmt.Println(string(s.cache["rollbackMsg"]))
 
@@ -47,7 +47,7 @@ func (s *mockStopContainersStep) Rollback(ctx context.Context, prevFailure *Fail
 	return s.FailedRollback(ctx, prevFailure, err, report)
 }
 
-func (s *mockFetchLatestStep) Run(ctx context.Context, prevSuccess *Success) (*WorkflowReport, error) {
+func (s *mockFetchLatestStep) Run(ctx context.Context, prevSuccess *Success) (WorkflowReport, error) {
 	report := NewStepReport(s.ID, RunAction)
 	fmt.Printf("RUN - %q", s.ID)
 	s.cache["rollbackMsg"] = []byte(fmt.Sprintf("ROLLBACK - %q", s.ID))
@@ -55,26 +55,26 @@ func (s *mockFetchLatestStep) Run(ctx context.Context, prevSuccess *Success) (*W
 	return s.RunNext(ctx, prevSuccess, report)
 }
 
-func (s *mockFetchLatestStep) Rollback(ctx context.Context, prevFailure *Failure) (*WorkflowReport, error) {
+func (s *mockFetchLatestStep) Rollback(ctx context.Context, prevFailure *Failure) (WorkflowReport, error) {
 	report := NewStepReport(s.ID, RollbackAction)
 	fmt.Println(string(s.cache["rollbackMsg"]))
 	return s.RollbackPrev(ctx, prevFailure, report)
 }
 
-func (s *mockNotifyStep) Run(ctx context.Context, prevSuccess *Success) (*WorkflowReport, error) {
+func (s *mockNotifyStep) Run(ctx context.Context, prevSuccess *Success) (WorkflowReport, error) {
 	report := NewStepReport(s.ID, RunAction)
 	fmt.Printf("SKIP RUN - %q", s.ID)
 	s.cache["rollbackMsg"] = []byte(fmt.Sprintf("SKIP ROLLBACK - %q", s.ID))
 	return s.SkippedRun(ctx, prevSuccess, report)
 }
 
-func (s *mockNotifyStep) Rollback(ctx context.Context, prevFailure *Failure) (*WorkflowReport, error) {
+func (s *mockNotifyStep) Rollback(ctx context.Context, prevFailure *Failure) (WorkflowReport, error) {
 	report := NewStepReport(s.ID, RollbackAction)
 	fmt.Println(string(s.cache["rollbackMsg"]))
 	return s.SkippedRollback(ctx, prevFailure, report)
 }
 
-func (s *mockRestartContainersStep) Run(ctx context.Context, prevSuccess *Success) (*WorkflowReport, error) {
+func (s *mockRestartContainersStep) Run(ctx context.Context, prevSuccess *Success) (WorkflowReport, error) {
 	report := NewStepReport(s.ID, RunAction)
 	fmt.Printf("RUN - %q", s.ID)
 	s.cache["rollbackMsg"] = []byte(fmt.Sprintf("ROLLBACK - %q", s.ID))
@@ -88,7 +88,7 @@ func (s *mockRestartContainersStep) Run(ctx context.Context, prevSuccess *Succes
 	return s.RunNext(ctx, prevSuccess, report)
 }
 
-func (s *mockRestartContainersStep) Rollback(ctx context.Context, prevFailure *Failure) (*WorkflowReport, error) {
+func (s *mockRestartContainersStep) Rollback(ctx context.Context, prevFailure *Failure) (WorkflowReport, error) {
 	report := NewStepReport(s.ID, RollbackAction)
 	fmt.Println(string(s.cache["rollbackMsg"]))
 	return s.RollbackPrev(ctx, prevFailure, report)


### PR DESCRIPTION
This PR refactors old `Report` and introduces `WorkflowReport` with more granular reporting for `Run` and `Rollback` step actions.

A `WorkflowReport` is passed along the steps where each step adds its own report for its `Run` and `Rollback` action. Note that `Rollback` report may not be added if workflow succeeds and never hits the `Rollback` methods.

A `WorkflowReport` can be exported as YAML or JSON for local/remote storage.


**This PR also introduces breaking interface changes** to simplify Step implementations.