### PR TITLE
feat: add a Step parameter to enable step callbacks to access their own state

### DIFF
--- a/automa_steps/step_bash.go
+++ b/automa_steps/step_bash.go
@@ -42,11 +42,13 @@ func RunBashScript(scripts []string, workDir string) (string, error) {
 
 // BashScriptStep creates a new step builder that executes a list of bash scripts in the specified working directory.
 // The returned StepBuilder can be further configured via method chaining (e.g., to add rollback, onPrepare, or completion functions).
-// The step will return a success report if all scripts execute successfully, otherwise it returns an error report.
+// For a stateful step, add a prepare function that initializes state before execution.
+// The step captures the combined output of all scripts and includes it in the step report metadata under the "output" key.
+// If any script fails, the step reports failure with the error and partial output.
 func BashScriptStep(id string, scripts []string, workDir string) *automa.StepBuilder {
 	return automa.NewStepBuilder().
 		WithId(id).
-		WithExecute(func(ctx context.Context) *automa.Report {
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			output, err := RunBashScript(scripts, workDir)
 			if err != nil {
 				return automa.StepFailureReport(id, automa.WithError(err), automa.WithMetadata(map[string]string{

--- a/examples/setup_local/main.go
+++ b/examples/setup_local/main.go
@@ -145,7 +145,7 @@ func buildWorkflow(wg *sync.WaitGroup) *automa.WorkflowBuilder {
 	// This ensures that we don't exit the program before all steps are done.
 	workflow := automa.NewWorkflowBuilder().
 		WithId("setup_local_dev").
-		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+		WithPrepare(func(ctx context.Context, w automa.Step) (context.Context, error) {
 			err := os.RemoveAll(setupDir)
 			if err != nil && !os.IsNotExist(err) {
 				return nil, err
@@ -172,11 +172,11 @@ func buildWorkflow(wg *sync.WaitGroup) *automa.WorkflowBuilder {
 				),
 		).
 		WithRollbackMode(automa.RollbackModeStopOnError).
-		WithOnCompletion(func(ctx context.Context, stp automa.Step, report *automa.Report) {
+		WithOnCompletion(func(ctx context.Context, w automa.Step, report *automa.Report) {
 			wgStep.Wait()
 			wg.Done() // we mark is done only after all steps are complete
 		}).
-		WithOnFailure(func(ctx context.Context, stp automa.Step, report *automa.Report) {
+		WithOnFailure(func(ctx context.Context, w automa.Step, report *automa.Report) {
 			go func() {
 				// call wgStep.Wait() for the steps that we started
 				for id, sp := range spinners {

--- a/examples/setup_local/main.go
+++ b/examples/setup_local/main.go
@@ -98,7 +98,7 @@ func buildWorkflow(wg *sync.WaitGroup) *automa.WorkflowBuilder {
 	// We need to start them before the step starts executing,
 	// so that we can see the spinner while the step is running.
 	onPrepare := func(ctx context.Context, stp automa.Step) (context.Context, error) {
-		startSpinner(st.Id(), &wgStep)
+		startSpinner(stp.Id(), &wgStep)
 		return ctx, nil
 	}
 
@@ -166,9 +166,9 @@ func buildWorkflow(wg *sync.WaitGroup) *automa.WorkflowBuilder {
 						WithOnCompletion(onCompletion).
 						WithOnFailure(onFailure),
 					installKind("v0.2x.x"). // pass an incorrect version to test failure and rollback
-								WithPrepare(onPrepare).
-								WithOnCompletion(onCompletion).
-								WithOnFailure(onFailure),
+						WithPrepare(onPrepare).
+						WithOnCompletion(onCompletion).
+						WithOnFailure(onFailure),
 				),
 		).
 		WithRollbackMode(automa.RollbackModeStopOnError).

--- a/examples/setup_local/main.go
+++ b/examples/setup_local/main.go
@@ -82,6 +82,7 @@ func buildWorkflow(wg *sync.WaitGroup) *automa.WorkflowBuilder {
 			} else {
 				fmt.Printf("%s %s\n", greenTick, report.Id)
 			}
+			delete(spinners, report.Id) // remove spinner from map
 		} else {
 			fmt.Printf("No spinner found for step: %s\n", report.Id)
 		}
@@ -96,15 +97,8 @@ func buildWorkflow(wg *sync.WaitGroup) *automa.WorkflowBuilder {
 	// This is important because the spinners run in separate goroutines.
 	// We need to start them before the step starts executing,
 	// so that we can see the spinner while the step is running.
-	onPrepare := func(ctx context.Context) (context.Context, error) {
-		state := automa.StateFromContext(ctx)
-		id := automa.StringFromState(state, automa.KeyId)
-		if id == "" {
-			return nil, fmt.Errorf("step id not found in state bag")
-		}
-
-		startSpinner(id, &wgStep)
-
+	onPrepare := func(ctx context.Context, stp automa.Step) (context.Context, error) {
+		startSpinner(st.Id(), &wgStep)
 		return ctx, nil
 	}
 
@@ -130,10 +124,10 @@ func buildWorkflow(wg *sync.WaitGroup) *automa.WorkflowBuilder {
 	// So always remember to wait for your spinners to complete! Check the OnCompletion callback for the workflow below.
 	// Otherwise, you may end up with a messy CLI output!
 	//
-	onCompletion := func(ctx context.Context, report *automa.Report) {
+	onCompletion := func(ctx context.Context, stp automa.Step, report *automa.Report) {
 		stopSpinner(report, spinners, &wgStep)
 	}
-	onFailure := func(ctx context.Context, report *automa.Report) {
+	onFailure := func(ctx context.Context, stp automa.Step, report *automa.Report) {
 		stopSpinner(report, spinners, &wgStep)
 	}
 
@@ -151,7 +145,7 @@ func buildWorkflow(wg *sync.WaitGroup) *automa.WorkflowBuilder {
 	// This ensures that we don't exit the program before all steps are done.
 	workflow := automa.NewWorkflowBuilder().
 		WithId("setup_local_dev").
-		WithPrepare(func(ctx context.Context) (context.Context, error) {
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			err := os.RemoveAll(setupDir)
 			if err != nil && !os.IsNotExist(err) {
 				return nil, err
@@ -172,18 +166,27 @@ func buildWorkflow(wg *sync.WaitGroup) *automa.WorkflowBuilder {
 						WithOnCompletion(onCompletion).
 						WithOnFailure(onFailure),
 					installKind("v0.2x.x"). // pass an incorrect version to test failure and rollback
-						WithPrepare(onPrepare).
-						WithOnCompletion(onCompletion).
-						WithOnFailure(onFailure),
+								WithPrepare(onPrepare).
+								WithOnCompletion(onCompletion).
+								WithOnFailure(onFailure),
 				),
 		).
 		WithRollbackMode(automa.RollbackModeStopOnError).
-		WithOnCompletion(func(ctx context.Context, report *automa.Report) {
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, report *automa.Report) {
 			wgStep.Wait()
 			wg.Done() // we mark is done only after all steps are complete
 		}).
-		WithOnFailure(func(ctx context.Context, report *automa.Report) {
+		WithOnFailure(func(ctx context.Context, stp automa.Step, report *automa.Report) {
+			go func() {
+				// call wgStep.Wait() for the steps that we started
+				for id, sp := range spinners {
+					sp.Stop()
+					fmt.Printf("✘ %s - stopped because of failure\n", id)
+					wgStep.Done()
+				}
+			}()
 			wgStep.Wait()
+
 			wg.Done()
 		})
 

--- a/examples/setup_local/steps.go
+++ b/examples/setup_local/steps.go
@@ -25,7 +25,7 @@ func setupDirectories() *automa.StepBuilder {
 	}
 	script := fmt.Sprintf("mkdir -p %s", strings.Join(dirs, " "))
 	return automa_steps.BashScriptStep(setupDirStepId, []string{script}, "").
-		WithRollback(func(ctx context.Context) *automa.Report {
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
 			_, err := os.Stat(setupDir)
 			if err != nil {
 				if os.IsNotExist(err) {
@@ -58,7 +58,7 @@ if ! command -v %[1]s/bin/task &> /dev/null; then
   chmod +x %[1]s/bin/task
 fi`, setupDir, version))
 	return automa_steps.BashScriptStep(installTaskStepId, []string{installCmd}, "").
-		WithRollback(func(ctx context.Context) *automa.Report {
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
 			p := path.Join(setupDir, "bin", "task")
 			_, err := os.Stat(p)
 			if err != nil {
@@ -91,7 +91,7 @@ if ! command -v %[1]s/bin/kind &> /dev/null; then
   chmod +x %[1]s/bin/kind
 fi`, setupDir, version))
 	return automa_steps.BashScriptStep(installKindStepId, []string{installCmd}, "").
-		WithRollback(func(ctx context.Context) *automa.Report {
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
 			p := path.Join(setupDir, "bin", "kind")
 			_, err := os.Stat(p)
 			if err != nil {

--- a/step_builder.go
+++ b/step_builder.go
@@ -6,11 +6,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
-type ExecuteFunc func(ctx context.Context) *Report
-type RollbackFunc func(ctx context.Context) *Report
-type PrepareFunc func(ctx context.Context) (context.Context, error)
-type OnCompletionFunc func(ctx context.Context, report *Report)
-type OnFailureFunc func(ctx context.Context, report *Report)
+type ExecuteFunc func(ctx context.Context, stp Step) *Report
+type RollbackFunc func(ctx context.Context, stp Step) *Report
+type PrepareFunc func(ctx context.Context, stp Step) (context.Context, error)
+type OnCompletionFunc func(ctx context.Context, stp Step, report *Report)
+type OnFailureFunc func(ctx context.Context, stp Step, report *Report)
 
 // StepBuilder is a builder for creating steps with optional prepare, execute, completion, and rollback functions.
 type StepBuilder struct {

--- a/step_builder_test.go
+++ b/step_builder_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func dummyExecute(ctx context.Context) *Report                  { return &Report{} }
-func dummyRollback(ctx context.Context) *Report                 { return &Report{} }
-func dummyPrepare(ctx context.Context) (context.Context, error) { return ctx, nil }
-func dummyOnCompletion(ctx context.Context, report *Report)     {}
-func dummyOnFailure(ctx context.Context, report *Report)        {}
+func dummyExecute(ctx context.Context, stp Step) *Report                  { return &Report{} }
+func dummyRollback(ctx context.Context, stp Step) *Report                 { return &Report{} }
+func dummyPrepare(ctx context.Context, stp Step) (context.Context, error) { return ctx, nil }
+func dummyOnCompletion(ctx context.Context, stp Step, report *Report)     {}
+func dummyOnFailure(ctx context.Context, stp Step, report *Report)        {}
 
 func TestStepBuilder_WithMethods(t *testing.T) {
 	logger := zerolog.Nop()

--- a/type_action_test.go
+++ b/type_action_test.go
@@ -67,3 +67,33 @@ func TestTypeAction_MarshalYAML_UnmarshalYAML(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, TypeAction(0), a)
 }
+
+func TestTypeAction_String_Prepare(t *testing.T) {
+	assert.Equal(t, "prepare", ActionPrepare.String())
+}
+
+func TestTypeAction_UnmarshalJSON_Invalid(t *testing.T) {
+	var a TypeAction
+	err := json.Unmarshal([]byte(`"invalid"`), &a)
+	assert.NoError(t, err)
+	assert.Equal(t, TypeAction(0), a)
+}
+
+func TestTypeAction_UnmarshalYAML_Invalid(t *testing.T) {
+	var a TypeAction
+	err := yaml.Unmarshal([]byte("invalid\n"), &a)
+	assert.NoError(t, err)
+	assert.Equal(t, TypeAction(0), a)
+}
+
+func TestTypeAction_MarshalYAML_Prepare(t *testing.T) {
+	b, err := yaml.Marshal(ActionPrepare)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), "prepare")
+}
+
+func TestTypeAction_MarshalJSON_Prepare(t *testing.T) {
+	b, err := json.Marshal(ActionPrepare)
+	assert.NoError(t, err)
+	assert.Equal(t, `"prepare"`, string(b))
+}


### PR DESCRIPTION
## Description

### Key changes:
- Add a Step parameter to enable step functions to access their own state and metadata directly
- Do not inject State in the context, rather leave it to the step functions to handle the State
- Do not let step manipulate or access Workflow State (however, workflow instance will be able to access steps' State since it has access to its own steps)

<img width="564" height="483" alt="Screenshot 2025-10-07 at 5 03 47 pm" src="https://github.com/user-attachments/assets/ad95b110-b20b-499a-898b-5fcb28c2a036" />


# -

This pull request introduces a breaking change to the step function signatures throughout the workflow engine, updating all step-related function types to receive the current `Step` as an additional argument. This enables greater flexibility and context-awareness within user-defined step functions. The change is applied consistently across the core step implementation, test helpers, and example workflows. Additionally, minor improvements and bug fixes are included for spinner handling and output reporting.

**API changes:**

* All step function types (`ExecuteFunc`, `RollbackFunc`, `PrepareFunc`, `OnCompletionFunc`, `OnFailureFunc`) now accept the current `Step` as an argument, enabling step functions to access their own state and metadata. (`step_builder.go` [step_builder.goL9-R13](diffhunk://#diff-de7fbc5fe7dcf3fe1020642b6d29bc5047a74e96a7db21e1157221bc840cc214L9-R13))
* The default step implementation (`defaultStep`) is updated to use the new function signatures, passing itself as the `Step` argument in all relevant calls. (`step_default.go` [[1]](diffhunk://#diff-51ba6897a18f3ca97dd7dc56fcc91ddc51081ad6aff5e62e43060edb49542eb2L23-R53) [[2]](diffhunk://#diff-51ba6897a18f3ca97dd7dc56fcc91ddc51081ad6aff5e62e43060edb49542eb2L72-R100) [[3]](diffhunk://#diff-51ba6897a18f3ca97dd7dc56fcc91ddc51081ad6aff5e62e43060edb49542eb2L122-R125) [[4]](diffhunk://#diff-51ba6897a18f3ca97dd7dc56fcc91ddc51081ad6aff5e62e43060edb49542eb2L144-R161)

**Examples and usage updates:**

* All custom step functions in the example workflow (`examples/setup_local/main.go` and `examples/setup_local/steps.go`) are updated to the new function signatures, ensuring compatibility with the new API. (`examples/setup_local/main.go` [[1]](diffhunk://#diff-9e2fa7436d2f7fde697b922e3932a5e54db6c915dc8078dc9aab20f0cf05b164L99-R101) [[2]](diffhunk://#diff-9e2fa7436d2f7fde697b922e3932a5e54db6c915dc8078dc9aab20f0cf05b164L133-R130) [[3]](diffhunk://#diff-9e2fa7436d2f7fde697b922e3932a5e54db6c915dc8078dc9aab20f0cf05b164L154-R148) [[4]](diffhunk://#diff-9e2fa7436d2f7fde697b922e3932a5e54db6c915dc8078dc9aab20f0cf05b164L181-R189); `examples/setup_local/steps.go` [[5]](diffhunk://#diff-eeeaba5ca2534358a7accd50cc0f20f51d7e565a240a5aa571ce19e47f65b3fcL28-R28) [[6]](diffhunk://#diff-eeeaba5ca2534358a7accd50cc0f20f51d7e565a240a5aa571ce19e47f65b3fcL61-R61) [[7]](diffhunk://#diff-eeeaba5ca2534358a7accd50cc0f20f51d7e565a240a5aa571ce19e47f65b3fcL94-R94)
* Spinner cleanup is improved by removing finished spinners from the tracking map and ensuring all spinners are stopped on workflow failure. (`examples/setup_local/main.go` [[1]](diffhunk://#diff-9e2fa7436d2f7fde697b922e3932a5e54db6c915dc8078dc9aab20f0cf05b164R85) [[2]](diffhunk://#diff-9e2fa7436d2f7fde697b922e3932a5e54db6c915dc8078dc9aab20f0cf05b164L181-R189)

**Testing and internal consistency:**

* All test helpers and mocks are updated to use the new function signatures. (`step_builder_test.go` [[1]](diffhunk://#diff-b08c88a7246c09c1850198ef6c60361ad68095c472ee219ecc73b57ef10777ddL11-R15) `step_default_test.go` [[2]](diffhunk://#diff-33527770786c6662135e4cc6457704b22d7cbcab802a1ed4d49f7f7bec8c2b56L16-R16) [[3]](diffhunk://#diff-33527770786c6662135e4cc6457704b22d7cbcab802a1ed4d49f7f7bec8c2b56L29-R29) [[4]](diffhunk://#diff-33527770786c6662135e4cc6457704b22d7cbcab802a1ed4d49f7f7bec8c2b56L41-R45) [[5]](diffhunk://#diff-33527770786c6662135e4cc6457704b22d7cbcab802a1ed4d49f7f7bec8c2b56L57-R62) [[6]](diffhunk://#diff-33527770786c6662135e4cc6457704b22d7cbcab802a1ed4d49f7f7bec8c2b56L84-R84) [[7]](diffhunk://#diff-33527770786c6662135e4cc6457704b22d7cbcab802a1ed4d49f7f7bec8c2b56L99-R99) [[8]](diffhunk://#diff-33527770786c6662135e4cc6457704b22d7cbcab802a1ed4d49f7f7bec8c2b56L142-R145)
* Additional tests for action type marshaling and error handling are added. (`type_action_test.go` [type_action_test.goR70-R99](diffhunk://#diff-3daae95ce3e7e7490f88eec64c7be4aeba8f2d2e2a48879e97f442a1289ed106R70-R99))

**Documentation and minor improvements:**

* Step function documentation is updated to clarify the new function signatures and output reporting. (`automa_steps/step_bash.go` [automa_steps/step_bash.goL45-R51](diffhunk://#diff-35b024487ffec02b64e31ad18427d1a6c1fb716a5ce14b40bcd4ba07b1646317L45-R51))
* Minor code cleanup, such as renaming variables for clarity and updating the `IsWorkflow` function for consistency. (`workflow.go` [workflow.goL22-R23](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL22-R23))

This update is a breaking change and will require all consumers of the workflow engine to update their step function signatures accordingly.

### Related Issues

* Closes #36 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
