### PR TITLE
feat: allow custom rollback for a workflow

### DIFF
--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -141,6 +141,11 @@ func (wb *WorkflowBuilder) WithState(state StateBag) *WorkflowBuilder {
 	return wb
 }
 
+func (wb *WorkflowBuilder) WithRollback(rollback RollbackFunc) *WorkflowBuilder {
+	wb.workflow.rollback = rollback
+	return wb
+}
+
 func NewWorkflowBuilder() *WorkflowBuilder {
 	return &WorkflowBuilder{
 		workflow:     newWorkflow(),


### PR DESCRIPTION
## Key change

- Users can now provide a custom rollback function via the builder API.
- The custom rollback function receives the current context and step, and returns a Report.
- This allows for more granular control over rollback actions, error handling, and reporting during workflow execution.
- This helpful where user don't want to rollback all steps based on certain conditions or for efficiency.
Example Usage
```
wb := NewWorkflowBuilder().
    WithId("my-workflow").
    WithRollback(func(ctx context.Context, stp Step) *Report {
        // custom rollback logic here
        return StepSuccessReport("my-workflow")
    })
```

## Test coverage
<img width="628" height="478" alt="Screenshot 2025-10-08 at 7 59 19 pm" src="https://github.com/user-attachments/assets/c4bdf00f-978f-48cc-be33-969d6b63b11b" />


## Description
This pull request introduces support for user-defined rollback functions in the workflow engine, enhances the workflow builder API, and adds comprehensive tests for new and existing functionality. The most important changes are grouped below:

### User-Defined Rollback Functionality

* Added a `rollback` field to the `workflow` struct, allowing users to supply a custom rollback function for the entire workflow. The `Rollback` method now invokes this function if provided, and the new `invokeRollbackFunc` helper ensures correct handling of its result, including error propagation and action setting. (`workflow.go` [[1]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL13-L19) [[2]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR199-R234)

### Workflow Builder Enhancements

* Added a `WithRollback` method to `WorkflowBuilder`, enabling fluent configuration of the user-defined rollback function. (`workflow_builder.go` [workflow_builder.goR144-R148](diffhunk://#diff-e7c112cda9bd742190f9330772f29be4afcc18e33049f3dc0c47553f22d6d0e0R144-R148))

### Testing Improvements

* Added tests to verify user-defined rollback function invocation, correct handling of nil and failed rollback reports, and method chaining in the workflow builder. These tests ensure the new and existing workflow builder and rollback functionality behave as expected. (`workflow_test.go` [[1]](diffhunk://#diff-69a2723318db0a4416df092fc13f68f8e05454975c93b361dd777d7b19eb0e97R421-R488) `workflow_builder_test.go` [[2]](diffhunk://#diff-02239529c9b1eb159de49e681ff184f2b7e24b607c8611ee67884d2c80f49d67R180-R236)

### Validation and Method Chaining

* Added validation tests for empty workflow IDs and missing steps, and a test for method chaining in the workflow builder, improving robustness and usability. (`workflow_builder_test.go` [workflow_builder_test.goR180-R236](diffhunk://#diff-02239529c9b1eb159de49e681ff184f2b7e24b607c8611ee67884d2c80f49d67R180-R236))

### Related Issues

* Closes #38 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
