### PR TITLE
fix: support rollback-on-error and stop-on-error workflow execution modes

### DIFF
--- a/type_mode.go
+++ b/type_mode.go
@@ -14,12 +14,15 @@ type TypeMode uint8
 const (
 	ContinueOnError TypeMode = 1
 	StopOnError     TypeMode = 2
+	RollbackOnError TypeMode = 3
 )
 
 func (rm TypeMode) String() string {
 	switch rm {
 	case ContinueOnError:
 		return "continue"
+	case RollbackOnError:
+		return "rollback"
 	case StopOnError:
 		return "stop"
 	default:
@@ -39,6 +42,8 @@ func (rm *TypeMode) UnmarshalJSON(data []byte) error {
 	switch s {
 	case "continue":
 		*rm = ContinueOnError
+	case "rollback":
+		*rm = RollbackOnError
 	case "stop":
 		*rm = StopOnError
 	default:
@@ -59,6 +64,8 @@ func (rm *TypeMode) UnmarshalYAML(value *yaml.Node) error {
 	switch s {
 	case "continue":
 		*rm = ContinueOnError
+	case "rollback":
+		*rm = RollbackOnError
 	case "stop":
 		*rm = StopOnError
 	default:

--- a/type_mode_test.go
+++ b/type_mode_test.go
@@ -11,6 +11,7 @@ import (
 func TestTypeMode_String(t *testing.T) {
 	assert.Equal(t, "continue", ContinueOnError.String())
 	assert.Equal(t, "stop", StopOnError.String())
+	assert.Equal(t, "rollback", RollbackOnError.String())
 	assert.Equal(t, "unknown", TypeMode(99).String())
 }
 
@@ -21,6 +22,7 @@ func TestTypeMode_MarshalJSON_UnmarshalJSON(t *testing.T) {
 	}{
 		{ContinueOnError, `"continue"`},
 		{StopOnError, `"stop"`},
+		{RollbackOnError, `"rollback"`},
 	}
 
 	for _, tt := range tests {
@@ -35,8 +37,8 @@ func TestTypeMode_MarshalJSON_UnmarshalJSON(t *testing.T) {
 	}
 
 	// Unknown value
-	var m TypeMode
-	err := json.Unmarshal([]byte(`"unknown"`), &m)
+	var mu TypeMode
+	err := json.Unmarshal([]byte(`"unknown"`), &mu)
 	assert.Error(t, err)
 }
 
@@ -47,6 +49,7 @@ func TestTypeMode_MarshalYAML_UnmarshalYAML(t *testing.T) {
 	}{
 		{ContinueOnError, "continue"},
 		{StopOnError, "stop"},
+		{RollbackOnError, "rollback"},
 	}
 
 	for _, tt := range tests {
@@ -61,7 +64,7 @@ func TestTypeMode_MarshalYAML_UnmarshalYAML(t *testing.T) {
 	}
 
 	// Unknown value
-	var m TypeMode
-	err := yaml.Unmarshal([]byte("unknown\n"), &m)
+	var mu TypeMode
+	err := yaml.Unmarshal([]byte("unknown\n"), &mu)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
## Description

This pull request introduces a new error handling mode called `RollbackOnError` to the workflow system, allowing workflows to automatically rollback all executed steps when a failure occurs, instead of just stopping or continuing. The changes update type definitions, serialization logic, and execution flow to support this new mode.

### Error Handling Modes

* Added the `RollbackOnError` mode to the `TypeMode` enum in `type_mode.go`, including support in the `String()` method for proper string representation.
* Updated JSON and YAML unmarshalling logic in `type_mode.go` to recognize and correctly parse the new `"rollback"` string value for the error handling mode. [[1]](diffhunk://#diff-11fc89a7b91f6d0ed4cefd47b1c74be8b7f9801757762b67d460aadbcccfaec8R45-R46) [[2]](diffhunk://#diff-11fc89a7b91f6d0ed4cefd47b1c74be8b7f9801757762b67d460aadbcccfaec8R67-R68)

### Workflow Execution Logic

* Modified the workflow execution logic in `workflow.go` so that, when `RollbackOnError` is set, a failure triggers rollback of all executed steps from the current one back to the start, rather than simply stopping or continuing.

### Code Structure

* Minor code organization improvement: separated the `Rollback` function from the rollback invocation helper for clarity in `workflow.go`.

### Related Issues

* Closes #56 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
