### PR TITLE
fix: inherit execution mode in child workflow from parent

### DIFF
--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -35,7 +35,17 @@ func (wb *WorkflowBuilder) Build() (Step, error) {
 		if err != nil {
 			return nil, IllegalArgument.New("failed to build step '%s': %v", builder.Id(), err)
 		}
+
 		if step != nil {
+			// If the step itself is a workflow, propagate the parent workflow's
+			// execution and rollback modes so that nested workflows behave
+			// consistently and follow the same error handling and rollback
+			// strategy as the enclosing workflow.
+			if wfStep, ok := step.(*workflow); ok {
+				wfStep.executionMode = wb.workflow.executionMode
+				wfStep.rollbackMode = wb.workflow.rollbackMode
+			}
+
 			steps = append(steps, step)
 		}
 	}


### PR DESCRIPTION
## Description

This pull request enhances the workflow builder to ensure that nested workflows inherit execution and rollback modes from their parent workflow. It also adds a test to verify this behavior.

**Workflow inheritance improvements:**

* Updated the `Build` method in `workflow_builder.go` so that when a step is itself a workflow, it now inherits the `executionMode` and `rollbackMode` from the parent workflow.

**Testing:**

* Added a new test `TestWorkflowBuilder_InheritModesForNestedWorkflow` in `workflow_builder_test.go` to confirm that nested workflows correctly inherit execution and rollback modes from their parent workflow.

### Related Issues

* Closes #58 
* Related to #

### Pull request (PR) checklist

* \[x] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[x] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
