### PR TITLE
feat: support runtime value and state management across sub-workflows

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# (mandatory) 
+# Path to coverage profile file (output of `go test -coverprofile` command).
+#
+# For cases where there are many coverage profiles, such as when running 
+# unit tests and integration tests separately, you can combine all those
+# profiles into one. In this case, the profile should have a comma-separated list 
+# of profile files, e.g., 'cover_unit.out,cover_integration.out'.
+profile: cover.out
+
+# Holds coverage thresholds percentages, values should be in range [0-100].
+threshold:
+  # (optional; default 0) 
+  # Minimum coverage percentage required for individual files.
+  file: 60
+
+  # (optional; default 0) 
+  # Minimum coverage percentage required for each package.
+  package: 80
+
+  # (optional; default 0) 
+  # Minimum overall project coverage percentage required.
+  total: 80
+
+# Holds regexp rules which will override thresholds for matched files or packages 
+# using their paths.
+#
+# First rule from this list that matches file or package is going to apply 
+# new threshold to it. If project has multiple rules that match same path, 
+# override rules should be listed in order from specific to more general rules.
+override:
+  # Increase coverage threshold to 100% for `foo` package 
+  # (default is 80, as configured above in this example).
+  - path: ^pkg/lib/foo$
+    threshold: 100
+
+# Holds regexp rules which will exclude matched files or packages 
+# from coverage statistics.
+exclude:
+  # Exclude files or packages matching their paths
+  paths:
+    - \.pb\.go$    # excludes all protobuf generated files
+    - ^pkg/bar     # exclude package `pkg/bar`
+
+# File name of go-test-coverage breakdown file, which can be used to 
+# analyze coverage difference.
+breakdown-file-name: ''
+
+diff:
+  # File name of go-test-coverage breakdown file which will be used to 
+  # report coverage difference.
+  base-breakdown-file-name: ''

--- a/automa.go
+++ b/automa.go
@@ -11,6 +11,7 @@ type Step interface {
 	Execute(ctx context.Context) *Report
 	Rollback(ctx context.Context) *Report
 	State() StateBag
+	WithState(s StateBag) Step
 }
 
 type StateBag interface {

--- a/automa.go
+++ b/automa.go
@@ -22,7 +22,7 @@ type StateBag interface {
 	Size() int
 	Items() map[Key]interface{}
 	Merge(other StateBag) StateBag
-	Clone() StateBag
+	Clone() (StateBag, error)
 	// Helper methods for extracting typed values
 	String(key Key) string
 	Bool(key Key) bool

--- a/examples/setup_local/go.mod
+++ b/examples/setup_local/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/term v0.1.0 // indirect
 )

--- a/examples/setup_local/go.sum
+++ b/examples/setup_local/go.sum
@@ -31,6 +31,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=

--- a/examples/setup_local/main.go
+++ b/examples/setup_local/main.go
@@ -172,6 +172,7 @@ func buildWorkflow(wg *sync.WaitGroup) *automa.WorkflowBuilder {
 								WithOnFailure(onFailure),
 				),
 		).
+		WithExecutionMode(automa.RollbackOnError).
 		WithRollbackMode(automa.StopOnError).
 		WithOnCompletion(func(ctx context.Context, w automa.Step, report *automa.Report) {
 			wgStep.Wait()

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/joomcode/errorx v1.2.0
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.19.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=

--- a/runtime_value.go
+++ b/runtime_value.go
@@ -1,0 +1,423 @@
+package automa
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/joomcode/errorx"
+)
+
+// Value provides primitives for building and resolving typed
+// configuration values used by the automa framework. It is centered around
+// the concept of a runtime-resolvable value container represented
+// by the Value[T] interface which supports producing a deep-cloned copy.
+//
+// This file contains the default Value implementation and the RuntimeValue
+// container which composes default values, optional user input and an
+// optional effective resolution function.
+type Value[T any] interface {
+	Clone() (Value[T], error)
+	Val() T
+}
+
+// defaultValue is a concrete implementation of Value.
+//
+// It holds the actual value and an optional custom cloner function.
+// If cloner is nil, encoding/gob is used to perform deep cloning.
+type defaultValue[T any] struct {
+	v      T
+	cloner func(v T) (Value[T], error)
+}
+
+// NewValue constructs a new Value instance validated to be encodable by
+// encoding/gob. It performs a test gob encode of the value to ensure
+// that Clone (which uses gob) will succeed. Returns an error if the
+// value (or nested types) are not encodable by gob.
+//
+// For types that are not encodable by encoding/gob, use NewValueWithCloner
+// to provide a custom cloner.
+func NewValue[T any](v T) (Value[T], error) {
+	// exported wrapper so gob can encode fields of T if needed
+	type exported[T any] struct {
+		V T
+	}
+
+	ev := exported[T]{V: v}
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(&ev); err != nil {
+		return nil, errorx.IllegalArgument.Wrap(err,
+			"value is not encodable by encoding/gob; register concrete types with RegisterGobTypes or provide a custom cloner")
+	}
+
+	return &defaultValue[T]{v: v, cloner: nil}, nil
+}
+
+// NewValueWithCloner constructs a new Value instance with a custom cloner
+// function. The provided clonerFunc is used to create a deep copy of the
+// value when Clone is called. If clonerFunc is nil, the default gob-based
+// cloning will be used.
+func NewValueWithCloner[T any](v T, clonerFunc func(v T) (Value[T], error)) Value[T] {
+	return &defaultValue[T]{v: v, cloner: clonerFunc}
+}
+
+// Val returns the underlying value stored in the defaultValue.
+//
+// This method is nil-receiver safe: calling Val on a nil *defaultValue
+// returns the zero value of T to avoid panics.
+func (v *defaultValue[T]) Val() T {
+	if v == nil {
+		var zero T
+		return zero
+	}
+	return v.v
+}
+
+// Clone returns a deep copy of the Value.
+//
+// Behavior:
+// - If the receiver is nil, returns an error (errorx.IllegalState).
+// - If a custom cloner is provided, it is used to clone the value.
+// - Otherwise encoding/gob is used to encode+decode a copy of the value.
+//
+// Errors are wrapped with errorx.IllegalState to indicate cloning failures.
+func (v *defaultValue[T]) Clone() (Value[T], error) {
+	if v == nil {
+		return nil, errorx.IllegalState.New("cannot clone nil Value")
+	}
+
+	if v.cloner != nil {
+		cloned, err := v.cloner(v.v)
+		if err != nil {
+			return nil, errorx.IllegalState.Wrap(err,
+				"failed to clone value using custom clone")
+		}
+		// preserve custom cloner on the returned value
+		return NewValueWithCloner(cloned.Val(), v.cloner), nil
+	}
+
+	// exported wrapper so gob can encode fields of T if needed
+	type exported[T any] struct {
+		V T
+	}
+
+	ev := exported[T]{V: v.v}
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(&ev); err != nil {
+		return nil, errorx.IllegalState.Wrap(err,
+			"failed to gob.encode value for cloning, "+
+				"ensure all nested types are encodable with gob or provide a custom clone")
+	}
+
+	var ev2 exported[T]
+	if err := gob.NewDecoder(&buf).Decode(&ev2); err != nil {
+		return nil, errorx.IllegalState.Wrap(err,
+			"failed to gob.decode value for cloning, "+
+				"ensure all nested types are decodable with gob or provide a custom clone")
+	}
+
+	return NewValue(ev2.V)
+}
+
+// EffectiveFunc is a function type used to compute the effective Value[T]
+// based on the provided defaultVal and userInput.
+//
+// The function should return the computed Value[T], a boolean indicating
+// whether the result should be cached for future calls, and an error if
+// the computation fails.
+//
+// Semantics:
+//   - If error != nil the call fails.
+//   - If returned Value[T] is nil, the call fails (treated as an implementation error).
+//   - If shouldCache == true the first successful non-nil result will be cached
+//     in the RuntimeValue instance and returned to subsequent callers.
+//   - If shouldCache == false the computed result will be returned to the caller
+//     but not cached; subsequent calls will re-evaluate.
+//
+// The function is expected to be side-effect-free if caching is enabled.
+type EffectiveFunc[T any] func(ctx context.Context, defaultVal Value[T], userInput Value[T]) (Value[T], bool, error)
+
+// RuntimeValue is a generic container for a default value together with
+// optional user input and an optional effective function.
+//
+// Resolution semantics:
+//   - If an effectiveFunc is provided, it is invoked during the first call
+//     to Effective() to compute the effective value. The function is expected
+//     to return a non-nil Value and to be side-effect-free when it returns shouldCache=true.
+//   - If effectiveFunc is not provided, the effective value is determined
+//     at construction time: userInput (if provided) otherwise defaultVal.
+//   - Default() returns the configured defaultVal.
+//   - UserInput() returns the configured userInput, if any.
+//
+// Concurrency:
+//   - RuntimeValue is safe for concurrent use by multiple goroutines.
+//   - The type uses an internal sync.RWMutex for protecting its fields and
+//     golang.org/x/sync/singleflight to deduplicate concurrent evaluations
+//     of effectiveFunc when the cached effective value is not yet set.
+//   - Provided Value implementations are assumed to be safe for concurrent use
+//     or immutable; if they are mutable, callers should take care to clone or
+//     otherwise protect them.
+type RuntimeValue[T any] struct {
+	mu            sync.RWMutex
+	effective     Value[T]
+	defaultVal    Value[T]
+	userInput     Value[T]
+	effectiveFunc EffectiveFunc[T]
+
+	sf singleflight.Group
+}
+
+// Effective returns the effective Value for the runtime value.
+//
+// If an effectiveFunc is provided, it is invoked to compute the effective
+// value on demand. If the effectiveFunc returns a value with shouldCache==true,
+// the first successful non-nil result is cached for subsequent calls. If
+// shouldCache==false the computed result is returned but not cached.
+//
+// Concurrency: this method is safe for concurrent callers. It uses a
+// read-mostly pattern: read locks for fast returns and a write lock only when
+// the effective value must be cached after computing it via effectiveFunc.
+// Concurrent evaluations of effectiveFunc are deduplicated using singleflight.
+func (v *RuntimeValue[T]) Effective(ctx context.Context) (Value[T], error) {
+	if v == nil {
+		return nil, errorx.IllegalState.New("RuntimeValue receiver is nil")
+	}
+
+	// Snapshot under read lock
+	v.mu.RLock()
+	eff := v.effective
+	effFunc := v.effectiveFunc
+	def := v.defaultVal
+	user := v.userInput
+	v.mu.RUnlock()
+
+	// fast path: already resolved or no effective function configured
+	if eff != nil || effFunc == nil {
+		return eff, nil
+	}
+
+	// Use singleflight to dedupe concurrent evaluations for this instance.
+	res, err, _ := v.sf.Do("effective", func() (interface{}, error) {
+		val, shouldCache, err := effFunc(ctx, def, user)
+		if err != nil {
+			return nil, err
+		}
+		if val == nil {
+			return nil, errorx.IllegalState.New("effectiveFunc returned nil Value")
+		}
+
+		// If caller requested not to cache, return value directly.
+		if !shouldCache {
+			return val, nil
+		}
+
+		// Cache the computed value if still unset.
+		v.mu.Lock()
+		if v.effective == nil {
+			v.effective = val
+		}
+		cached := v.effective
+		v.mu.Unlock()
+
+		return cached, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, nil
+	}
+
+	vres, ok := res.(Value[T])
+	if !ok {
+		return nil, errorx.IllegalState.New("singleflight invocation for effectiveFunc returned unexpected type")
+	}
+	return vres, nil
+}
+
+// Default returns the configured default Value.
+//
+// This method is nil-receiver safe: calling Default on a nil *RuntimeValue
+// returns nil.
+func (v *RuntimeValue[T]) Default() Value[T] {
+	if v == nil {
+		return nil
+	}
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.defaultVal
+}
+
+// UserInput returns the configured user input Value, if any.
+//
+// This method is nil-receiver safe: calling UserInput on a nil *RuntimeValue
+// returns nil.
+func (v *RuntimeValue[T]) UserInput() Value[T] {
+	if v == nil {
+		return nil
+	}
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.userInput
+}
+
+// Clone produces a deep copy of the RuntimeValue.
+//
+// The cloned RuntimeValue preserves the effectiveFunc reference and clones
+// effective, defaultVal and userInput (if non-nil) using their Clone methods.
+//
+// If the receiver is nil, Clone returns an error (errorx.IllegalState).
+//
+// Clone snapshots the pointers under a read lock, then performs the potentially
+// expensive Clone operations outside the lock to avoid blocking concurrent readers.
+//
+// Note: the singleflight.Group is intentionally not copied (zero-value is fine).
+// The clone will deduplicate its own concurrent Effective invocations.
+func (v *RuntimeValue[T]) Clone() (*RuntimeValue[T], error) {
+	if v == nil {
+		return nil, errorx.IllegalState.New("cannot clone nil RuntimeValue")
+	}
+
+	// Snapshot under read lock
+	v.mu.RLock()
+	eff := v.effective
+	def := v.defaultVal
+	user := v.userInput
+	effFunc := v.effectiveFunc
+	v.mu.RUnlock()
+
+	var err error
+	var ceff, cdef, cuser Value[T]
+
+	if eff != nil {
+		ceff, err = eff.Clone()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if def != nil {
+		cdef, err = def.Clone()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if user != nil {
+		cuser, err = user.Clone()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	c := &RuntimeValue[T]{
+		effective:     ceff,
+		defaultVal:    cdef,
+		userInput:     cuser,
+		effectiveFunc: effFunc,
+	}
+
+	return c, nil
+}
+
+// ValueOption is a functional option used to configure a RuntimeValue.
+type ValueOption[T any] func(*RuntimeValue[T])
+
+// WithEffectiveFunc returns a ValueOption that sets the effective function
+// which will be invoked by Effective.
+//
+// Note: these option setters mutate fields without internal locking and are
+// intended for construction-time configuration only. For runtime-safe updates
+// use the SetEffectiveFunc method on RuntimeValue.
+func WithEffectiveFunc[T any](f EffectiveFunc[T]) ValueOption[T] {
+	return func(v *RuntimeValue[T]) {
+		v.effectiveFunc = f
+	}
+}
+
+// WithUserInput returns a ValueOption that sets a user input Value to be
+// used as the effective value (unless an effectiveFunc is provided).
+//
+// Note: see WithEffectiveFunc regarding runtime mutation.
+func WithUserInput[T any](userInput Value[T]) ValueOption[T] {
+	return func(v *RuntimeValue[T]) {
+		v.userInput = userInput
+	}
+}
+
+// NewRuntimeValue constructs a new RuntimeValue instance.
+//
+// The defaultVal must be provided and cannot be nil. Optional ValueOptions
+// may set userInput and effectiveFunc. If effectiveFunc is not provided,
+// the effective value is set to userInput if present, otherwise to defaultVal.
+func NewRuntimeValue[T any](defaultVal Value[T], opts ...ValueOption[T]) (*RuntimeValue[T], error) {
+	if defaultVal == nil {
+		return nil, IllegalArgument.New("defaultVal must be provided and cannot be nil")
+	}
+
+	v := &RuntimeValue[T]{
+		defaultVal: defaultVal,
+	}
+
+	for _, opt := range opts {
+		opt(v)
+	}
+
+	// Determine effective defaultValue if effectiveFunc is not provided
+	if v.effectiveFunc == nil {
+		if v.userInput != nil {
+			v.effective = v.userInput
+		} else {
+			v.effective = defaultVal
+		}
+	}
+
+	return v, nil
+}
+
+// SetEffectiveFunc safely sets a new EffectiveFunc at runtime.
+// It clears any cached effective value to ensure the new function will be used.
+func (v *RuntimeValue[T]) SetEffectiveFunc(f EffectiveFunc[T]) {
+	if v == nil {
+		return
+	}
+	v.mu.Lock()
+	v.effectiveFunc = f
+	v.effective = nil
+	v.mu.Unlock()
+}
+
+// SetUserInput safely sets (or clears) the user input Value at runtime.
+// If an effectiveFunc is not configured the effective value is updated
+// immediately to reflect the new userInput; otherwise the cached effective
+// is cleared so future calls will re-evaluate.
+func (v *RuntimeValue[T]) SetUserInput(user Value[T]) {
+	if v == nil {
+		return
+	}
+	v.mu.Lock()
+	v.userInput = user
+	if v.effectiveFunc == nil {
+		if user != nil {
+			v.effective = user
+		} else {
+			v.effective = v.defaultVal
+		}
+	} else {
+		v.effective = nil
+	}
+	v.mu.Unlock()
+}
+
+// ClearCache clears any cached effective value so subsequent Effective calls
+// will re-evaluate according to the configured effectiveFunc (if any).
+func (v *RuntimeValue[T]) ClearCache() {
+	if v == nil {
+		return
+	}
+	v.mu.Lock()
+	v.effective = nil
+	v.mu.Unlock()
+}

--- a/runtime_value.go
+++ b/runtime_value.go
@@ -11,6 +11,12 @@ import (
 	"github.com/joomcode/errorx"
 )
 
+// Cloner marks values that can return a cloned copy of themselves.
+// Keep it minimal: Clone returns an `interface{}` and the caller decides what to store.
+type Cloner[T any] interface {
+	Clone() (T, error)
+}
+
 // Value provides primitives for building and resolving typed
 // configuration values used by the automa framework. It is centered around
 // the concept of a runtime-resolvable value container represented
@@ -20,7 +26,7 @@ import (
 // container which composes default values, optional user input and an
 // optional effective resolution function.
 type Value[T any] interface {
-	Clone() (Value[T], error)
+	Cloner[Value[T]]
 	Val() T
 }
 

--- a/runtime_value.go
+++ b/runtime_value.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Cloner marks values that can return a cloned copy of themselves.
-// Keep it minimal: Clone returns an `interface{}` and the caller decides what to store.
+// Clone returns a typed value of type T and an error; the caller decides what to store.
 type Cloner[T any] interface {
 	Clone() (T, error)
 }

--- a/runtime_value_test.go
+++ b/runtime_value_test.go
@@ -100,11 +100,16 @@ func TestRuntimeValue_CloneDeepCopiesInternalValues(t *testing.T) {
 	// Modify original
 	orig.M["x"] = 99
 
+	if rv.Default().Val().M["x"] != 99 {
+		t.Fatalf("expected original RuntimeValue default to reflect mutated value 99, got %d", rv.Default().Val().M["x"])
+	}
+
 	// cloned default should remain unchanged
 	clonedDefault := clonedRV.Default().Val()
 	if clonedDefault.M["x"] != 1 {
 		t.Fatalf("expected cloned default to keep value 1, got %d", clonedDefault.M["x"])
 	}
+
 }
 
 // Test that WithUserInput makes userInput the effective value and Clone deep-copies default and userInput.
@@ -447,7 +452,7 @@ func TestValue_Val(t *testing.T) {
 }
 
 func TestRuntimeValue_UserInput(t *testing.T) {
-	v, err := NewValue[int](10)
+	v, err := NewValue(10)
 	require.NoError(t, err)
 
 	rv, err := NewRuntimeValue[int](v)
@@ -456,7 +461,7 @@ func TestRuntimeValue_UserInput(t *testing.T) {
 	ui := rv.UserInput()
 	require.Nil(t, ui)
 
-	uv, err := NewValue[int](20)
+	uv, err := NewValue(20)
 	require.NoError(t, err)
 
 	rv.SetUserInput(uv)

--- a/runtime_value_test.go
+++ b/runtime_value_test.go
@@ -1,0 +1,504 @@
+package automa
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+)
+
+// Test gob-based cloning produces an independent deep copy for pointer-with-map types.
+func TestNewValue_GobDeepCopyPointerMap(t *testing.T) {
+	type S struct {
+		M map[string]int
+	}
+
+	orig := &S{M: map[string]int{"a": 1}}
+	v, err := NewValue[*S](orig)
+	if err != nil {
+		t.Fatalf("NewValue failed: %v", err)
+	}
+
+	cloneV, err := v.Clone()
+	if err != nil {
+		t.Fatalf("Clone failed: %v", err)
+	}
+
+	cloned := cloneV.Val()
+
+	// Mutate original
+	orig.M["a"] = 42
+
+	if cloned.M["a"] != 1 {
+		t.Fatalf("expected cloned map to keep original value 1, got %d", cloned.M["a"])
+	}
+}
+
+// Test NewValue returns an error for a type that is not encodable by encoding/gob (contains a func).
+func TestNewValue_InvalidGobType(t *testing.T) {
+	type Bad struct {
+		F func()
+	}
+
+	_, err := NewValue(Bad{F: func() {}})
+	if err == nil {
+		t.Fatalf("expected NewValue to fail for non-gob-encodable type, got nil error")
+	}
+}
+
+// Test that NewValueWithCloner uses the provided custom cloner.
+func TestNewValueWithCloner_UsesCustomCloner(t *testing.T) {
+	type NonEnc struct {
+		Ch chan int
+	}
+
+	called := false
+	var cloner func(NonEnc) (Value[NonEnc], error)
+	cloner = func(v NonEnc) (Value[NonEnc], error) {
+		called = true
+		// return a new Value using NewValueWithCloner to avoid gob encoding
+		return NewValueWithCloner(NonEnc{Ch: v.Ch}, cloner), nil
+	}
+
+	val := NewValueWithCloner(NonEnc{Ch: make(chan int)}, cloner)
+
+	cloned, err := val.Clone()
+	if err != nil {
+		t.Fatalf("Clone with custom cloner returned error: %v", err)
+	}
+	if !called {
+		t.Fatalf("expected custom cloner to be called")
+	}
+	_ = cloned.Val() // ensure we can inspect the value without panicking
+}
+
+// Test RuntimeValue cloning deep-copies the contained Values.
+func TestRuntimeValue_CloneDeepCopiesInternalValues(t *testing.T) {
+	type S struct {
+		M map[string]int
+	}
+
+	orig := &S{M: map[string]int{"x": 1}}
+	defVal, err := NewValue[*S](orig)
+	if err != nil {
+		t.Fatalf("NewValue failed: %v", err)
+	}
+
+	rv, err := NewRuntimeValue[*S](defVal)
+	require.NoError(t, err)
+	require.NotNil(t, rv)
+
+	clonedRV, err := rv.Clone()
+	if err != nil {
+		t.Fatalf("RuntimeValue.Clone failed: %v", err)
+	}
+
+	// Modify original
+	orig.M["x"] = 99
+
+	// cloned default should remain unchanged
+	clonedDefault := clonedRV.Default().Val()
+	if clonedDefault.M["x"] != 1 {
+		t.Fatalf("expected cloned default to keep value 1, got %d", clonedDefault.M["x"])
+	}
+}
+
+// Test that WithUserInput makes userInput the effective value and Clone deep-copies default and userInput.
+func TestRuntimeValue_UserInputBecomesEffectiveAndCloneDeepCopies(t *testing.T) {
+	type S struct {
+		M map[string]int
+	}
+
+	origDef := &S{M: map[string]int{"d": 1}}
+	origUser := &S{M: map[string]int{"u": 2}}
+
+	defVal, err := NewValue[*S](origDef)
+	if err != nil {
+		t.Fatalf("NewValue(def) failed: %v", err)
+	}
+
+	userVal, err := NewValue[*S](origUser)
+	if err != nil {
+		t.Fatalf("NewValue(user) failed: %v", err)
+	}
+
+	rv, err := NewRuntimeValue[*S](defVal, WithUserInput[*S](userVal))
+	require.NoError(t, err)
+	require.NotNil(t, rv)
+
+	// Effective should be userInput
+	eff, err := rv.Effective(context.Background())
+	if err != nil {
+		t.Fatalf("Effective returned error: %v", err)
+	}
+	if eff == nil {
+		t.Fatalf("Effective returned nil value")
+	}
+	if eff.Val().M["u"] != 2 {
+		t.Fatalf("expected effective user value 2, got %d", eff.Val().M["u"])
+	}
+
+	// Clone and then mutate originals; clone should remain unchanged
+	clone, err := rv.Clone()
+	if err != nil {
+		t.Fatalf("Clone failed: %v", err)
+	}
+	// mutate originals
+	origDef.M["d"] = 99
+	origUser.M["u"] = 99
+
+	// cloned default should keep original default value 1
+	clonedDef := clone.Default()
+	if clonedDef == nil {
+		t.Fatalf("cloned default is nil")
+	}
+	if clonedDef.Val().M["d"] != 1 {
+		t.Fatalf("expected cloned default d==1, got %d", clonedDef.Val().M["d"])
+	}
+
+	// cloned effective (userInput) should keep original user value 2
+	clonedEff, err := clone.Effective(context.Background())
+	if err != nil {
+		t.Fatalf("cloned Effective returned error: %v", err)
+	}
+	if clonedEff == nil {
+		t.Fatalf("cloned Effective is nil")
+	}
+	if clonedEff.Val().M["u"] != 2 {
+		t.Fatalf("expected cloned effective u==2, got %d", clonedEff.Val().M["u"])
+	}
+}
+
+// Test that effectiveFunc is invoked once for the original (cached) and preserved on Clone,
+// where the clone will not invoke it since the cached effective is copied into the clone.
+func TestRuntimeValue_EffectiveFuncInvokedAndPreservedOnClone(t *testing.T) {
+	type S struct {
+		M map[string]int
+	}
+
+	var counter int32
+	effFunc := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+		v := atomic.AddInt32(&counter, 1)
+		val, err := NewValue(&S{M: map[string]int{"ctr": int(v)}})
+		if err != nil {
+			return nil, false, err
+		}
+		// cache the computed result
+		return val, true, nil
+	}
+
+	// provide a non-nil defaultVal as required by NewRuntimeValue
+	defVal, err := NewValue(&S{M: map[string]int{}})
+	if err != nil {
+		t.Fatalf("NewValue(default) failed: %v", err)
+	}
+
+	// create a runtime value with an effectiveFunc
+	rv, err := NewRuntimeValue[*S](defVal, WithEffectiveFunc[*S](effFunc))
+	require.NoError(t, err)
+	require.NotNil(t, rv)
+
+	// first call computes and caches (counter -> 1)
+	v1, err := rv.Effective(context.Background())
+	if err != nil {
+		t.Fatalf("Effective call 1 failed: %v", err)
+	}
+	if v1.Val().M["ctr"] != 1 {
+		t.Fatalf("expected ctr==1 on first call, got %d", v1.Val().M["ctr"])
+	}
+
+	// second call should return cached value (counter still 1)
+	v2, err := rv.Effective(context.Background())
+	if err != nil {
+		t.Fatalf("Effective call 2 failed: %v", err)
+	}
+	if v2.Val().M["ctr"] != 1 {
+		t.Fatalf("expected ctr==1 on second call (cached), got %d", v2.Val().M["ctr"])
+	}
+
+	// Clone the runtime value; cloned effective is copied, so clone should not invoke effFunc
+	clone, err := rv.Clone()
+	if err != nil {
+		t.Fatalf("Clone failed: %v", err)
+	}
+
+	cv, err := clone.Effective(context.Background())
+	if err != nil {
+		t.Fatalf("clone Effective failed: %v", err)
+	}
+	// clone had cached effective, so counter remains 1
+	if cv.Val().M["ctr"] != 1 {
+		t.Fatalf("expected ctr==1 after clone Effective, got %d", cv.Val().M["ctr"])
+	}
+}
+
+// Test that NewRuntimeValue returns an error if defaultVal is nil.
+func TestNewRuntimeValue_NilDefaultReturnsError(t *testing.T) {
+	rv, err := NewRuntimeValue[*int](nil)
+	require.Error(t, err)
+	require.Nil(t, rv)
+	require.True(t, errorx.IsOfType(err, IllegalArgument))
+	require.Contains(t, err.Error(), "defaultVal must be provided")
+}
+
+// Test that concurrent Effective calls are deduplicated using singleflight.
+func TestRuntimeValue_SingleFlightDedupesConcurrentEvaluations(t *testing.T) {
+	type S struct {
+		M map[string]int
+	}
+
+	var counter int32
+	effFunc := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+		// simulate expensive work
+		time.Sleep(100 * time.Millisecond)
+		v := atomic.AddInt32(&counter, 1)
+		val, err := NewValue(&S{M: map[string]int{"ctr": int(v)}})
+		if err != nil {
+			return nil, false, err
+		}
+		// cache the result
+		return val, true, nil
+	}
+
+	defVal, err := NewValue(&S{M: map[string]int{}})
+	if err != nil {
+		t.Fatalf("NewValue(default) failed: %v", err)
+	}
+
+	rv, err := NewRuntimeValue[*S](defVal, WithEffectiveFunc[*S](effFunc))
+	require.NoError(t, err)
+	require.NotNil(t, rv)
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+	results := make([]Value[*S], goroutines)
+	errs := make([]error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			v, e := rv.Effective(context.Background())
+			results[idx] = v
+			errs[idx] = e
+		}(i)
+	}
+	wg.Wait()
+
+	// ensure effectiveFunc ran exactly once
+	if atomic.LoadInt32(&counter) != 1 {
+		t.Fatalf("expected effectiveFunc to be invoked once, got %d", atomic.LoadInt32(&counter))
+	}
+
+	for i := 0; i < goroutines; i++ {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: Effective returned error: %v", i, errs[i])
+		}
+		if results[i] == nil {
+			t.Fatalf("goroutine %d: Effective returned nil", i)
+		}
+		if results[i].Val().M["ctr"] != 1 {
+			t.Fatalf("goroutine %d: expected ctr==1, got %d", i, results[i].Val().M["ctr"])
+		}
+	}
+}
+
+// Test default effective when no effectiveFunc configured.
+func TestRuntimeValue_DefaultWhenNoEffectiveFunc(t *testing.T) {
+	type S struct{ V int }
+	orig := &S{V: 7}
+	defVal, err := NewValue[*S](orig)
+	require.NoError(t, err)
+
+	rv, err := NewRuntimeValue[*S](defVal)
+	require.NoError(t, err)
+
+	eff, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, eff)
+	require.Equal(t, 7, eff.Val().V)
+}
+
+// Test SetUserInput updates effective when no effectiveFunc and clears cache when effectiveFunc present.
+func TestRuntimeValue_SetUserInputUpdatesEffective(t *testing.T) {
+	type S struct{ V int }
+
+	origDef := &S{V: 1}
+	origUser := &S{V: 42}
+
+	defVal, err := NewValue[*S](origDef)
+	require.NoError(t, err)
+	userVal, err := NewValue[*S](origUser)
+	require.NoError(t, err)
+
+	rv, err := NewRuntimeValue[*S](defVal)
+	require.NoError(t, err)
+
+	// initially effective is default
+	eff, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, eff.Val().V)
+
+	// set user input, effective should switch
+	rv.SetUserInput(userVal)
+	eff2, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 42, eff2.Val().V)
+
+	// now configure an effectiveFunc that caches a computed value
+	var counter int32
+	effFunc := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+		v := atomic.AddInt32(&counter, 1)
+		val, err := NewValue(&S{V: int(v)})
+		return val, true, err
+	}
+
+	rv.SetEffectiveFunc(effFunc)
+	// first Effective will compute & cache
+	v1, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, v1.Val().V)
+
+	// set user input while effectiveFunc configured -> cache cleared
+	rv.SetUserInput(userVal)
+	// since effectiveFunc present, Effective will recompute using effFunc
+	v2, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 2, v2.Val().V)
+}
+
+// Test SetEffectiveFunc clears previous cache and new function is used.
+func TestRuntimeValue_SetEffectiveFuncClearsCache(t *testing.T) {
+	type S struct{ V int }
+
+	defVal, err := NewValue(&S{V: 0})
+	require.NoError(t, err)
+
+	var c1 int32
+	f1 := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+		v := atomic.AddInt32(&c1, 1)
+		val, err := NewValue(&S{V: int(v)})
+		return val, true, err
+	}
+
+	rv, err := NewRuntimeValue[*S](defVal, WithEffectiveFunc[*S](f1))
+	require.NoError(t, err)
+
+	v1, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, v1.Val().V)
+
+	// replace effective func
+	var c2 int32
+	f2 := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+		v := atomic.AddInt32(&c2, 1)
+		val, err := NewValue(&S{V: int(v * 10)})
+		return val, true, err
+	}
+
+	rv.SetEffectiveFunc(f2)
+	v2, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 10, v2.Val().V)
+}
+
+// Test that effectiveFunc returning shouldCache==false is re-evaluated on each call.
+func TestRuntimeValue_Effective_ReevaluatesWhenNotCaching(t *testing.T) {
+	type S struct{ V int }
+
+	defVal, err := NewValue(&S{V: 0})
+	require.NoError(t, err)
+
+	var counter int32
+	f := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+		v := atomic.AddInt32(&counter, 1)
+		val, err := NewValue(&S{V: int(v)})
+		return val, false, err
+	}
+
+	rv, err := NewRuntimeValue[*S](defVal, WithEffectiveFunc[*S](f))
+	require.NoError(t, err)
+
+	a, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, a.Val().V)
+
+	b, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 2, b.Val().V)
+}
+
+// Test cloning a nil *defaultValue returns an error.
+func TestDefaultValue_CloneNilReceiver(t *testing.T) {
+	var dv *defaultValue[int] = nil
+	_, err := dv.Clone()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot clone nil Value")
+}
+
+func TestValue_Val(t *testing.T) {
+	v, err := NewValue[int](5)
+	require.NoError(t, err)
+	require.Equal(t, 5, v.Val())
+}
+
+func TestRuntimeValue_UserInput(t *testing.T) {
+	v, err := NewValue[int](10)
+	require.NoError(t, err)
+
+	rv, err := NewRuntimeValue[int](v)
+	require.NoError(t, err)
+
+	ui := rv.UserInput()
+	require.Nil(t, ui)
+
+	uv, err := NewValue[int](20)
+	require.NoError(t, err)
+
+	rv.SetUserInput(uv)
+
+	ui2 := rv.UserInput()
+	require.NotNil(t, ui2)
+	require.Equal(t, 20, ui2.Val())
+
+	// nil-receiver: calling UserInput on a nil *RuntimeValue should return nil
+	var nilRV *RuntimeValue[int] = nil
+	nilUI := nilRV.UserInput()
+	require.Nil(t, nilUI)
+}
+
+func TestRuntimeValue_ClearCache(t *testing.T) {
+	type S struct{ V int }
+
+	defVal, err := NewValue(&S{V: 0})
+	require.NoError(t, err)
+
+	var counter int32
+	f := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+		v := atomic.AddInt32(&counter, 1)
+		val, err := NewValue(&S{V: int(v)})
+		return val, true, err
+	}
+
+	rv, err := NewRuntimeValue[*S](defVal, WithEffectiveFunc[*S](f))
+	require.NoError(t, err)
+
+	// First call should compute & cache (counter == 1)
+	v1, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, v1.Val().V)
+
+	// Clear cache and ensure next call recomputes (counter == 2)
+	rv.ClearCache()
+	v2, err := rv.Effective(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 2, v2.Val().V)
+
+	// nil-receiver: calling ClearCache on a nil *RuntimeValue should be safe (no panic)
+	var nilRV *RuntimeValue[*S] = nil
+	nilRV.ClearCache()
+}

--- a/state.go
+++ b/state.go
@@ -2,6 +2,7 @@ package automa
 
 import (
 	"context"
+	"reflect"
 	"sync"
 
 	"github.com/joomcode/errorx"
@@ -26,25 +27,49 @@ type SyncStateBag struct {
 	m sync.Map
 }
 
-// Clone creates a deep copy of the SyncStateBag if all items implements Cloner and returns deep copy when invoked.
-// If any item does not implement Cloner, it performs a shallow copy for that item.
+// Clone creates a deep copy of the SyncStateBag if all items implements Clone method and returns deep copy when invoked.
+// If any item does not implement Cloner or Clone method, it performs a shallow copy for that item.
 func (s *SyncStateBag) Clone() (StateBag, error) {
 	if s == nil {
 		return nil, IllegalArgument.New("cannot clone a nil SyncStateBag")
 	}
 
 	clone := &SyncStateBag{}
+	errInterface := reflect.TypeOf((*error)(nil)).Elem()
+
 	for k, v := range s.Items() {
-		// if the value implements Cloner, use it to clone the value
-		if c, ok := v.(Cloner[any]); ok {
-			cp, err := c.Clone()
-			if err != nil {
-				return nil, errorx.IllegalState.Wrap(err, "failed to clone value for key %v", k)
-			}
-			clone.m.Store(k, cp)
-		} else {
-			clone.m.Store(k, v) // store the value as is (shallow copy)
+		if v == nil {
+			clone.m.Store(k, nil)
+			continue
 		}
+
+		rv := reflect.ValueOf(v)
+		m := rv.MethodByName("Clone")
+		if m.IsValid() && m.Type().NumIn() == 0 {
+			outCount := m.Type().NumOut()
+
+			// support Clone() (value, error): Cloner interface
+			if outCount == 2 && m.Type().Out(1).Implements(errInterface) {
+				results := m.Call([]reflect.Value{})
+				// check error
+				if !results[1].IsNil() {
+					errVal := results[1].Interface().(error)
+					return nil, errorx.IllegalState.Wrap(errVal, "failed to clone value for key %v", k)
+				}
+				clone.m.Store(k, results[0].Interface())
+				continue
+			}
+
+			// support Clone() value: if any other clone signature without error
+			if outCount == 1 {
+				results := m.Call([]reflect.Value{})
+				clone.m.Store(k, results[0].Interface())
+				continue
+			}
+		}
+
+		// fallback: shallow copy
+		clone.m.Store(k, v)
 	}
 
 	return clone, nil

--- a/state.go
+++ b/state.go
@@ -27,7 +27,7 @@ type SyncStateBag struct {
 	m sync.Map
 }
 
-// Clone creates a deep copy of the SyncStateBag if all items implements Clone method and returns deep copy when invoked.
+// Clone creates a deep copy of the SyncStateBag if all items implement Clone method and returns deep copy when invoked.
 // If any item does not implement Cloner or Clone method, it performs a shallow copy for that item.
 func (s *SyncStateBag) Clone() (StateBag, error) {
 	if s == nil {

--- a/state_test.go
+++ b/state_test.go
@@ -229,7 +229,7 @@ func TestSyncStateBag_HelperMethods_TypeSafety(t *testing.T) {
 	assert.Equal(t, 0.0, bag.Float("notAFloat"))
 }
 
-// testCloner implements the repository's expected Cloner\[any\] shape used in tests.
+// testCloner implements the repository's expected Cloner[any] shape used in tests.
 type testCloner struct {
 	Data []int
 }

--- a/state_test.go
+++ b/state_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/joomcode/errorx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSyncStateBag_SetAndGet(t *testing.T) {
@@ -156,22 +158,6 @@ func TestSyncStateBag_Items(t *testing.T) {
 	assert.Equal(t, "baz", items["bar"])
 }
 
-func TestSyncStateBag_Clone(t *testing.T) {
-	orig := &SyncStateBag{}
-	orig.Set("foo", 42)
-	orig.Set("bar", "baz")
-
-	clone := orig.Clone()
-	assert.Equal(t, 2, clone.Size())
-	assert.Equal(t, 42, IntFromState(clone, "foo"))
-	assert.Equal(t, "baz", StringFromState(clone, "bar"))
-
-	// Mutate clone and check original is unchanged
-	clone.Set("foo", 100)
-	assert.Equal(t, 42, IntFromState(orig, "foo"))
-	assert.Equal(t, 100, IntFromState(clone, "foo"))
-}
-
 func TestSyncStateBag_HelperMethods(t *testing.T) {
 	bag := &SyncStateBag{}
 
@@ -241,4 +227,117 @@ func TestSyncStateBag_HelperMethods_TypeSafety(t *testing.T) {
 
 	bag.Set("notAFloat", "3.14")
 	assert.Equal(t, 0.0, bag.Float("notAFloat"))
+}
+
+// testCloner implements the repository's expected Cloner\[any\] shape used in tests.
+type testCloner struct {
+	Data []int
+}
+
+func (t *testCloner) Clone() interface{} {
+	cp := make([]int, len(t.Data))
+	copy(cp, t.Data)
+	return &testCloner{Data: cp}
+}
+
+type errCloner struct{}
+
+func (e *errCloner) Clone() (interface{}, error) {
+	return nil, errorx.IllegalState.New("clone error")
+}
+
+type simplePtr struct {
+	X int
+}
+
+func TestSyncStateBag_Clone_DeepCloneForCloner(t *testing.T) {
+	type S struct {
+		M map[string]int
+	}
+
+	defVal, err := NewValue[*S](&S{M: map[string]int{"x": 1}})
+	if err != nil {
+		t.Fatalf("NewValue failed: %v", err)
+	}
+
+	rv, err := NewRuntimeValue[*S](defVal)
+	require.NoError(t, err)
+	require.NotNil(t, rv)
+
+	orig := &SyncStateBag{}
+	orig.Set("NIL", nil)
+	orig.Set("clonable", &testCloner{Data: []int{1, 2, 3}})
+	orig.Set("ptr", &simplePtr{X: 1}) // non-clonable: should be shallow-copied
+	orig.Set("runtimeVal", rv)
+
+	cloned, err := orig.Clone()
+	require.NoError(t, err)
+	require.NotNil(t, cloned)
+
+	// verify clonable deep-copy
+	clonedVal, ok := cloned.Get("clonable")
+	require.True(t, ok)
+	clonedTC, ok := clonedVal.(*testCloner)
+	require.True(t, ok)
+
+	_, ok = orig.Get("NIL")
+	require.True(t, ok)
+
+	origVal, ok := orig.Get("clonable")
+	require.True(t, ok)
+
+	_, ok = cloned.Get("NIL")
+	require.True(t, ok)
+
+	clonedVal, ok = cloned.Get("runtimeVal")
+	require.True(t, ok)
+
+	clonedRV, ok := clonedVal.(*RuntimeValue[*S])
+	require.True(t, ok)
+
+	require.True(t, ok)
+	origTC, ok := origVal.(*testCloner)
+	require.True(t, ok)
+
+	// modify clone's data; original should remain unchanged
+	clonedTC.Data[0] = 999
+	clonedRV.Default().Val().M["x"] = 999
+	rv.Default().Val().M["d"] = 2
+	assert.Equal(t, 1, origTC.Data[0], "original should not be affected by clone modification")
+	assert.Equal(t, 999, clonedTC.Data[0], "clone should reflect modification")
+	assert.Equal(t, 1, rv.Default().Val().M["x"], "Runtime value should not reflect modification")
+	assert.Equal(t, 0, clonedRV.Default().Val().M["d"], "Cloned runtime value should not reflect modification in the original")
+
+	// verify non-clonable is shallow-copied (same pointer)
+	clonedPtrVal, ok := cloned.Get("ptr")
+	require.True(t, ok)
+	clonedPtr, ok := clonedPtrVal.(*simplePtr)
+	require.True(t, ok)
+
+	origPtrVal, ok := orig.Get("ptr")
+	require.True(t, ok)
+	origPtr, ok := origPtrVal.(*simplePtr)
+	require.True(t, ok)
+
+	// pointers should be identical (shallow copy)
+	assert.Equal(t, origPtr, clonedPtr)
+	clonedPtr.X = 42
+	assert.Equal(t, 42, origPtr.X, "modifying shallow-copied value should reflect in original")
+}
+
+func TestSyncStateBag_Clone_FailsWhenClonerReturnsError(t *testing.T) {
+	orig := &SyncStateBag{}
+	orig.Set("bad", &errCloner{})
+
+	clone, err := orig.Clone()
+	assert.Nil(t, clone)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to clone", "error should indicate failure to clone value")
+}
+
+func TestSyncStateBag_Clone_NilReceiver(t *testing.T) {
+	var nilBag *SyncStateBag
+	clone, err := nilBag.Clone()
+	assert.Nil(t, clone)
+	require.Error(t, err)
 }

--- a/step_builder.go
+++ b/step_builder.go
@@ -3,6 +3,7 @@ package automa
 import (
 	"context"
 
+	"github.com/joomcode/errorx"
 	"github.com/rs/zerolog"
 )
 
@@ -108,8 +109,12 @@ func (s *StepBuilder) BuildAndCopy() (Step, error) {
 	s.Step.onFailure = finishedStep.onFailure
 	s.Step.enableAsyncCallbacks = finishedStep.enableAsyncCallbacks
 
+	var err error
 	if finishedStep.state != nil {
-		s.Step.state = finishedStep.state.Clone()
+		s.Step.state, err = finishedStep.state.Clone()
+		if err != nil {
+			return nil, errorx.IllegalState.Wrap(err, "failed to clone state bag for step %q", finishedStep.id)
+		}
 	} else {
 		s.Step.state = nil
 	}

--- a/step_default.go
+++ b/step_default.go
@@ -27,6 +27,16 @@ func (s *defaultStep) State() StateBag {
 	return s.state
 }
 
+func (s *defaultStep) WithState(st StateBag) Step {
+	// avoid redundant assignment when same state is provided
+	if s.state == st {
+		return s
+	}
+
+	s.state = st
+	return s
+}
+
 func (s *defaultStep) Id() string {
 	return s.id
 }

--- a/workflow.go
+++ b/workflow.go
@@ -7,6 +7,34 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// workflow provides orchestration primitives for composing and executing
+// Steps with structured reporting, error handling and rollback support.
+//
+// Overview:
+//   - A workflow exposes a workflow-level StateBag via Workflow.State() that represents
+//     workflow-wide state.
+//   - Ordinary Steps receive the shared workflow StateBag (mutations are visible to later
+//     steps and to the workflow).
+//   - Steps that are themselves Workflows receive a cloned StateBag so sub-workflows cannot
+//     unintentionally mutate parent workflow state. The parent workflow may still mutate its
+//     own state between steps and thus pass different versions to subsequent steps/sub-workflows.
+//   - Execute records per-step state snapshots to enable deterministic rollback. When a
+//     rollback is triggered by execution failure, rollback routines operate against the state
+//     snapshot that existed when each step executed. Direct calls to Rollback fall back to the
+//     current workflow state (preserving prior behavior).
+//
+// Hooks and callbacks:
+//   - A workflow-level prepare hook (w.prepare) can return a context used for subsequent
+//     step Prepare/Execute calls. Each Step's Prepare is invoked after the step's StateBag
+//     has been attached so Prepare can access state.
+//   - onCompletion and onFailure callbacks are supported; when enableAsyncCallbacks is true,
+//     reports are cloned and callbacks are invoked asynchronously.
+//
+// Execution/rollback modes:
+//   - Execution and rollback semantics respect w.executionMode and w.rollbackMode (StopOnError,
+//     ContinueOnError, RollbackOnError).
+//   - Execute and Rollback produce aggregated Reports containing per-step reports and, when
+//     applicable, per-step rollback reports.
 type workflow struct {
 	id                   string
 	state                StateBag
@@ -21,6 +49,16 @@ type workflow struct {
 	rollback     RollbackFunc // optional user-defined rollback function for the entire workflow
 	onCompletion OnCompletionFunc
 	onFailure    OnFailureFunc
+}
+
+func (w *workflow) WithState(s StateBag) Step {
+	if w.state == s {
+		// avoid redundant assignment when same state is provided
+		return w
+	}
+
+	w.state = s
+	return w
 }
 
 func IsWorkflow(stp Step) bool {
@@ -64,12 +102,40 @@ func RunWorkflow(ctx context.Context, wb *WorkflowBuilder) *Report {
 }
 
 // rollbackFrom rollbacks the workflow backward from the given index to the start.
-func (w *workflow) rollbackFrom(ctx context.Context, index int) map[string]*Report {
+func (w *workflow) rollbackFrom(ctx context.Context, index int, states []StateBag) map[string]*Report {
 	stepReports := map[string]*Report{}
+	startTime := time.Now()
+
 	for i := index; i >= 0; i-- {
 		step := w.steps[i]
 
-		rollbackReport := step.Rollback(ctx)
+		// choose snapshot if provided, otherwise use workflow state
+		var state StateBag
+		if states != nil && i < len(states) && states[i] != nil {
+			state = states[i]
+		} else {
+			state = w.State()
+		}
+
+		// pass the chosen state in context for the rollback
+		stepCtx := context.WithValue(ctx, KeyState, state.
+			Set(KeyId, w.Id()).
+			Set(KeyIsWorkflow, true).
+			Set(KeyStartTime, startTime),
+		)
+
+		rollbackReport := step.Rollback(stepCtx)
+
+		if rollbackReport == nil {
+			rollbackReport = FailureReport(step,
+				WithWorkflow(w),
+				WithActionType(ActionRollback),
+				WithStartTime(startTime),
+				WithError(StepExecutionError.New("workflow %q step %q returned nil report from Rollback", w.id, step.Id()).
+					WithProperty(StepIdProperty, step.Id()),
+				),
+			)
+		}
 
 		// Ensure rollback report has ActionRollback set for consistency
 		if rollbackReport.Action != ActionRollback {
@@ -121,9 +187,25 @@ func (w *workflow) State() StateBag {
 }
 
 // Execute runs the workflow by executing each step in sequence.
-// It returns a Report summarizing the execution result.
-// When execution mode is StopOnError, a step failure triggers rollback all previously executed steps
-// When execution mode is ContinueOnError, step failures don't need to be rolled back.
+//
+// Preparation and state handling:
+//   - If a workflow-level `prepare` hook is configured it is invoked first with the incoming `ctx` and the
+//     workflow instance. The returned context (if non-nil) is used for step preparation and execution.
+//   - The workflow exposes a shared `StateBag` via `w.State()` that represents workflow-wide state.
+//   - For ordinary steps the shared `StateBag` is used as-is (state is shared between workflow and step).
+//   - For steps that are themselves workflows (detected with `IsWorkflow(step)`), `Execute` clones the
+//     workflow state by calling `StateBag.Clone()` and provides the cloned `StateBag` to the sub-workflow.
+//     This prevents unintended state sharing and isolates sub-workflow mutations from the parent workflow.
+//   - If cloning the state fails or context preparation fails, the step is treated as failed and a failure `Report`
+//     is produced; the step is not executed.
+//   - After state preparation each step's `Prepare` hook is invoked; the context returned by the step's
+//     `Prepare` (if any) is used for the step's execution.
+//     A nil `Report` from a step is treated as a failure.
+//
+// Execution semantics:
+//   - Execution behavior respects `w.executionMode` (StopOnError, ContinueOnError, RollbackOnError).
+//   - When rollback is required, rollback reports from executed steps are attached to the corresponding
+//     step reports and returned as part of the workflow `Report`.
 func (w *workflow) Execute(ctx context.Context) *Report {
 	startTime := time.Now()
 
@@ -137,24 +219,58 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 
 	var stepReports []*Report
 	var hasFailed bool
+
+	// capture per-step state snapshots for rollback
+	stepStates := make([]StateBag, 0, len(w.steps))
+
 	for index, step := range w.steps {
 		var report *Report
 		stepStart := time.Now()
-		stepCtx, err := step.Prepare(ctx)
-		if err != nil {
-			report = FailureReport(step,
-				WithWorkflow(w),
-				WithStartTime(stepStart),
-				WithActionType(ActionExecute),
-				WithError(StepExecutionError.
-					Wrap(err, "workflow %q step %q preparation failed", w.id, step.Id()).
-					WithProperty(StepIdProperty, step.Id()),
-				))
 
-			if stepCtx == nil {
-				stepCtx = ctx
+		var stepCtx context.Context
+		var stepState StateBag
+		var statePrepError error
+		var ctxPrepError error
+
+		// prepare step state (start from current workflow state)
+		stepState = w.State()
+		if IsWorkflow(step) { // clone state for sub-workflows
+			stepState, statePrepError = stepState.Clone()
+			if statePrepError != nil {
+				report = FailureReport(step,
+					WithWorkflow(w),
+					WithStartTime(stepStart),
+					WithActionType(ActionExecute),
+					WithError(StepExecutionError.
+						Wrap(statePrepError, "workflow %q step %q failed to clone state for sub-workflow execution", w.id, step.Id()).
+						WithProperty(StepIdProperty, step.Id()),
+					))
 			}
-		} else {
+		}
+
+		// attach snapshot for possible rollback (keeps alignment even if nil)
+		stepStates = append(stepStates, stepState)
+
+		// make sure step has its state before calling Prepare so Prepare can access it
+		step = step.WithState(stepState)
+
+		// prepare step context
+		if statePrepError == nil {
+			stepCtx, ctxPrepError = step.Prepare(ctx)
+			if ctxPrepError != nil {
+				report = FailureReport(step,
+					WithWorkflow(w),
+					WithStartTime(stepStart),
+					WithActionType(ActionExecute),
+					WithError(StepExecutionError.
+						Wrap(ctxPrepError, "workflow %q step %q preparation failed", w.id, step.Id()).
+						WithProperty(StepIdProperty, step.Id()),
+					))
+			}
+		}
+
+		// execute step if preparation succeeded
+		if statePrepError == nil && ctxPrepError == nil {
 			report = step.Execute(stepCtx)
 			if report == nil {
 				report = FailureReport(step,
@@ -168,19 +284,18 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 			}
 		}
 
+		// collect step report
 		stepReports = append(stepReports, report)
 
+		// check for step failure
 		if report.IsFailed() {
 			hasFailed = true
 
-			// if execution mode is StopOnError, we stop execution
-			// if execution mode is RollbackOnError, we perform rollback from this step to the start and break
-			// if it's ContinueOnError, we continue to next step without rolling back
 			if w.executionMode == StopOnError {
-				break // stop execution on first failure
+				break
 			} else if w.executionMode == RollbackOnError {
-				// Perform rollback for all executed steps from the current one to the start
-				rollbackReports := w.rollbackFrom(stepCtx, index)
+				// perform rollback using recorded per-step states
+				rollbackReports := w.rollbackFrom(stepCtx, index, stepStates)
 
 				// Attach rollback reports to corresponding step reports
 				for _, stepReport := range stepReports {
@@ -194,8 +309,7 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		}
 	}
 
-	if hasFailed { // workflow failed, but we don't need to rollback here as it's already done above if needed
-		// collect failed step IDs for reporting
+	if hasFailed {
 		var failedStepIDs []string
 		for _, sr := range stepReports {
 			if sr.IsFailed() {
@@ -215,10 +329,9 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 
 		w.handleFailure(ctx, workflowReport)
 
-		return workflowReport // return failure report
+		return workflowReport
 	}
 
-	// all steps succeeded, return success report
 	workflowReport := SuccessReport(w,
 		WithWorkflow(w),
 		WithStartTime(startTime),
@@ -268,7 +381,7 @@ func (w *workflow) invokeRollbackFunc(ctx context.Context) *Report {
 
 func (w *workflow) Rollback(ctx context.Context) *Report {
 	if w.rollback != nil {
-		return w.invokeRollbackFunc(ctx) // use user-defined rollback function if provided
+		return w.invokeRollbackFunc(ctx)
 	}
 
 	startTime := time.Now()
@@ -277,7 +390,8 @@ func (w *workflow) Rollback(ctx context.Context) *Report {
 		Set(KeyIsWorkflow, true).
 		Set(KeyStartTime, startTime),
 	)
-	rollbackReports := w.rollbackFrom(stepCtx, len(w.steps)-1)
+	// call with nil states so rollbackFrom falls back to current workflow state
+	rollbackReports := w.rollbackFrom(stepCtx, len(w.steps)-1, nil)
 
 	var stepReports []*Report
 	for _, step := range w.steps {

--- a/workflow.go
+++ b/workflow.go
@@ -227,7 +227,7 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		var report *Report
 		stepStart := time.Now()
 
-		var stepCtx context.Context
+		stepCtx := ctx
 		var stepState StateBag
 		var statePrepError error
 		var ctxPrepError error
@@ -251,7 +251,8 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		// attach snapshot for possible rollback (keeps alignment even if nil)
 		stepStates = append(stepStates, stepState)
 
-		// make sure step has its state before calling Prepare so Prepare can access it
+		// make sure step has its state before calling Prepare so Prepare can access it.
+		// It also ensures during Execute the step has the correct state
 		step = step.WithState(stepState)
 
 		// prepare step context

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -402,9 +402,9 @@ func TestWorkflow_StepStatePropagation(t *testing.T) {
 			assert.True(t, ok, "step state should contain the key set in prepare")
 			assert.Equal(t, stepStateValue, StringFromState(state, stepStateKey))
 
-			// also verify workflow state item is not accessible
+			// also verify workflow state item is accessible
 			_, ok = state.Get(workflowStateKey)
-			assert.False(t, ok, "workflow state should not be accessible from step")
+			assert.True(t, ok, "workflow state should not be accessible from step")
 
 			return StepSuccessReport("step")
 		},


### PR DESCRIPTION
## Description
This pull request introduces significant improvements to workflow state management, particularly around deep cloning of state for sub-workflows and robust error handling during cloning. It also adds a `.testcoverage.yml` configuration for coverage enforcement, and updates interfaces and tests to support the new cloning semantics. The most important changes are grouped below:

**Workflow State Management and Cloning Improvements:**

* The `StateBag` interface's `Clone()` method now returns `(StateBag, error)` to support error reporting during deep cloning. The `SyncStateBag` implementation attempts a deep clone for items that implement a `Clone` method (with or without error), falling back to a shallow copy otherwise. Errors during cloning are correctly propagated. (`automa.go`, `state.go`, [[1]](diffhunk://#diff-2f78a604a2a388d0cd14602cb33e14d37d22b5a98b276f6774a39cbcd2c49d83L25-R26) [[2]](diffhunk://#diff-320959764bfa2277e0bdd4eaa741f02891d123c42150d4ccb76de0bdbf6e591aL27-R75)
* Workflow execution now clones the workflow state for sub-workflows, ensuring that sub-workflows cannot mutate the parent workflow's state unintentionally. If state cloning fails, the step is marked as failed and not executed. Rollbacks use per-step state snapshots to ensure deterministic behavior. (`workflow.go`, [[1]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR10-R37) [[2]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR54-R63) [[3]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL67-R138) [[4]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL124-R208) [[5]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR222-R273) [[6]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR287-R298)

**Interface and API Enhancements:**

* The `Step` interface gains a `WithState(StateBag) Step` method, and both `defaultStep` and `workflow` implement this to support explicit state assignment. (`automa.go`, `step_default.go`, `workflow.go`, [[1]](diffhunk://#diff-2f78a604a2a388d0cd14602cb33e14d37d22b5a98b276f6774a39cbcd2c49d83R14) [[2]](diffhunk://#diff-51ba6897a18f3ca97dd7dc56fcc91ddc51081ad6aff5e62e43060edb49542eb2R30-R39) [[3]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR54-R63)
* The `StepBuilder.BuildAndCopy()` method now handles errors from state cloning and returns an error if cloning fails. (`step_builder.go`, [step_builder.goR112-R117](diffhunk://#diff-de7fbc5fe7dcf3fe1020642b6d29bc5047a74e96a7db21e1157221bc840cc214R112-R117))

**Testing and Coverage:**

* Extensive new tests verify deep and shallow cloning behavior, error propagation from failed clones, and handling of nil receivers. (`state_test.go`, [[1]](diffhunk://#diff-864944c880a2e4db1b8f93f33a58303d840fb4b6c50147cc2f915c6d48f7bf2cL159-L174) [[2]](diffhunk://#diff-864944c880a2e4db1b8f93f33a58303d840fb4b6c50147cc2f915c6d48f7bf2cR231-R343)
* Added `.testcoverage.yml` for Go test coverage configuration, with thresholds and exclusion rules. (`.testcoverage.yml`, [.testcoverage.ymlR1-R53](diffhunk://#diff-6d09ae139b77769862a6695df9e82e6f27d74fa6ace5b4ee56bfc51272458b7aR1-R53))

**Dependency and Import Updates:**

* Added `golang.org/x/sync` dependency and improved import organization. (`go.mod`, [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R9) [[2]](diffhunk://#diff-320959764bfa2277e0bdd4eaa741f02891d123c42150d4ccb76de0bdbf6e591aR5-R8) [[3]](diffhunk://#diff-de7fbc5fe7dcf3fe1020642b6d29bc5047a74e96a7db21e1157221bc840cc214R6) [[4]](diffhunk://#diff-864944c880a2e4db1b8f93f33a58303d840fb4b6c50147cc2f915c6d48f7bf2cR7-R9)

(References: [[1]](diffhunk://#diff-2f78a604a2a388d0cd14602cb33e14d37d22b5a98b276f6774a39cbcd2c49d83R14) [[2]](diffhunk://#diff-2f78a604a2a388d0cd14602cb33e14d37d22b5a98b276f6774a39cbcd2c49d83L25-R26) [[3]](diffhunk://#diff-320959764bfa2277e0bdd4eaa741f02891d123c42150d4ccb76de0bdbf6e591aL27-R75) [[4]](diffhunk://#diff-51ba6897a18f3ca97dd7dc56fcc91ddc51081ad6aff5e62e43060edb49542eb2R30-R39) [[5]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR10-R37) [[6]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR54-R63) [[7]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL67-R138) [[8]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL124-R208) [[9]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR222-R273) [[10]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR287-R298) [[11]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL197-R312) [[12]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL218-L221) [[13]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL271-R384) [[14]](diffhunk://#diff-de7fbc5fe7dcf3fe1020642b6d29bc5047a74e96a7db21e1157221bc840cc214R112-R117) [[15]](diffhunk://#diff-864944c880a2e4db1b8f93f33a58303d840fb4b6c50147cc2f915c6d48f7bf2cL159-L174) [[16]](diffhunk://#diff-864944c880a2e4db1b8f93f33a58303d840fb4b6c50147cc2f915c6d48f7bf2cR231-R343) [[17]](diffhunk://#diff-6d09ae139b77769862a6695df9e82e6f27d74fa6ace5b4ee56bfc51272458b7aR1-R53) [[18]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R9) [[19]](diffhunk://#diff-320959764bfa2277e0bdd4eaa741f02891d123c42150d4ccb76de0bdbf6e591aR5-R8) [[20]](diffhunk://#diff-de7fbc5fe7dcf3fe1020642b6d29bc5047a74e96a7db21e1157221bc840cc214R6) [[21]](diffhunk://#diff-864944c880a2e4db1b8f93f33a58303d840fb4b6c50147cc2f915c6d48f7bf2cR7-R9)

### Related Issues

* Closes #51
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
