### PR TITLE
fix: use a default effective function if not passed

### DIFF
--- a/runtime_value_test.go
+++ b/runtime_value_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -396,6 +397,11 @@ func TestRuntimeValue_SetEffectiveFuncClearsCache(t *testing.T) {
 	v1, err := rv.Effective()
 	require.NoError(t, err)
 	require.Equal(t, 1, v1.Val().V)
+
+	// setting nil effectiveFunc won't set it
+	assert.NotNil(t, rv.effectiveFunc)
+	rv.SetEffectiveFunc(nil)
+	assert.NotNil(t, rv.effectiveFunc)
 
 	// replace effective func
 	var c2 int32


### PR DESCRIPTION
## Description

This pull request refactors the logic around setting and handling the `effectiveFunc` and user input in the `RuntimeValue` type to ensure more consistent and predictable behavior. The main improvements include always setting a default `effectiveFunc`, preventing nil assignments, and simplifying the logic for determining the effective value.

**RuntimeValue effective value handling:**

* The constructor `NewRuntimeValue` now always sets an `effectiveFunc` (if none is provided, a default is used that prefers `userInput` over `defaultVal`), which simplifies the logic for determining the effective value.
* The `SetEffectiveFunc` method now prevents setting a nil `effectiveFunc`, ensuring that the effective value logic remains valid.

**User input and effective value logic:**

* The `SetUserInput` method is simplified: it now always clears the cached effective value, regardless of whether an `effectiveFunc` is present, relying on the always-present `effectiveFunc` to determine the new effective value.
* The comment for `UserInput` clarifies that user input may be nil if not set, and callers should check for nil.
### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
