### PR TITLE
fix: add support for strategy field to indicate how effective value was determined

### DIFF
--- a/runtime_value_test.go
+++ b/runtime_value_test.go
@@ -222,6 +222,7 @@ func TestRuntimeValue_EffectiveFuncInvokedAndPreservedOnClone(t *testing.T) {
 	if v1.Get().Val().M["ctr"] != 1 {
 		t.Fatalf("expected ctr==1 on first call, got %d", v1.Get().Val().M["ctr"])
 	}
+	assert.Equal(t, StrategyCustom, v1.Strategy())
 
 	// second call should return cached value (counter still 1)
 	v2, err := rv.Effective()
@@ -231,6 +232,7 @@ func TestRuntimeValue_EffectiveFuncInvokedAndPreservedOnClone(t *testing.T) {
 	if v2.Get().Val().M["ctr"] != 1 {
 		t.Fatalf("expected ctr==1 on second call (cached), got %d", v2.Get().Val().M["ctr"])
 	}
+	assert.Equal(t, StrategyCustom, v2.Strategy())
 
 	// Clone the runtime value; cloned effective is copied, so clone should not invoke effFunc
 	clone, err := rv.Clone()
@@ -339,6 +341,7 @@ func TestRuntimeValue_DefaultWhenNoEffectiveFunc(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, eff)
 	require.Equal(t, 7, eff.Get().Val().V)
+	assert.Equal(t, StrategyDefault, eff.Strategy())
 }
 
 // Test SetUserInput updates effective when no effectiveFunc and clears cache when effectiveFunc present.
@@ -366,6 +369,7 @@ func TestRuntimeValue_SetUserInputUpdatesEffective(t *testing.T) {
 	eff2, err := rv.Effective()
 	require.NoError(t, err)
 	require.Equal(t, 42, eff2.Get().Val().V)
+	assert.Equal(t, StrategyDefault, eff.Strategy())
 
 	// now configure an effectiveFunc that caches a computed value
 	var counter int32
@@ -390,6 +394,7 @@ func TestRuntimeValue_SetUserInputUpdatesEffective(t *testing.T) {
 	v1, err := rv.Effective()
 	require.NoError(t, err)
 	require.Equal(t, 1, v1.Get().Val().V)
+	assert.Equal(t, StrategyCustom, v1.Strategy())
 
 	// set user input while effectiveFunc configured -> cache cleared
 	rv.SetUserInput(userVal)
@@ -397,6 +402,8 @@ func TestRuntimeValue_SetUserInputUpdatesEffective(t *testing.T) {
 	v2, err := rv.Effective()
 	require.NoError(t, err)
 	require.Equal(t, 2, v2.Get().Val().V)
+	assert.Equal(t, StrategyCustom, v2.Strategy())
+
 }
 
 // Test SetEffectiveFunc clears previous cache and new function is used.

--- a/runtime_value_test.go
+++ b/runtime_value_test.go
@@ -144,8 +144,8 @@ func TestRuntimeValue_UserInputBecomesEffectiveAndCloneDeepCopies(t *testing.T) 
 	if eff == nil {
 		t.Fatalf("Effective returned nil value")
 	}
-	if eff.Val().M["u"] != 2 {
-		t.Fatalf("expected effective user value 2, got %d", eff.Val().M["u"])
+	if eff.Get().Val().M["u"] != 2 {
+		t.Fatalf("expected effective user value 2, got %d", eff.Get().Val().M["u"])
 	}
 
 	// Clone and then mutate originals; clone should remain unchanged
@@ -174,8 +174,8 @@ func TestRuntimeValue_UserInputBecomesEffectiveAndCloneDeepCopies(t *testing.T) 
 	if clonedEff == nil {
 		t.Fatalf("cloned Effective is nil")
 	}
-	if clonedEff.Val().M["u"] != 2 {
-		t.Fatalf("expected cloned effective u==2, got %d", clonedEff.Val().M["u"])
+	if clonedEff.Get().Val().M["u"] != 2 {
+		t.Fatalf("expected cloned effective u==2, got %d", clonedEff.Get().Val().M["u"])
 	}
 }
 
@@ -187,14 +187,20 @@ func TestRuntimeValue_EffectiveFuncInvokedAndPreservedOnClone(t *testing.T) {
 	}
 
 	var counter int32
-	effFunc := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+	effFunc := func(ctx context.Context, _ Value[*S], _ Value[*S]) (*EffectiveValue[*S], bool, error) {
 		v := atomic.AddInt32(&counter, 1)
 		val, err := NewValue(&S{M: map[string]int{"ctr": int(v)}})
 		if err != nil {
 			return nil, false, err
 		}
+
+		ev, err := NewEffectiveValue(val, StrategyCustom)
+		if err != nil {
+			return nil, false, err
+		}
+
 		// cache the computed result
-		return val, true, nil
+		return ev, true, nil
 	}
 
 	// provide a non-nil defaultVal as required by NewRuntimeValue
@@ -213,8 +219,8 @@ func TestRuntimeValue_EffectiveFuncInvokedAndPreservedOnClone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Effective call 1 failed: %v", err)
 	}
-	if v1.Val().M["ctr"] != 1 {
-		t.Fatalf("expected ctr==1 on first call, got %d", v1.Val().M["ctr"])
+	if v1.Get().Val().M["ctr"] != 1 {
+		t.Fatalf("expected ctr==1 on first call, got %d", v1.Get().Val().M["ctr"])
 	}
 
 	// second call should return cached value (counter still 1)
@@ -222,8 +228,8 @@ func TestRuntimeValue_EffectiveFuncInvokedAndPreservedOnClone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Effective call 2 failed: %v", err)
 	}
-	if v2.Val().M["ctr"] != 1 {
-		t.Fatalf("expected ctr==1 on second call (cached), got %d", v2.Val().M["ctr"])
+	if v2.Get().Val().M["ctr"] != 1 {
+		t.Fatalf("expected ctr==1 on second call (cached), got %d", v2.Get().Val().M["ctr"])
 	}
 
 	// Clone the runtime value; cloned effective is copied, so clone should not invoke effFunc
@@ -237,8 +243,8 @@ func TestRuntimeValue_EffectiveFuncInvokedAndPreservedOnClone(t *testing.T) {
 		t.Fatalf("clone Effective failed: %v", err)
 	}
 	// clone had cached effective, so counter remains 1
-	if cv.Val().M["ctr"] != 1 {
-		t.Fatalf("expected ctr==1 after clone Effective, got %d", cv.Val().M["ctr"])
+	if cv.Get().Val().M["ctr"] != 1 {
+		t.Fatalf("expected ctr==1 after clone Effective, got %d", cv.Get().Val().M["ctr"])
 	}
 }
 
@@ -258,7 +264,7 @@ func TestRuntimeValue_SingleFlightDedupesConcurrentEvaluations(t *testing.T) {
 	}
 
 	var counter int32
-	effFunc := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+	effFunc := func(ctx context.Context, _ Value[*S], _ Value[*S]) (*EffectiveValue[*S], bool, error) {
 		// simulate expensive work
 		time.Sleep(100 * time.Millisecond)
 		v := atomic.AddInt32(&counter, 1)
@@ -266,8 +272,14 @@ func TestRuntimeValue_SingleFlightDedupesConcurrentEvaluations(t *testing.T) {
 		if err != nil {
 			return nil, false, err
 		}
-		// cache the result
-		return val, true, nil
+
+		ev, err := NewEffectiveValue(val, StrategyCustom)
+		if err != nil {
+			return nil, false, err
+		}
+
+		// cache the computed result
+		return ev, true, nil
 	}
 
 	defVal, err := NewValue(&S{M: map[string]int{}})
@@ -281,7 +293,7 @@ func TestRuntimeValue_SingleFlightDedupesConcurrentEvaluations(t *testing.T) {
 
 	var wg sync.WaitGroup
 	const goroutines = 20
-	results := make([]Value[*S], goroutines)
+	results := make([]*EffectiveValue[*S], goroutines)
 	errs := make([]error, goroutines)
 
 	for i := 0; i < goroutines; i++ {
@@ -307,8 +319,8 @@ func TestRuntimeValue_SingleFlightDedupesConcurrentEvaluations(t *testing.T) {
 		if results[i] == nil {
 			t.Fatalf("goroutine %d: Effective returned nil", i)
 		}
-		if results[i].Val().M["ctr"] != 1 {
-			t.Fatalf("goroutine %d: expected ctr==1, got %d", i, results[i].Val().M["ctr"])
+		if results[i].Get().Val().M["ctr"] != 1 {
+			t.Fatalf("goroutine %d: expected ctr==1, got %d", i, results[i].Get().Val().M["ctr"])
 		}
 	}
 }
@@ -326,7 +338,7 @@ func TestRuntimeValue_DefaultWhenNoEffectiveFunc(t *testing.T) {
 	eff, err := rv.Effective()
 	require.NoError(t, err)
 	require.NotNil(t, eff)
-	require.Equal(t, 7, eff.Val().V)
+	require.Equal(t, 7, eff.Get().Val().V)
 }
 
 // Test SetUserInput updates effective when no effectiveFunc and clears cache when effectiveFunc present.
@@ -347,34 +359,44 @@ func TestRuntimeValue_SetUserInputUpdatesEffective(t *testing.T) {
 	// initially effective is default
 	eff, err := rv.Effective()
 	require.NoError(t, err)
-	require.Equal(t, 1, eff.Val().V)
+	require.Equal(t, 1, eff.Get().Val().V)
 
 	// set user input, effective should switch
 	rv.SetUserInput(userVal)
 	eff2, err := rv.Effective()
 	require.NoError(t, err)
-	require.Equal(t, 42, eff2.Val().V)
+	require.Equal(t, 42, eff2.Get().Val().V)
 
 	// now configure an effectiveFunc that caches a computed value
 	var counter int32
-	effFunc := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+	effFunc := func(ctx context.Context, _ Value[*S], _ Value[*S]) (*EffectiveValue[*S], bool, error) {
 		v := atomic.AddInt32(&counter, 1)
 		val, err := NewValue(&S{V: int(v)})
-		return val, true, err
+		if err != nil {
+			return nil, false, err
+		}
+
+		ev, err := NewEffectiveValue(val, StrategyCustom)
+		if err != nil {
+			return nil, false, err
+		}
+
+		// cache the computed result
+		return ev, true, nil
 	}
 
 	rv.SetEffectiveFunc(effFunc)
 	// first Effective will compute & cache
 	v1, err := rv.Effective()
 	require.NoError(t, err)
-	require.Equal(t, 1, v1.Val().V)
+	require.Equal(t, 1, v1.Get().Val().V)
 
 	// set user input while effectiveFunc configured -> cache cleared
 	rv.SetUserInput(userVal)
 	// since effectiveFunc present, Effective will recompute using effFunc
 	v2, err := rv.Effective()
 	require.NoError(t, err)
-	require.Equal(t, 2, v2.Val().V)
+	require.Equal(t, 2, v2.Get().Val().V)
 }
 
 // Test SetEffectiveFunc clears previous cache and new function is used.
@@ -385,10 +407,19 @@ func TestRuntimeValue_SetEffectiveFuncClearsCache(t *testing.T) {
 	require.NoError(t, err)
 
 	var c1 int32
-	f1 := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+	f1 := func(ctx context.Context, _ Value[*S], _ Value[*S]) (*EffectiveValue[*S], bool, error) {
 		v := atomic.AddInt32(&c1, 1)
 		val, err := NewValue(&S{V: int(v)})
-		return val, true, err
+		if err != nil {
+			return nil, false, err
+		}
+
+		ev, err := NewEffectiveValue(val, StrategyCustom)
+		if err != nil {
+			return nil, false, err
+		}
+
+		return ev, true, nil
 	}
 
 	rv, err := NewRuntimeValue[*S](defVal, WithEffectiveFunc[*S](f1))
@@ -396,7 +427,7 @@ func TestRuntimeValue_SetEffectiveFuncClearsCache(t *testing.T) {
 
 	v1, err := rv.Effective()
 	require.NoError(t, err)
-	require.Equal(t, 1, v1.Val().V)
+	require.Equal(t, 1, v1.Get().Val().V)
 
 	// setting nil effectiveFunc won't set it
 	assert.NotNil(t, rv.effectiveFunc)
@@ -405,16 +436,25 @@ func TestRuntimeValue_SetEffectiveFuncClearsCache(t *testing.T) {
 
 	// replace effective func
 	var c2 int32
-	f2 := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+	f2 := func(ctx context.Context, _ Value[*S], _ Value[*S]) (*EffectiveValue[*S], bool, error) {
 		v := atomic.AddInt32(&c2, 1)
 		val, err := NewValue(&S{V: int(v * 10)})
-		return val, true, err
+		if err != nil {
+			return nil, false, err
+		}
+
+		ev, err := NewEffectiveValue(val, StrategyCustom)
+		if err != nil {
+			return nil, false, err
+		}
+
+		return ev, true, nil
 	}
 
 	rv.SetEffectiveFunc(f2)
 	v2, err := rv.Effective()
 	require.NoError(t, err)
-	require.Equal(t, 10, v2.Val().V)
+	require.Equal(t, 10, v2.Get().Val().V)
 }
 
 // Test that effectiveFunc returning shouldCache==false is re-evaluated on each call.
@@ -425,10 +465,19 @@ func TestRuntimeValue_Effective_ReevaluatesWhenNotCaching(t *testing.T) {
 	require.NoError(t, err)
 
 	var counter int32
-	f := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+	f := func(ctx context.Context, _ Value[*S], _ Value[*S]) (*EffectiveValue[*S], bool, error) {
 		v := atomic.AddInt32(&counter, 1)
 		val, err := NewValue(&S{V: int(v)})
-		return val, false, err
+		if err != nil {
+			return nil, false, err
+		}
+
+		ev, err := NewEffectiveValue(val, StrategyCustom)
+		if err != nil {
+			return nil, false, err
+		}
+
+		return ev, false, nil
 	}
 
 	rv, err := NewRuntimeValue[*S](defVal, WithEffectiveFunc[*S](f))
@@ -436,11 +485,11 @@ func TestRuntimeValue_Effective_ReevaluatesWhenNotCaching(t *testing.T) {
 
 	a, err := rv.Effective()
 	require.NoError(t, err)
-	require.Equal(t, 1, a.Val().V)
+	require.Equal(t, 1, a.Get().Val().V)
 
 	b, err := rv.Effective()
 	require.NoError(t, err)
-	require.Equal(t, 2, b.Val().V)
+	require.Equal(t, 2, b.Get().Val().V)
 }
 
 // Test cloning a nil *defaultValue returns an error.
@@ -489,10 +538,19 @@ func TestRuntimeValue_ClearCache(t *testing.T) {
 	require.NoError(t, err)
 
 	var counter int32
-	f := func(ctx context.Context, _ Value[*S], _ Value[*S]) (Value[*S], bool, error) {
+	f := func(ctx context.Context, _ Value[*S], _ Value[*S]) (*EffectiveValue[*S], bool, error) {
 		v := atomic.AddInt32(&counter, 1)
 		val, err := NewValue(&S{V: int(v)})
-		return val, true, err
+		if err != nil {
+			return nil, false, err
+		}
+
+		ev, err := NewEffectiveValue(val, StrategyCustom)
+		if err != nil {
+			return nil, false, err
+		}
+
+		return ev, true, nil
 	}
 
 	rv, err := NewRuntimeValue[*S](defVal, WithEffectiveFunc[*S](f))
@@ -501,15 +559,106 @@ func TestRuntimeValue_ClearCache(t *testing.T) {
 	// First call should compute & cache (counter == 1)
 	v1, err := rv.Effective()
 	require.NoError(t, err)
-	require.Equal(t, 1, v1.Val().V)
+	require.Equal(t, 1, v1.Get().Val().V)
 
 	// Clear cache and ensure next call recomputes (counter == 2)
 	rv.ClearCache()
 	v2, err := rv.Effective()
 	require.NoError(t, err)
-	require.Equal(t, 2, v2.Val().V)
+	require.Equal(t, 2, v2.Get().Val().V)
 
 	// nil-receiver: calling ClearCache on a nil *RuntimeValue should be safe (no panic)
 	var nilRV *RuntimeValue[*S] = nil
 	nilRV.ClearCache()
+}
+
+// Test that WithContext stores the provided context and that Effective()
+// uses the stored context when invoking the EffectiveFunc.
+func TestRuntimeValue_WithContext_EffectiveReceivesContext(t *testing.T) {
+	type S struct{ V int }
+
+	seen := false
+	effFunc := func(ctx context.Context, _ Value[*S], _ Value[*S]) (*EffectiveValue[*S], bool, error) {
+		// ensure the context value is propagated
+		if ctx.Value("test-key") == "test-val" {
+			seen = true
+		}
+		val, err := NewValue(&S{V: 123})
+		if err != nil {
+			return nil, false, err
+		}
+		ev, err := NewEffectiveValue(val, StrategyCustom)
+		if err != nil {
+			return nil, false, err
+		}
+		return ev, true, nil
+	}
+
+	defVal, err := NewValue(&S{V: 0})
+	require.NoError(t, err)
+
+	rv, err := NewRuntimeValue[*S](defVal, WithEffectiveFunc[*S](effFunc))
+	require.NoError(t, err)
+	require.NotNil(t, rv)
+
+	ctx := context.WithValue(context.Background(), "test-key", "test-val")
+	rv = rv.WithContext(ctx)
+
+	ev, err := rv.Effective()
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	assert.True(t, seen, "effectiveFunc should receive the context set via WithContext")
+	assert.Equal(t, 123, ev.Get().Val().V)
+}
+
+// Test Clone deep-copies contained Values and preserves the stored context.
+func TestRuntimeValue_ClonePreservesContextAndDeepCopies(t *testing.T) {
+	type S struct {
+		M map[string]int
+	}
+
+	origDef := &S{M: map[string]int{"d": 1}}
+	origUser := &S{M: map[string]int{"u": 2}}
+
+	defVal, err := NewValue[*S](origDef)
+	require.NoError(t, err)
+	userVal, err := NewValue[*S](origUser)
+	require.NoError(t, err)
+
+	ctx := context.WithValue(context.Background(), "ctx-key", "ctx-val")
+
+	rv, err := NewRuntimeValue[*S](defVal, WithUserInput[*S](userVal))
+	require.NoError(t, err)
+	require.NotNil(t, rv)
+	rv = rv.WithContext(ctx)
+
+	clone, err := rv.Clone()
+	require.NoError(t, err)
+	require.NotNil(t, clone)
+
+	// Mutate original underlying objects after cloning
+	origDef.M["d"] = 99
+	origUser.M["u"] = 99
+
+	// cloned default and user input should preserve original values
+	clonedDef := clone.Default()
+	require.NotNil(t, clonedDef)
+	assert.Equal(t, 1, clonedDef.Val().M["d"])
+
+	clonedUser := clone.UserInput()
+	require.NotNil(t, clonedUser)
+	assert.Equal(t, 2, clonedUser.Val().M["u"])
+
+	// clone should preserve stored context value
+	require.NotNil(t, rv)
+	require.NotNil(t, clone)
+	assert.Equal(t, rv.ctx.Value("ctx-key"), clone.ctx.Value("ctx-key"))
+}
+
+// Test that Clone on a nil *RuntimeValue returns an error.
+func TestRuntimeValue_CloneNilReceiver(t *testing.T) {
+	var rv *RuntimeValue[int] = nil
+	_, err := rv.Clone()
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, errorx.IllegalState) || errorx.IsOfType(err, IllegalArgument))
 }

--- a/type_effective_value.go
+++ b/type_effective_value.go
@@ -1,0 +1,131 @@
+package automa
+
+import (
+	"encoding/json"
+
+	"github.com/joomcode/errorx"
+)
+
+// EffectiveStrategy describes how an effective value was determined.
+//
+// It is used to indicate whether a value came from the system default,
+// from explicit user input, or from custom resolution logic.
+type EffectiveStrategy uint8
+
+const (
+	// StrategyDefault indicates that the effective value was determined by
+	// the system's default value.
+	StrategyDefault EffectiveStrategy = 0
+
+	// StrategyUserInput indicates that the effective value was provided
+	// explicitly by user input.
+	StrategyUserInput EffectiveStrategy = 1
+
+	// StrategyCustom indicates that the effective value was determined by
+	// custom logic (for example, an EffectiveFunc).
+	StrategyCustom EffectiveStrategy = 2
+)
+
+// String returns the textual representation of the EffectiveStrategy.
+//
+// Known values are "default", "userInput" and "custom". Unknown values
+// return "unknown".
+func (es EffectiveStrategy) String() string {
+	switch es {
+	case StrategyDefault:
+		return "default"
+	case StrategyUserInput:
+		return "userInput"
+	case StrategyCustom:
+		return "custom"
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalJSON implements json.Marshaler for EffectiveStrategy.
+//
+// It encodes the strategy as a quoted string using the same values as
+// String().
+func (es EffectiveStrategy) MarshalJSON() ([]byte, error) {
+	return json.Marshal(es.String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler for EffectiveStrategy.
+//
+// It accepts the quoted string representations "default", "userInput" and
+// "custom". Unknown values are mapped to StrategyDefault for backward
+// compatibility.
+func (es *EffectiveStrategy) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "default":
+		*es = StrategyDefault
+	case "userInput":
+		*es = StrategyUserInput
+	case "custom":
+		*es = StrategyCustom
+	default:
+		*es = StrategyDefault
+	}
+	return nil
+}
+
+// EffectiveValue wraps a Value[T] together with information about how that
+// value was chosen (the EffectiveStrategy).
+//
+// The wrapper provides cloning and accessors to retrieve the underlying
+// value and the associated strategy.
+type EffectiveValue[T any] struct {
+	v        Value[T]
+	strategy EffectiveStrategy
+}
+
+// NewEffectiveValue constructs a new EffectiveValue that pairs the provided
+// Value with the given EffectiveStrategy.
+// An error is returned if the provided Value is nil.
+func NewEffectiveValue[T any](v Value[T], strategy EffectiveStrategy) (*EffectiveValue[T], error) {
+	if v == nil {
+		return nil, errorx.IllegalArgument.New("value cannot be nil")
+	}
+
+	return &EffectiveValue[T]{
+		v:        v,
+		strategy: strategy,
+	}, nil
+}
+
+// Clone produces a deep clone of the EffectiveValue by cloning the
+// underlying Value using its Clone method.
+//
+// If the underlying Value's Clone fails, the error is returned.
+func (ev EffectiveValue[T]) Clone() (*EffectiveValue[T], error) {
+	cv, err := ev.v.Clone()
+	if err != nil {
+		return nil, err
+	}
+
+	clone := &EffectiveValue[T]{
+		v:        cv,
+		strategy: ev.strategy,
+	}
+
+	return clone, nil
+}
+
+// Get returns the underlying Value[T] wrapped by this EffectiveValue.
+//
+// The returned Value should be treated according to its own concurrency and
+// cloning semantics.
+func (ev EffectiveValue[T]) Get() Value[T] {
+	return ev.v
+}
+
+// Strategy returns the EffectiveStrategy indicating how the underlying
+// value was selected.
+func (ev EffectiveValue[T]) Strategy() EffectiveStrategy {
+	return ev.strategy
+}

--- a/type_effective_value_test.go
+++ b/type_effective_value_test.go
@@ -1,0 +1,80 @@
+package automa
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveStrategy_JSONAndString(t *testing.T) {
+	cases := []struct {
+		s        EffectiveStrategy
+		expected string
+	}{
+		{StrategyDefault, "default"},
+		{StrategyUserInput, "userInput"},
+		{StrategyCustom, "custom"},
+	}
+
+	for _, c := range cases {
+		// String
+		assert.Equal(t, c.expected, c.s.String())
+
+		// Marshal JSON -> quoted string
+		b, err := json.Marshal(c.s)
+		require.NoError(t, err)
+		assert.Equal(t, "\""+c.expected+"\"", string(b))
+
+		// Unmarshal back
+		var got EffectiveStrategy
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.Equal(t, c.s, got)
+	}
+}
+
+func TestEffectiveValue_BasicBehavior(t *testing.T) {
+	// create a Value via existing constructor to avoid depending on internal interfaces
+	v, err := NewValue[string]("hello")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	ev, err := NewEffectiveValue(v, StrategyUserInput)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+
+	// accessors
+	assert.Equal(t, StrategyUserInput, ev.Strategy())
+	assert.Equal(t, v, ev.Get())
+
+	// Clone should succeed and preserve strategy
+	clone, err := ev.Clone()
+	require.NoError(t, err)
+	require.NotNil(t, clone)
+	assert.Equal(t, ev.Strategy(), clone.Strategy())
+	// underlying value must be present on clone
+	assert.NotNil(t, clone.Get())
+}
+
+// Test that unknown/invalid strategy strings decode to StrategyDefault.
+// This documents the current decision to treat unknown values as StrategyDefault.
+func TestEffectiveStrategy_UnmarshalUnknownDefaultsToDefault(t *testing.T) {
+	var es EffectiveStrategy
+	err := json.Unmarshal([]byte(`"invalid"`), &es)
+	require.NoError(t, err)
+	assert.Equal(t, StrategyDefault, es)
+
+	// also test another unknown token
+	err = json.Unmarshal([]byte(`"unknown"`), &es)
+	require.NoError(t, err)
+	assert.Equal(t, StrategyDefault, es)
+}
+
+func TestNewEffectiveValue_NilValueBehavior(t *testing.T) {
+	var nilVal Value[string] = nil
+
+	ev, err := NewEffectiveValue[string](nilVal, StrategyDefault)
+	require.Error(t, err)
+	require.Nil(t, ev)
+}


### PR DESCRIPTION
## Description

This pull request introduces a new `EffectiveValue` type to the codebase, providing a structured way to represent both the value and the strategy used to compute the "effective" value in the `RuntimeValue` container. The changes refactor the `EffectiveFunc` and related methods to use this new type, update the caching and concurrency logic, and add comprehensive tests for the new behavior.

Key changes include:

**Core Type and API Changes:**

* Introduced the `EffectiveValue` type and `EffectiveStrategy` enum in a new file (`type_effective_value.go`), encapsulating both the value and the strategy (default, user input, or custom logic) used to compute it. Includes JSON marshaling and string conversion.
* Refactored the `EffectiveFunc` signature and related fields/methods in `runtime_value.go` to use `*EffectiveValue[T]` instead of `Value[T]`, updating all usages and cache logic accordingly. [[1]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L149-R149) [[2]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L173-R173) [[3]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L204-R204) [[4]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L254-R254) [[5]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L265-R265) [[6]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L322-R323) [[7]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L443-R449)

**Behavioral and Logic Updates:**

* Updated the default `effectiveFunc` to wrap values in `EffectiveValue` and assign the correct strategy, ensuring consistent strategy tracking and simplifying downstream logic.
* Adjusted all test cases in `runtime_value_test.go` to use the new `EffectiveValue` API, including checks for strategy and value access. [[1]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL146-R147) [[2]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL176-R177) [[3]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL189-R196) [[4]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL215-R225) [[5]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL239-R240) [[6]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL260-R260) [[7]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL269-R269) [[8]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL283-R283) [[9]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL309-R310) [[10]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL328-R328) [[11]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL349-R376) [[12]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL387-R411) [[13]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL422-R437) [[14]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL486-R489) [[15]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dL498-R504)

**Testing:**

* Added a new test file, `type_effective_value_test.go`, to verify the behavior of `EffectiveValue` and `EffectiveStrategy`, including JSON marshaling, cloning, and helper functions.

These changes improve the clarity, extensibility, and correctness of how effective values and their provenance are managed throughout the system.

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
