### PR TITLE
fix: add a new effective strategy and support ValueOption to return error

### DIFF
--- a/runtime_value.go
+++ b/runtime_value.go
@@ -508,7 +508,11 @@ func NewRuntime[T any](defaultVal T, opts ...ValueOption[T]) (*RuntimeValue[T], 
 }
 
 // IsNil reports whether the provided generic value is nil for kinds that can be nil.
-// It returns false for non-nilable kinds (and will not panic).
+//
+// It returns true for values that are nil, and also for untyped nil values
+// (for example `var x interface{} = nil`) which are represented internally as
+// an invalid `reflect.Value`. For kinds that cannot be nil this function
+// returns false and will not panic.
 func IsNil[T any](v T) bool {
 	rv := reflect.ValueOf(v)
 	if !rv.IsValid() {

--- a/type_effective_value.go
+++ b/type_effective_value.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/joomcode/errorx"
+	"gopkg.in/yaml.v3"
 )
 
 // EffectiveStrategy describes how an effective value was determined.
@@ -22,8 +23,12 @@ const (
 	StrategyUserInput EffectiveStrategy = 1
 
 	// StrategyCustom indicates that the effective value was determined by
-	// custom logic (for example, an EffectiveFunc).
+	// custom logic
 	StrategyCustom EffectiveStrategy = 2
+
+	// StrategyCurrent indicates that the effective value was determined by
+	// current state
+	StrategyCurrent EffectiveStrategy = 3
 )
 
 // String returns the textual representation of the EffectiveStrategy.
@@ -38,6 +43,10 @@ func (es EffectiveStrategy) String() string {
 		return "userInput"
 	case StrategyCustom:
 		return "custom"
+	case StrategyCurrent:
+		{
+			return "current"
+		}
 	default:
 		return "unknown"
 	}
@@ -68,6 +77,37 @@ func (es *EffectiveStrategy) UnmarshalJSON(data []byte) error {
 		*es = StrategyUserInput
 	case "custom":
 		*es = StrategyCustom
+	case "current":
+		{
+			*es = StrategyCurrent
+		}
+	default:
+		*es = StrategyDefault
+	}
+	return nil
+}
+
+// MarshalYAML encodes the EffectiveStrategy as its string representation.
+func (es EffectiveStrategy) MarshalYAML() (interface{}, error) {
+	return es.String(), nil
+}
+
+// UnmarshalYAML decodes the EffectiveStrategy from a YAML node containing the string.
+// Unknown values are mapped to StrategyDefault for compatibility.
+func (es *EffectiveStrategy) UnmarshalYAML(node *yaml.Node) error {
+	var s string
+	if err := node.Decode(&s); err != nil {
+		return err
+	}
+	switch s {
+	case "default":
+		*es = StrategyDefault
+	case "userInput":
+		*es = StrategyUserInput
+	case "custom":
+		*es = StrategyCustom
+	case "current":
+		*es = StrategyCurrent
 	default:
 		*es = StrategyDefault
 	}

--- a/type_effective_value.go
+++ b/type_effective_value.go
@@ -98,6 +98,22 @@ func NewEffectiveValue[T any](v Value[T], strategy EffectiveStrategy) (*Effectiv
 	}, nil
 }
 
+// NewEffective constructs a new EffectiveValue that pairs the provided
+// Value with the given EffectiveStrategy.
+// An error is returned if the provided Value is nil.
+func NewEffective[T any](v T, strategy EffectiveStrategy) (*EffectiveValue[T], error) {
+	if IsNil(v) {
+		return nil, errorx.IllegalArgument.New("value cannot be nil")
+	}
+
+	vv, err := NewValue[T](v)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewEffectiveValue(vv, strategy)
+}
+
 // Clone produces a deep clone of the EffectiveValue by cloning the
 // underlying Value using its Clone method.
 //

--- a/type_effective_value_test.go
+++ b/type_effective_value_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestEffectiveStrategy_JSONAndString(t *testing.T) {
@@ -16,6 +17,7 @@ func TestEffectiveStrategy_JSONAndString(t *testing.T) {
 		{StrategyDefault, "default"},
 		{StrategyUserInput, "userInput"},
 		{StrategyCustom, "custom"},
+		{StrategyCurrent, "current"},
 	}
 
 	for _, c := range cases {
@@ -89,4 +91,18 @@ func TestNewEffectiveRaw(t *testing.T) {
 	require.NotNil(t, ev)
 	assert.Equal(t, StrategyCustom, ev.Strategy())
 	assert.Equal(t, "test", ev.Get().Val())
+}
+
+func TestEffectiveStrategy_YAMLUnmarshalUnknownDefaultsToDefault(t *testing.T) {
+	var es EffectiveStrategy
+
+	// plain unknown token
+	err := yaml.Unmarshal([]byte("invalid\n"), &es)
+	require.NoError(t, err)
+	assert.Equal(t, StrategyDefault, es)
+
+	// quoted unknown token
+	err = yaml.Unmarshal([]byte("\"unknown\"\n"), &es)
+	require.NoError(t, err)
+	assert.Equal(t, StrategyDefault, es)
 }

--- a/type_effective_value_test.go
+++ b/type_effective_value_test.go
@@ -106,3 +106,21 @@ func TestEffectiveStrategy_YAMLUnmarshalUnknownDefaultsToDefault(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, StrategyDefault, es)
 }
+
+func TestEffectiveStrategy_YAMLMarshal(t *testing.T) {
+	cases := []struct {
+		s        EffectiveStrategy
+		expected string
+	}{
+		{StrategyDefault, "default"},
+		{StrategyUserInput, "userInput"},
+		{StrategyCustom, "custom"},
+		{StrategyCurrent, "current"},
+	}
+
+	for _, c := range cases {
+		b, err := yaml.Marshal(c.s)
+		require.NoError(t, err)
+		assert.Equal(t, c.expected+"\n", string(b))
+	}
+}

--- a/type_effective_value_test.go
+++ b/type_effective_value_test.go
@@ -77,4 +77,16 @@ func TestNewEffectiveValue_NilValueBehavior(t *testing.T) {
 	ev, err := NewEffectiveValue[string](nilVal, StrategyDefault)
 	require.Error(t, err)
 	require.Nil(t, ev)
+
+	evr, err := NewEffective[*string](nil, StrategyDefault)
+	require.Error(t, err)
+	require.Nil(t, evr)
+}
+
+func TestNewEffectiveRaw(t *testing.T) {
+	ev, err := NewEffective[string]("test", StrategyCustom)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	assert.Equal(t, StrategyCustom, ev.Strategy())
+	assert.Equal(t, "test", ev.Get().Val())
 }


### PR DESCRIPTION
## Description

This pull request introduces several enhancements and refactorings to the runtime value and effective value handling, focusing on improving type safety, error handling, and serialization support. The most significant changes are the introduction of generic nil checking, stricter option validation, new construction helpers, and YAML support for `EffectiveStrategy`.

### Runtime value improvements
- **Generic nil checking utility:** Added a generic `IsNil` function in `runtime_value.go` to safely check if a value of any type is nil, supporting all nil-able kinds without panics. Includes comprehensive tests in `runtime_value_test.go`. [[1]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96R492-R523) [[2]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dR672-R701)
- **Stricter ValueOption validation:** Modified the `ValueOption` type to return errors, and updated option functions (`WithEffectiveFunc`, `WithUserInput`) to validate inputs and return errors on invalid arguments. Construction now aborts on invalid options. [[1]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L406-R407) [[2]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L415-R422) [[3]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L429-R437) [[4]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96L450-R460)

### Construction helpers
- **New generic constructors:** Introduced `NewRuntime` and `NewEffective` helpers for constructing `RuntimeValue` and `EffectiveValue` directly from raw values, with nil checks and error returns for invalid input. [[1]](diffhunk://#diff-735149d89d66dd98a8dcfcbcca658d494eb530bfddd0ba42b6543a7f6cab2f96R492-R523) [[2]](diffhunk://#diff-9d756e473e40c0d9e704d62685ed578dc3c2551d9af23bab4e0bfb605928063fR141-R156)
- **Expanded tests:** Added tests for the new constructors and nil handling scenarios. [[1]](diffhunk://#diff-d6049c83d49fac755be39b20dd741b15eb3d1cfd9f34531c06de830378245d9dR672-R701) [[2]](diffhunk://#diff-d9a0d4e75c971c48f82f8c069e56c22b6dd17d4d0dbd161e5d2572dbd58530f4R82-R107)

### EffectiveStrategy serialization and extension
- **YAML support for EffectiveStrategy:** Added `MarshalYAML` and `UnmarshalYAML` methods to support YAML serialization/deserialization, defaulting unknown values to `StrategyDefault`.
- **New strategy value:** Added `StrategyCurrent` to `EffectiveStrategy`, with support in string conversion and (un)marshaling logic. [[1]](diffhunk://#diff-9d756e473e40c0d9e704d62685ed578dc3c2551d9af23bab4e0bfb605928063fL25-R31) [[2]](diffhunk://#diff-9d756e473e40c0d9e704d62685ed578dc3c2551d9af23bab4e0bfb605928063fR46-R49) [[3]](diffhunk://#diff-9d756e473e40c0d9e704d62685ed578dc3c2551d9af23bab4e0bfb605928063fR80-R110) [[4]](diffhunk://#diff-d9a0d4e75c971c48f82f8c069e56c22b6dd17d4d0dbd161e5d2572dbd58530f4R20)

### Dependency updates
- **YAML library import:** Added `gopkg.in/yaml.v3` as a dependency for YAML support. [[1]](diffhunk://#diff-9d756e473e40c0d9e704d62685ed578dc3c2551d9af23bab4e0bfb605928063fR7) [[2]](diffhunk://#diff-d9a0d4e75c971c48f82f8c069e56c22b6dd17d4d0dbd161e5d2572dbd58530f4R9)


### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:


The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
