### PR TITLE
fix: add a strategy option for configuration driven effective value

### DIFF
--- a/type_effective_value.go
+++ b/type_effective_value.go
@@ -29,6 +29,10 @@ const (
 	// StrategyCurrent indicates that the effective value was determined by
 	// current state
 	StrategyCurrent EffectiveStrategy = 3
+
+	// StrategyConfig indicates that the effective value was determined by
+	// configuration
+	StrategyConfig EffectiveStrategy = 4
 )
 
 // String returns the textual representation of the EffectiveStrategy.
@@ -46,6 +50,10 @@ func (es EffectiveStrategy) String() string {
 	case StrategyCurrent:
 		{
 			return "current"
+		}
+	case StrategyConfig:
+		{
+			return "config"
 		}
 	default:
 		return "unknown"
@@ -78,9 +86,9 @@ func (es *EffectiveStrategy) UnmarshalJSON(data []byte) error {
 	case "custom":
 		*es = StrategyCustom
 	case "current":
-		{
-			*es = StrategyCurrent
-		}
+		*es = StrategyCurrent
+	case "config":
+		*es = StrategyConfig
 	default:
 		*es = StrategyDefault
 	}
@@ -108,6 +116,8 @@ func (es *EffectiveStrategy) UnmarshalYAML(node *yaml.Node) error {
 		*es = StrategyCustom
 	case "current":
 		*es = StrategyCurrent
+	case "config":
+		*es = StrategyConfig
 	default:
 		*es = StrategyDefault
 	}

--- a/type_effective_value_test.go
+++ b/type_effective_value_test.go
@@ -18,6 +18,7 @@ func TestEffectiveStrategy_JSONAndString(t *testing.T) {
 		{StrategyUserInput, "userInput"},
 		{StrategyCustom, "custom"},
 		{StrategyCurrent, "current"},
+		{StrategyConfig, "config"},
 	}
 
 	for _, c := range cases {
@@ -116,6 +117,7 @@ func TestEffectiveStrategy_YAMLMarshal(t *testing.T) {
 		{StrategyUserInput, "userInput"},
 		{StrategyCustom, "custom"},
 		{StrategyCurrent, "current"},
+		{StrategyConfig, "config"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Description
This pull request adds support for a new `StrategyConfig` value to the `EffectiveStrategy` type, allowing the system to recognize and handle configuration-based strategies. The update includes changes to string representations, JSON/YAML unmarshalling, and associated tests.

**Support for new `StrategyConfig` value:**

* Added the `StrategyConfig` constant to the `EffectiveStrategy` type and updated its documentation in `type_effective_value.go`.
* Updated the `String()` method to return `"config"` for the new strategy.

**Deserialization improvements:**

* Modified both `UnmarshalJSON` and `UnmarshalYAML` methods to recognize `"config"` as a valid strategy value. [[1]](diffhunk://#diff-9d756e473e40c0d9e704d62685ed578dc3c2551d9af23bab4e0bfb605928063fL81-R91) [[2]](diffhunk://#diff-9d756e473e40c0d9e704d62685ed578dc3c2551d9af23bab4e0bfb605928063fR119-R120)

**Test coverage:**

* Added a test case for `StrategyConfig` to ensure correct string conversion and JSON handling in `type_effective_value_test.go`.

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
