### PR TITLE
feat: implement namespaced state model to support local and global states

### DIFF
--- a/automa.go
+++ b/automa.go
@@ -27,7 +27,7 @@ type StateBag interface {
 	Keys() []Key
 	Size() int
 	Items() map[Key]interface{}
-	Merge(other StateBag) StateBag
+	Merge(other StateBag) (StateBag, error)
 	Clone() (StateBag, error)
 
 	// Helper methods for extracting typed values
@@ -95,7 +95,7 @@ type NamespacedStateBag interface {
 	// - Custom namespaces are merged individually by name
 	//   - If a custom namespace exists in both, they are merged
 	//   - If a custom namespace only exists in other, it is added
-	Merge(other NamespacedStateBag) NamespacedStateBag
+	Merge(other NamespacedStateBag) (NamespacedStateBag, error)
 }
 
 type Workflow interface {

--- a/automa.go
+++ b/automa.go
@@ -10,10 +10,15 @@ type Step interface {
 	Prepare(ctx context.Context) (context.Context, error)
 	Execute(ctx context.Context) *Report
 	Rollback(ctx context.Context) *Report
-	State() StateBag
-	WithState(s StateBag) Step
+	State() NamespacedStateBag
+	WithState(s NamespacedStateBag) Step
 }
 
+// StateBag is a thread-safe key-value store for workflow state management.
+// It provides basic storage operations without namespace support.
+//
+// StateBag is used as the underlying storage for individual namespaces in NamespacedStateBag.
+// For step state management with namespace isolation, use NamespacedStateBag instead.
 type StateBag interface {
 	Get(key Key) (interface{}, bool)
 	Set(key Key, value interface{}) StateBag
@@ -24,6 +29,7 @@ type StateBag interface {
 	Items() map[Key]interface{}
 	Merge(other StateBag) StateBag
 	Clone() (StateBag, error)
+
 	// Helper methods for extracting typed values
 	String(key Key) string
 	Bool(key Key) bool
@@ -35,6 +41,61 @@ type StateBag interface {
 	Float(key Key) float64
 	Float32(key Key) float32
 	Float64(key Key) float64
+}
+
+// NamespacedStateBag provides namespace-aware state management for workflow steps.
+//
+// It supports three types of namespaces:
+//   - Local: Step-private state that is not visible to other steps
+//   - Global: Workflow-shared state that all steps can access
+//   - Custom: Named namespaces for specific use cases
+//
+// Usage Examples:
+//
+//	// Write to local state (isolated, not visible to other steps)
+//	step.State().Local().Set("my-data", value)
+//
+//	// Write to global state (shared across all steps)
+//	step.State().Global().Set("shared-config", config)
+//
+//	// Read from local namespace
+//	val, ok := step.State().Local().Get("key")
+//
+//	// Read from global namespace
+//	val, ok := step.State().Global().Get("shared-config")
+//
+//	// Custom namespace
+//	step.State().WithNamespace("custom").Set("key", value)
+//
+// Implementation:
+//
+// SyncNamespacedStateBag is the primary implementation.
+type NamespacedStateBag interface {
+	// Local returns a view of the local namespace (step-private state).
+	// Operations on the returned StateBag affect only the local namespace.
+	Local() StateBag
+
+	// Global returns a view of the global namespace (workflow-shared state).
+	// Operations on the returned StateBag affect only the global namespace.
+	Global() StateBag
+
+	// WithNamespace returns a view of a custom namespace.
+	// Operations on the returned StateBag affect only the specified namespace.
+	// Custom namespaces are isolated from local and global namespaces.
+	WithNamespace(name string) StateBag
+
+	// Clone creates a deep copy of the NamespacedStateBag including all namespaces.
+	// This clones the local, global, and all custom namespaces.
+	Clone() (NamespacedStateBag, error)
+
+	// Merge merges another NamespacedStateBag into this one.
+	// It merges local, global, and custom namespaces separately:
+	// - Local namespaces are merged
+	// - Global namespaces are merged
+	// - Custom namespaces are merged individually by name
+	//   - If a custom namespace exists in both, they are merged
+	//   - If a custom namespace only exists in other, it is added
+	Merge(other NamespacedStateBag) NamespacedStateBag
 }
 
 type Workflow interface {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,195 @@
+# Automa Documentation
+
+Welcome to the automa workflow orchestration framework documentation.
+
+## Table of Contents
+
+- [Architecture](architecture.md) - Framework design and components
+- [Developer Guide](developer-guide.md) - Development, testing, and contribution guidelines  
+- [Usage Examples](usage-examples.md) - Practical examples and best practices
+- [State Preservation](state-preservation.md) - Memory optimization and configuration
+- [Thread Safety Tests](thread-safety-tests.md) - Concurrency testing details
+
+## Quick Start
+
+### Installation
+
+```bash
+go get github.com/automa-saga/automa
+```
+
+### Basic Usage
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "github.com/automa-saga/automa"
+)
+
+func main() {
+    // Define a simple step
+    step := automa.NewStepBuilder().
+        WithId("hello-step").
+        WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+            fmt.Println("Hello from automa!")
+            return automa.SuccessReport(stp)
+        }).
+        Build()
+
+    // Build a workflow
+    wf, _ := automa.NewWorkflowBuilder().
+        WithId("hello-workflow").
+        Steps(step).
+        Build()
+
+    // Execute the workflow
+    report := wf.Execute(context.Background())
+    
+    if report.IsSuccess() {
+        fmt.Println("Workflow completed successfully!")
+    }
+}
+```
+
+## Documentation Overview
+
+### For Users
+
+Start here if you want to use automa in your projects:
+
+1. **[Usage Examples](usage-examples.md)** - Learn by example
+   - Basic workflows
+   - Error handling modes
+   - State management
+   - Rollback scenarios
+   - Real-world examples
+
+2. **[State Preservation](state-preservation.md)** - Optimize memory usage
+   - When to enable/disable state preservation
+   - Memory impact analysis
+   - Configuration guide
+
+3. **[Architecture](architecture.md)** - Understand how it works
+   - Core components
+   - Execution modes
+   - State management design
+   - Thread safety model
+
+### For Contributors
+
+Start here if you want to contribute to automa:
+
+1. **[Developer Guide](developer-guide.md)** - Development workflow
+   - Setup instructions
+   - Testing guidelines
+   - Code style requirements
+   - Contribution process
+
+2. **[Architecture](architecture.md)** - Understand the design
+   - Design principles
+   - Extension points
+   - Performance characteristics
+
+3. **[Thread Safety Tests](thread-safety-tests.md)** - Concurrency testing
+   - Test strategy
+   - Race conditions found and fixed
+   - Running concurrency tests
+
+## Core Concepts
+
+### Step
+
+The fundamental unit of work. A step can:
+- Execute business logic
+- Prepare context and state
+- Rollback changes if needed
+- Report execution status
+
+### Workflow
+
+A composite step that orchestrates multiple steps in sequence. Features:
+- Sequential execution
+- Configurable error handling (StopOnError, ContinueOnError, RollbackOnError)
+- State isolation for sub-workflows
+- Async callback support
+
+### State Management
+
+Namespaced state bags provide flexible state isolation:
+- **Local**: Step-private state
+- **Global**: Workflow-shared state
+- **Custom**: Named namespaces for specific use cases
+
+### Report
+
+Structured execution results with:
+- Status (Success, Failure, Skipped)
+- Error information
+- Timing metadata
+- Hierarchical step reports
+
+## Execution Modes
+
+### RollbackOnError (Default)
+
+Safest mode - rolls back all executed steps when one fails:
+
+```
+Step1 ✓ → Step2 ✓ → Step3 ✗ → [ROLLBACK]
+                               ↓
+Step2 Rollback ✓ ← Step1 Rollback ✓
+```
+
+### StopOnError
+
+Stops immediately on first failure, no rollback:
+
+```
+Step1 ✓ → Step2 ✗ → [STOP]
+          Step3 (not executed)
+```
+
+### ContinueOnError
+
+Best-effort mode - continues despite failures:
+
+```
+Step1 ✓ → Step2 ✗ → Step3 ✓ → [COMPLETE]
+```
+
+## Key Features
+
+✅ **Composable** - Workflows are steps, enabling nesting  
+✅ **Type-safe** - Fluent builder API with compile-time checks  
+✅ **Thread-safe** - Concurrent-safe state management  
+✅ **Flexible** - Multiple execution and rollback modes  
+✅ **Observable** - Structured reports with rich metadata  
+✅ **Testable** - Clean interfaces and dependency injection  
+✅ **Memory-efficient** - Optional state preservation  
+✅ **Well-documented** - Comprehensive documentation and examples  
+
+## Common Use Cases
+
+- **Infrastructure automation** - Server provisioning, configuration management
+- **Database migrations** - Schema changes with rollback support
+- **Deployment pipelines** - Multi-environment deployments
+- **Data processing** - ETL workflows with error handling
+- **Test automation** - Setup/teardown with cleanup
+- **Workflow orchestration** - Complex multi-step processes
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/automa-saga/automa/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/automa-saga/automa/discussions)
+- **Examples**: See `examples/` directory in the repository
+
+## License
+
+See LICENSE file in the repository root.
+
+## Contributing
+
+We welcome contributions! See [Developer Guide](developer-guide.md) for details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,7 +133,7 @@ Structured execution results with:
 
 ## Execution Modes
 
-### RollbackOnError (Default)
+### RollbackOnError 
 
 Safest mode - rolls back all executed steps when one fails:
 
@@ -143,7 +143,7 @@ Step1 ✓ → Step2 ✓ → Step3 ✗ → [ROLLBACK]
 Step2 Rollback ✓ ← Step1 Rollback ✓
 ```
 
-### StopOnError
+### StopOnError (Default)
 
 Stops immediately on first failure, no rollback:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,7 +187,7 @@ Step1 ✓ → Step2 ✗ → Step3 ✓ → Step4 ✗ → [COMPLETE]
 
 ### RollbackOnError (Default)
 
-Rolls back all previously executed steps when a step fails, then stops.
+Rolls back all previously executed steps when a step fails, then stops. This mode must be explicitly configured; the default execution mode is **StopOnError**.
 
 ```
 Step1 ✓ → Step2 ✓ → Step3 ✗ → [ROLLBACK]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,512 @@
+# Automa Architecture
+
+This document describes the architecture and design principles of the automa workflow orchestration framework.
+
+## Overview
+
+Automa is a workflow orchestration framework designed for composing and executing automated steps with structured reporting, error handling, and rollback support. It follows a **builder pattern** for construction and provides **flexible execution modes** for different error handling strategies.
+
+## Core Components
+
+### 1. Step
+
+The fundamental unit of work in automa.
+
+```
+┌─────────────────────────────────────────┐
+│              Step Interface             │
+├─────────────────────────────────────────┤
+│  + Id() string                          │
+│  + Prepare(ctx) (context, error)        │
+│  + Execute(ctx) *Report                 │
+│  + Rollback(ctx) *Report                │
+│  + State() NamespacedStateBag           │
+│  + WithState(s) Step                    │
+├─────────────────────────────────────────┤
+│  Implementations:                       │
+│  - defaultStep (ordinary step)          │
+│  - workflow (composite step)            │
+└─────────────────────────────────────────┘
+```
+
+**Responsibilities:**
+- Execute business logic
+- Manage step-specific state
+- Provide rollback capability
+- Report execution status
+
+**Lifecycle:**
+1. **Prepare**: Initialize context and state
+2. **Execute**: Perform the actual work
+3. **Rollback**: Undo changes if needed
+
+### 2. Workflow
+
+A composite step that orchestrates multiple steps in sequence.
+
+```
+┌────────────────────────────────────────────────┐
+│              Workflow                          │
+├────────────────────────────────────────────────┤
+│  - id: string                                  │
+│  - steps: []Step                               │
+│  - state: NamespacedStateBag                   │
+│  - executionMode: TypeMode                     │
+│  - rollbackMode: TypeMode                      │
+│  - preserveStatesForRollback: bool             │
+│  - lastExecutionStates: map[string]NSB         │
+├────────────────────────────────────────────────┤
+│  + Execute(ctx) *Report                        │
+│  + Rollback(ctx) *Report                       │
+│  + State() NamespacedStateBag                  │
+├────────────────────────────────────────────────┤
+│  Callbacks:                                    │
+│  - prepare: PrepareFunc                        │
+│  - onCompletion: OnCompletionFunc              │
+│  - onFailure: OnFailureFunc                    │
+│  - rollback: RollbackFunc                      │
+└────────────────────────────────────────────────┘
+```
+
+**Key Features:**
+- Sequential execution of steps
+- Configurable error handling (StopOnError, ContinueOnError, RollbackOnError)
+- State isolation for sub-workflows
+- State snapshot preservation for rollback
+- Async callbacks support
+
+### 3. State Management
+
+Automa uses a **namespaced state bag** design for flexible state management.
+
+```
+┌─────────────────────────────────────────────────┐
+│        NamespacedStateBag Interface             │
+├─────────────────────────────────────────────────┤
+│  + Local() StateBag                             │
+│  + Global() StateBag                            │
+│  + WithNamespace(name) StateBag                 │
+│  + Clone() (NamespacedStateBag, error)          │
+│  + Merge(other) (NamespacedStateBag, error)     │
+└─────────────────────────────────────────────────┘
+                        │
+                        │ implements
+                        ▼
+┌─────────────────────────────────────────────────┐
+│       SyncNamespacedStateBag                    │
+├─────────────────────────────────────────────────┤
+│  - local: StateBag                              │
+│  - global: StateBag                             │
+│  - custom: map[string]StateBag                  │
+│  - mu: sync.RWMutex                             │
+│  - localOnce: sync.Once                         │
+├─────────────────────────────────────────────────┤
+│  Thread-safe implementation                     │
+│  Lazy initialization of local namespace         │
+└─────────────────────────────────────────────────┘
+```
+
+**Namespace Types:**
+
+1. **Local**: Step-private state (isolated, not visible to other steps)
+2. **Global**: Workflow-shared state (visible to all steps)
+3. **Custom**: Named namespaces for specific use cases
+
+**State Flow:**
+
+```
+Workflow Execution:
+┌────────────┐
+│  Workflow  │ Global State (shared)
+└─────┬──────┘
+      │
+      ├─────► Step1 ──► Local State (isolated)
+      │                 Global State (shared reference)
+      │
+      ├─────► Step2 ──► Local State (isolated)
+      │                 Global State (shared reference)
+      │
+      └─────► Sub-Workflow ──► Global State (cloned)
+                               Local State (isolated)
+```
+
+### 4. Report
+
+Structured execution results with metadata and error information.
+
+```
+┌─────────────────────────────────────────┐
+│              Report                     │
+├─────────────────────────────────────────┤
+│  + Id: string                           │
+│  + Status: TypeStatus                   │
+│  + Action: TypeAction                   │
+│  + StartTime: time.Time                 │
+│  + EndTime: time.Time                   │
+│  + Duration: time.Duration              │
+│  + Err: error                           │
+│  + Meta: StateBag                       │
+│  + Steps: []*Report                     │
+│  + Rollback: *Report                    │
+│  + WorkflowId: string                   │
+│  + StepId: string                       │
+└─────────────────────────────────────────┘
+```
+
+**Report Hierarchy:**
+
+```
+Workflow Report
+├── Step1 Report
+│   └── Rollback Report (if rolled back)
+├── Step2 Report
+│   └── Rollback Report (if rolled back)
+└── Sub-Workflow Report
+    ├── Sub-Step1 Report
+    └── Sub-Step2 Report
+```
+
+## Execution Modes
+
+### StopOnError
+
+Stops execution immediately when a step fails. No rollback is performed.
+
+```
+Step1 ✓ → Step2 ✗ → [STOP]
+          Step3 (not executed)
+```
+
+### ContinueOnError
+
+Continues executing remaining steps even if one fails.
+
+```
+Step1 ✓ → Step2 ✗ → Step3 ✓ → Step4 ✗ → [COMPLETE]
+```
+
+### RollbackOnError (Default)
+
+Rolls back all previously executed steps when a step fails, then stops.
+
+```
+Step1 ✓ → Step2 ✓ → Step3 ✗ → [ROLLBACK]
+                               ↓
+Step2 Rollback ✓ ← Step1 Rollback ✓
+```
+
+**Rollback includes failed step:**
+- Failed step's `Rollback()` is called to clean up partial work
+- All successfully executed steps are rolled back in reverse order
+- Each step receives its state snapshot from execution time
+
+## State Snapshot Design
+
+### With State Preservation Enabled (Default)
+
+```
+Execution Phase:
+Step1.Execute() → Clone(Step1.State()) → stepStates["step1"]
+Step2.Execute() → Clone(Step2.State()) → stepStates["step2"]
+Step3.Execute() → Clone(Step3.State()) → stepStates["step3"]
+
+Rollback Phase:
+Step3.WithState(stepStates["step3"]) → Step3.Rollback()
+Step2.WithState(stepStates["step2"]) → Step2.Rollback()
+Step1.WithState(stepStates["step1"]) → Step1.Rollback()
+```
+
+**Benefits:**
+- Deterministic rollback (each step sees its execution-time state)
+- Immutable snapshots (later steps can't mutate earlier snapshots)
+- Safe for complex workflows with state mutations
+
+**Cost:**
+- Memory: O(steps × state_size)
+- CPU: Clone overhead for each step
+
+### With State Preservation Disabled
+
+```
+Execution Phase:
+Step1.Execute() → [no snapshot]
+Step2.Execute() → [no snapshot]
+Step3.Execute() → [no snapshot]
+
+Rollback Phase:
+Step3.WithState(currentWorkflowState) → Step3.Rollback()
+Step2.WithState(currentWorkflowState) → Step2.Rollback()
+Step1.WithState(currentWorkflowState) → Step1.Rollback()
+```
+
+**Benefits:**
+- Zero memory overhead
+- No clone CPU cost
+
+**Tradeoffs:**
+- Rollback uses current state (may have been mutated)
+- Less deterministic for complex workflows
+
+## Thread Safety
+
+### SyncNamespacedStateBag
+
+Thread-safe via `sync.RWMutex`:
+
+- **Read operations** (`Local()`, `Global()`, `WithNamespace()`): `RLock`
+- **Write operations** (`Merge()`, custom namespace creation): `Lock`
+- **Clone operations**: `RLock` (reads all fields atomically)
+- **Lazy initialization**: `sync.Once` (ensures single init)
+
+### Workflow Execution
+
+**Not thread-safe** - designed for single-execution per instance:
+
+- Each workflow instance is executed by **one goroutine**
+- Steps execute **sequentially** (not concurrently)
+- Async callbacks operate on **cloned reports** (safe)
+
+**Best Practice**: Create new workflow instance for concurrent executions
+
+## Builder Pattern
+
+Automa uses builders for fluent API construction:
+
+```go
+// StepBuilder
+step := automa.NewStepBuilder().
+    WithId("my-step").
+    WithExecute(executeFunc).
+    WithRollback(rollbackFunc).
+    Build()
+
+// WorkflowBuilder
+wf := automa.NewWorkflowBuilder().
+    WithId("my-workflow").
+    WithExecutionMode(automa.RollbackOnError).
+    WithStatePreservation(true).
+    Steps(step1, step2, step3).
+    Build()
+```
+
+**Benefits:**
+- Fluent, readable API
+- Compile-time type safety
+- Validation before construction
+- Immutable after build
+
+## Error Handling Strategy
+
+### Errorx Integration
+
+Automa uses `github.com/joomcode/errorx` for structured errors:
+
+```go
+var (
+    StepExecutionError = errorx.NewType(namespace, "StepExecutionError")
+    IllegalArgument    = errorx.NewType(namespace, "IllegalArgument")
+    IllegalState       = errorx.NewType(namespace, "IllegalState")
+)
+```
+
+**Benefits:**
+- Error types with properties
+- Stack traces
+- Error wrapping and context
+
+### Error Propagation
+
+```
+Step Error → Report.Err → Workflow Report.Err
+                        ↓
+                  OnFailure Callback
+                        ↓
+                  Return to Caller
+```
+
+## Design Principles
+
+### 1. Composition Over Inheritance
+
+Workflows are steps, enabling nested composition:
+
+```go
+subWorkflow := NewWorkflowBuilder().Steps(s1, s2).Build()
+mainWorkflow := NewWorkflowBuilder().Steps(s3, subWorkflow, s4).Build()
+```
+
+### 2. Explicit State Management
+
+State is explicitly passed and managed:
+
+- Steps don't implicitly share state
+- Namespaces provide clear isolation/sharing semantics
+- Sub-workflows get cloned state (cannot mutate parent)
+
+### 3. Fail-Safe Defaults
+
+- State preservation: **enabled** (safer)
+- Execution mode: **RollbackOnError** (safer)
+- Rollback mode: **ContinueOnError** (complete rollback)
+
+### 4. Extensibility
+
+- Custom steps via `Step` interface
+- Custom state bags via `StateBag` interface
+- Custom error types via `errorx`
+- Callbacks for custom behavior
+
+## Memory Model
+
+### Workflow Instance
+
+```
+Workflow (heap-allocated)
+├── State: NamespacedStateBag (shared reference)
+│   ├── Local: StateBag (lazy-allocated)
+│   ├── Global: StateBag (heap-allocated)
+│   └── Custom: map[string]StateBag (heap-allocated)
+├── Steps: []Step (slice of interfaces)
+└── lastExecutionStates: map[string]NamespacedStateBag
+    └── [step-id]: NamespacedStateBag (cloned snapshots)
+```
+
+**Memory Growth:**
+
+- **Without state preservation**: O(1) - constant overhead
+- **With state preservation**: O(steps × state_size) - linear growth
+
+### Garbage Collection
+
+Workflow instances are GC'd when:
+
+1. No references remain
+2. `lastExecutionStates` can be GC'd
+3. Report references are released
+
+**Long-running workflows:** Consider disabling state preservation if memory is constrained.
+
+## Concurrency Model
+
+### Sequential Execution
+
+```
+┌──────────┐
+│  Caller  │
+└────┬─────┘
+     │
+     ▼
+┌──────────────┐
+│  Workflow    │ (single goroutine)
+│  Execute()   │
+└────┬─────────┘
+     │
+     ├──► Step1.Execute() (sequential)
+     │
+     ├──► Step2.Execute() (sequential)
+     │
+     └──► Step3.Execute() (sequential)
+```
+
+### Async Callbacks (Optional)
+
+```
+Step.Execute() completes
+     │
+     ├──► OnCompletion(cloned_report) ← async goroutine
+     │
+     └──► Continue to next step (main goroutine)
+```
+
+**Enabled via:** `WithAsyncCallbacks(true)`
+
+## Performance Characteristics
+
+| Operation | Time Complexity | Space Complexity |
+|-----------|----------------|------------------|
+| Execute (n steps) | O(n) | O(n) with preservation, O(1) without |
+| Rollback (n steps) | O(n) | O(1) |
+| State Clone | O(state_size) | O(state_size) |
+| State Merge | O(keys) | O(keys) |
+| Report Generation | O(1) | O(1) |
+
+## Extension Points
+
+### Custom Steps
+
+```go
+type MyCustomStep struct {
+    id string
+    state NamespacedStateBag
+}
+
+func (s *MyCustomStep) Id() string { return s.id }
+func (s *MyCustomStep) Execute(ctx context.Context) *Report { /* custom logic */ }
+// ... implement other Step methods
+```
+
+### Custom State Bags
+
+```go
+type MyStateBag struct {
+    // custom implementation
+}
+
+func (s *MyStateBag) Get(key Key) (interface{}, bool) { /* ... */ }
+// ... implement other StateBag methods
+```
+
+### Custom Reporters
+
+Use `Meta` field in reports to attach custom metadata:
+
+```go
+report := automa.SuccessReport(step,
+    automa.WithMetadata(map[string]string{
+        "custom_metric": "value",
+        "trace_id": "abc123",
+    }))
+```
+
+## Best Practices
+
+1. **Use namespaced state wisely**
+   - Local for step-private data
+   - Global for shared configuration
+   - Custom for domain-specific isolation
+
+2. **Enable state preservation for critical workflows**
+   - Ensures deterministic rollback
+   - Acceptable overhead for most workflows
+
+3. **Disable state preservation for high-volume workflows**
+   - Reduces memory pressure
+   - Trade determinism for performance
+
+4. **Handle errors in steps**
+   - Return structured `Report` objects
+   - Use `errorx` for rich error context
+   - Don't panic unless unrecoverable
+
+5. **Keep workflow instances short-lived**
+   - Create per-execution, don't reuse
+   - Avoids state pollution
+   - Enables garbage collection
+
+6. **Test rollback logic**
+   - Verify idempotency
+   - Check partial execution cleanup
+   - Validate state restoration
+
+## Future Enhancements
+
+Potential areas for extension:
+
+- [ ] Parallel step execution (fan-out/fan-in)
+- [ ] Conditional step execution (skip based on conditions)
+- [ ] Step retry mechanisms with backoff
+- [ ] Workflow pause/resume capabilities
+- [ ] Event-driven step triggers
+- [ ] Workflow versioning and migration
+- [ ] Distributed workflow execution
+- [ ] Workflow visualization and debugging tools

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,561 @@
+# Developer Guide
+
+Welcome to the automa developer guide. This document helps you understand how to develop, test, and contribute to the automa framework.
+
+## Table of Contents
+
+1. [Getting Started](#getting-started)
+2. [Project Structure](#project-structure)
+3. [Development Workflow](#development-workflow)
+4. [Testing](#testing)
+5. [Code Style](#code-style)
+6. [Contributing](#contributing)
+7. [Release Process](#release-process)
+
+## Getting Started
+
+### Prerequisites
+
+- **Go 1.25.0+** (check with `go version`)
+- **golangci-lint** (for linting)
+- **git** (for version control)
+
+### Initial Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/automa-saga/automa.git
+cd automa
+
+# Install dependencies
+go mod tidy
+
+# Verify setup
+go build ./...
+go test ./...
+```
+
+### Install Development Tools
+
+```bash
+# Install golangci-lint
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+# Verify installation
+golangci-lint --version
+```
+
+## Project Structure
+
+```
+automa/
+├── automa.go                    # Core interfaces and types
+├── step_*.go                    # Step implementations
+├── workflow_*.go                # Workflow implementations
+├── state_*.go                   # State management
+├── report_*.go                  # Report types
+├── errors.go                    # Error definitions
+├── type_*.go                    # Type enums (Mode, Status, Action)
+├── runtime_value.go             # Runtime value types
+├── registry.go                  # Builder registry
+│
+├── *_test.go                    # Unit tests (co-located)
+│
+├── automa_steps/                # Built-in step implementations
+│   ├── step_bash.go
+│   └── step_bash_test.go
+│
+├── examples/                    # Example usage
+│   └── setup_local/
+│
+├── docs/                        # Documentation
+│   ├── architecture.md
+│   ├── developer-guide.md
+│   ├── usage-examples.md
+│   ├── state-preservation.md
+│   └── thread-safety-tests.md
+│
+├── vendor/                      # Vendored dependencies
+├── go.mod                       # Go module definition
+├── go.sum                       # Go module checksums
+├── README.md                    # Project overview
+├── LICENSE                      # License file
+├── Taskfile.yaml                # Task runner configuration
+└── .golangci.yml                # Linter configuration
+```
+
+## Development Workflow
+
+### Making Changes
+
+1. **Create a feature branch**
+
+   ```bash
+   git checkout -b feature/my-feature
+   ```
+
+2. **Make your changes**
+
+   - Follow Go idioms and best practices
+   - Write tests for new functionality
+   - Update documentation as needed
+
+3. **Run tests locally**
+
+   ```bash
+   go test ./...
+   go test ./... -race  # with race detector
+   ```
+
+4. **Run linter**
+
+   ```bash
+   golangci-lint run
+   ```
+
+5. **Commit your changes**
+
+   ```bash
+   git add .
+   git commit -m "feat: add new feature description"
+   ```
+
+### Commit Message Convention
+
+Follow conventional commits format:
+
+- `feat:` New feature
+- `fix:` Bug fix
+- `docs:` Documentation changes
+- `test:` Test additions or changes
+- `refactor:` Code refactoring
+- `perf:` Performance improvements
+- `chore:` Build/tooling changes
+
+Example:
+```
+feat: add state preservation configuration
+
+- Add WithStatePreservation() to WorkflowBuilder
+- Add preserveStatesForRollback field to workflow
+- Update documentation
+```
+
+## Testing
+
+### Running Tests
+
+```bash
+# All tests
+go test ./...
+
+# Verbose output
+go test -v ./...
+
+# Specific package
+go test -v ./automa_steps
+
+# Specific test
+go test -v -run TestWorkflow_Execute
+
+# With race detector (important!)
+go test ./... -race
+
+# With coverage
+go test ./... -cover
+
+# Generate coverage report
+go test ./... -coverprofile=cover.out
+go tool cover -html=cover.out -o coverage.html
+```
+
+### Writing Tests
+
+#### Unit Tests
+
+Co-locate tests with source files:
+
+```go
+// workflow_test.go
+package automa
+
+import (
+    "testing"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestWorkflow_Execute_Success(t *testing.T) {
+    // Arrange
+    step := NewStepBuilder().
+        WithId("test-step").
+        WithExecute(func(ctx context.Context, stp Step) *Report {
+            return SuccessReport(stp)
+        }).
+        Build()
+    
+    wf := NewWorkflowBuilder().
+        WithId("test-workflow").
+        Steps(step).
+        Build()
+    
+    // Act
+    report := wf.Execute(context.Background())
+    
+    // Assert
+    assert.True(t, report.IsSuccess())
+    assert.Equal(t, "test-workflow", report.WorkflowId)
+}
+```
+
+#### Table-Driven Tests
+
+For testing multiple scenarios:
+
+```go
+func TestTypeMode_String(t *testing.T) {
+    tests := []struct {
+        name     string
+        mode     TypeMode
+        expected string
+    }{
+        {"StopOnError", StopOnError, "StopOnError"},
+        {"ContinueOnError", ContinueOnError, "ContinueOnError"},
+        {"RollbackOnError", RollbackOnError, "RollbackOnError"},
+    }
+    
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            assert.Equal(t, tt.expected, tt.mode.String())
+        })
+    }
+}
+```
+
+#### Concurrency Tests
+
+For thread-safety verification:
+
+```go
+func TestSyncStateBag_Concurrent(t *testing.T) {
+    bag := &SyncStateBag{}
+    const goroutines = 100
+    
+    var wg sync.WaitGroup
+    wg.Add(goroutines)
+    
+    for i := 0; i < goroutines; i++ {
+        go func(id int) {
+            defer wg.Done()
+            bag.Set(Key("key"), id)
+            _, _ = bag.Get(Key("key"))
+        }(i)
+    }
+    
+    wg.Wait()
+    // No assertions needed - race detector will catch issues
+}
+```
+
+### Test Coverage Goals
+
+- **Minimum**: 80% coverage for new code
+- **Target**: 90%+ coverage for core packages
+- **Focus areas**:
+  - Error paths
+  - Edge cases
+  - Concurrency scenarios
+
+### Running Specific Test Suites
+
+```bash
+# State management tests
+go test -v -run TestSync
+
+# Workflow tests
+go test -v -run TestWorkflow
+
+# Concurrency tests with race detector
+go test -v -run Concurrent -race
+
+# Builder tests
+go test -v -run TestBuilder
+```
+
+## Code Style
+
+### Go Formatting
+
+Always run `gofmt` before committing:
+
+```bash
+# Format all files
+gofmt -w .
+
+# Check formatting
+gofmt -l .
+```
+
+### Linting
+
+The project uses `golangci-lint` with custom configuration (`.golangci.yml`):
+
+```bash
+# Run all linters
+golangci-lint run
+
+# Run specific linters
+golangci-lint run --disable-all --enable=errcheck,govet
+
+# Fix auto-fixable issues
+golangci-lint run --fix
+```
+
+### Naming Conventions
+
+- **Interfaces**: Describe capability (e.g., `Step`, `StateBag`, `Builder`)
+- **Implementations**: Use concrete names (e.g., `defaultStep`, `SyncStateBag`)
+- **Builders**: Suffix with `Builder` (e.g., `StepBuilder`, `WorkflowBuilder`)
+- **Tests**: Prefix with `Test`, use descriptive names (e.g., `TestWorkflow_Execute_RollbackOnError`)
+
+### Documentation
+
+#### Package Documentation
+
+Every package should have a package comment:
+
+```go
+// Package automa provides workflow orchestration primitives for composing
+// and executing Steps with structured reporting, error handling and rollback support.
+package automa
+```
+
+#### Function/Method Documentation
+
+Document all exported functions:
+
+```go
+// Execute runs the workflow by executing each step in sequence.
+//
+// Execution behavior respects `w.executionMode`:
+//   - `StopOnError`: Stop immediately when a step fails, no rollback
+//   - `ContinueOnError`: Continue executing remaining steps even if one fails
+//   - `RollbackOnError`: Rollback the failed step and all previously executed steps, then stop
+//
+// Returns a Report containing execution status and step-level reports.
+func (w *workflow) Execute(ctx context.Context) *Report {
+    // ...
+}
+```
+
+#### Type Documentation
+
+Document all exported types:
+
+```go
+// TypeMode defines how a workflow or step handles execution errors.
+//
+// Available modes:
+//   - StopOnError: Stop execution immediately on first error
+//   - ContinueOnError: Continue execution despite errors
+//   - RollbackOnError: Rollback executed steps on error
+type TypeMode int
+```
+
+### Error Handling
+
+Use `errorx` for structured errors:
+
+```go
+// Define error types
+var (
+    StepExecutionError = errorx.NewType(namespace, "StepExecutionError")
+)
+
+// Create errors with context
+return StepExecutionError.
+    Wrap(err, "workflow %q step %q failed", w.id, step.Id()).
+    WithProperty(StepIdProperty, step.Id())
+```
+
+## Contributing
+
+### Pull Request Process
+
+1. **Fork the repository**
+2. **Create a feature branch**
+3. **Make your changes**
+4. **Add tests**
+5. **Update documentation**
+6. **Run full test suite + linter**
+7. **Submit PR with clear description**
+
+### PR Checklist
+
+- [ ] Tests added for new functionality
+- [ ] All tests pass (`go test ./...`)
+- [ ] Race detector passes (`go test ./... -race`)
+- [ ] Linter passes (`golangci-lint run`)
+- [ ] Documentation updated
+- [ ] CHANGELOG.md updated (if applicable)
+- [ ] Commit messages follow convention
+
+### Code Review Guidelines
+
+**For Authors:**
+- Keep PRs focused and small
+- Provide clear description and context
+- Respond to feedback promptly
+- Run tests locally before submitting
+
+**For Reviewers:**
+- Be constructive and specific
+- Focus on design, correctness, and maintainability
+- Suggest improvements, don't demand perfection
+- Approve when ready, request changes when needed
+
+## Release Process
+
+### Versioning
+
+Follow [Semantic Versioning 2.0.0](https://semver.org/):
+
+- **MAJOR**: Incompatible API changes
+- **MINOR**: Backward-compatible functionality additions
+- **PATCH**: Backward-compatible bug fixes
+
+### Creating a Release
+
+1. **Update version**
+
+   ```bash
+   # Update go.mod if needed
+   # Update CHANGELOG.md
+   ```
+
+2. **Tag the release**
+
+   ```bash
+   git tag -a v1.2.3 -m "Release v1.2.3"
+   git push origin v1.2.3
+   ```
+
+3. **Publish release notes**
+
+   Create GitHub release with:
+   - Version number
+   - Changelog excerpt
+   - Breaking changes (if any)
+   - Migration guide (if needed)
+
+### Deprecation Policy
+
+- Deprecated features remain for at least 2 minor versions
+- Clear migration path provided in documentation
+- Warnings logged when deprecated features are used
+
+## Debugging
+
+### Enabling Logging
+
+Set logger on workflow/step:
+
+```go
+import "github.com/rs/zerolog"
+
+logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
+
+wf := NewWorkflowBuilder().
+    WithId("debug-workflow").
+    WithLogger(logger).
+    Build()
+```
+
+### Common Issues
+
+#### "Step returned nil report"
+
+**Cause**: Step's `Execute()` returned `nil`
+
+**Fix**: Always return a valid `Report`:
+
+```go
+func (s *myStep) Execute(ctx context.Context) *Report {
+    // Do work...
+    return SuccessReport(s)  // or FailureReport(s, ...)
+}
+```
+
+#### Race conditions
+
+**Symptom**: Tests fail with `-race` flag
+
+**Debug**:
+```bash
+go test -race -v -run TestProblematicTest
+```
+
+**Fix**: Use proper synchronization (mutexes, channels, atomic operations)
+
+#### Memory leaks
+
+**Symptom**: Memory grows unbounded
+
+**Debug**:
+```bash
+go test -memprofile=mem.out
+go tool pprof mem.out
+```
+
+**Fix**: Ensure `lastExecutionStates` is released or disable state preservation
+
+## Performance Profiling
+
+### CPU Profiling
+
+```bash
+go test -cpuprofile=cpu.out -bench=.
+go tool pprof cpu.out
+```
+
+### Memory Profiling
+
+```bash
+go test -memprofile=mem.out -bench=.
+go tool pprof mem.out
+```
+
+### Benchmarks
+
+Add benchmarks for performance-critical code:
+
+```go
+func BenchmarkWorkflow_Execute(b *testing.B) {
+    wf := createTestWorkflow()
+    ctx := context.Background()
+    
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        wf.Execute(ctx)
+    }
+}
+```
+
+## Resources
+
+- **Go Documentation**: https://golang.org/doc/
+- **Effective Go**: https://golang.org/doc/effective_go
+- **Go Code Review Comments**: https://github.com/golang/go/wiki/CodeReviewComments
+- **Zerolog**: https://github.com/rs/zerolog
+- **Errorx**: https://github.com/joomcode/errorx
+- **Testify**: https://github.com/stretchr/testify
+
+## Getting Help
+
+- **Issues**: https://github.com/automa-saga/automa/issues
+- **Discussions**: https://github.com/automa-saga/automa/discussions
+- **Documentation**: https://github.com/automa-saga/automa/tree/main/docs
+
+## License
+
+This project is licensed under the terms specified in the LICENSE file.

--- a/docs/state-preservation.md
+++ b/docs/state-preservation.md
@@ -1,0 +1,103 @@
+# State Preservation Configuration
+
+The automa workflow framework supports optional state preservation for rollback scenarios. This feature can be configured to balance between rollback capability and memory usage.
+
+## Default Behavior (State Preservation Enabled)
+
+By default, state preservation is **enabled**. After each step executes, its state is cloned and stored for potential rollback:
+
+```go
+wb := automa.NewWorkflowBuilder().WithId("my-workflow")
+// State preservation is enabled by default
+wb.Steps(step1, step2, step3)
+
+wf, _ := wb.Build()
+report := wf.Execute(ctx)
+
+// Later: Manual rollback is possible using preserved state snapshots
+wf.Rollback(ctx)
+```
+
+## Disabling State Preservation (Memory Optimization)
+
+For workflows that don't need rollback capability or have many steps with large state, you can disable state preservation to reduce memory overhead:
+
+```go
+wb := automa.NewWorkflowBuilder().
+    WithId("my-workflow").
+    WithStatePreservation(false)  // Disable state preservation
+    
+wb.Steps(step1, step2, step3)
+
+wf, _ := wb.Build()
+report := wf.Execute(ctx)
+
+// Note: Manual Rollback() will use current workflow state, not per-step snapshots
+```
+
+## When to Disable State Preservation
+
+Consider disabling state preservation when:
+
+1. **High step count**: Workflows with hundreds of steps (memory grows linearly)
+2. **Large state**: Each step's state contains multi-MB of data
+3. **Long-running workflows**: Workflow instances remain in memory for hours/days
+4. **No rollback needed**: You never call `Rollback()` manually after execution
+5. **Only automatic rollback**: You rely solely on `RollbackOnError` mode during execution (which still works with preservation disabled, using non-cloned state references)
+
+## Memory Impact
+
+### With State Preservation Enabled (Default)
+
+```
+Memory = (number of steps) × (average state size per step) × 2
+         ^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^     ^
+         |                     |                             |
+         Step count            State size                    Clone overhead
+```
+
+Example: 100 steps × 10KB state = ~2MB total
+
+### With State Preservation Disabled
+
+```
+Memory = 0 (no state snapshots stored)
+```
+
+## Rollback Behavior
+
+### State Preservation Enabled
+- Each step's `Rollback()` receives its **exact state snapshot** from when it executed
+- **Deterministic**: Rollback sees the same state regardless of later mutations
+- **Safe**: No risk of rollback operating on stale/mutated state
+
+### State Preservation Disabled
+- Automatic rollback during execution (via `RollbackOnError`) still works but uses **current state references** (not clones)
+- Manual `Rollback()` calls use the **current workflow state**
+- **Risk**: If state is mutated between execution and rollback, rollback may see inconsistent data
+
+## Recommendations
+
+1. **Keep enabled for most workflows** (default behavior is safe)
+2. **Disable only when memory is a concern** and you understand the tradeoffs
+3. **Profile your workflow** to determine actual memory usage before optimizing
+4. **Document the decision** if you disable preservation (so maintainers understand why)
+
+## Example: High-Volume Workflow
+
+```go
+// Workflow with 1000 steps, each storing 100KB of state
+// With preservation: ~200MB memory overhead
+// Without preservation: ~0MB memory overhead
+
+wb := automa.NewWorkflowBuilder().
+    WithId("high-volume-workflow").
+    WithStatePreservation(false).  // Disable to reduce memory
+    WithExecutionMode(automa.StopOnError)  // Don't need rollback anyway
+    
+// ... add 1000 steps ...
+
+wf, _ := wb.Build()
+report := wf.Execute(ctx)
+// No manual rollback needed, so disabled preservation is fine
+```

--- a/state.go
+++ b/state.go
@@ -75,16 +75,16 @@ func (s *SyncStateBag) Clone() (StateBag, error) {
 	return clone, nil
 }
 
-func (s *SyncStateBag) Merge(other StateBag) StateBag {
+func (s *SyncStateBag) Merge(other StateBag) (StateBag, error) {
 	if other == nil {
-		return s
+		return s, nil
 	}
 
 	for k, v := range other.Items() {
 		s.m.Store(k, v)
 	}
 
-	return s
+	return s, nil
 }
 
 func (s *SyncStateBag) Items() map[Key]interface{} {

--- a/state_namespaced.go
+++ b/state_namespaced.go
@@ -1,0 +1,137 @@
+package automa
+
+import (
+	"sync"
+)
+
+// SyncNamespacedStateBag is a thread-safe implementation of NamespacedStateBag.
+// It maintains separate StateBag instances for local, global, and custom namespaces.
+type SyncNamespacedStateBag struct {
+	local  StateBag
+	global StateBag
+	custom map[string]StateBag
+	mu     sync.RWMutex // protects custom map
+}
+
+// NewNamespacedStateBag creates a new SyncNamespacedStateBag with the given local and global bags.
+// If local is nil, a new empty SyncStateBag is created.
+// If global is nil, a new empty SyncStateBag is created.
+func NewNamespacedStateBag(local, global StateBag) *SyncNamespacedStateBag {
+	if global == nil {
+		global = &SyncStateBag{}
+	}
+
+	return &SyncNamespacedStateBag{
+		local:  local, // could be nil, will be lazily initialized
+		global: global,
+		custom: make(map[string]StateBag),
+	}
+}
+
+// Local returns a view of the local namespace.
+func (n *SyncNamespacedStateBag) Local() StateBag {
+	if n.local == nil {
+		n.mu.Lock()
+		if n.local == nil { // double-check locking
+			n.local = &SyncStateBag{}
+		}
+		n.mu.Unlock()
+	}
+	return n.local
+}
+
+// Global returns a view of the global namespace.
+func (n *SyncNamespacedStateBag) Global() StateBag {
+	return n.global
+}
+
+// WithNamespace returns a view of a custom namespace.
+// Custom namespaces are created on-demand if they don't exist.
+func (n *SyncNamespacedStateBag) WithNamespace(name string) StateBag {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	bag, exists := n.custom[name]
+	if !exists {
+		bag = &SyncStateBag{}
+		n.custom[name] = bag
+	}
+
+	return bag
+}
+
+// Clone creates a deep copy of the SyncNamespacedStateBag including all namespaces.
+// This clones the local, global, and all custom namespaces.
+func (n *SyncNamespacedStateBag) Clone() (NamespacedStateBag, error) {
+	if n == nil {
+		return nil, IllegalArgument.New("cannot clone a nil SyncNamespacedStateBag")
+	}
+
+	// Clone local namespace
+	localClone, err := n.Local().Clone() // use Local() to ensure lazy initialization
+	if err != nil {
+		return nil, err
+	}
+
+	// Clone global namespace
+	globalClone, err := n.global.Clone()
+	if err != nil {
+		return nil, err
+	}
+
+	// Clone custom namespaces
+	customClone := make(map[string]StateBag)
+	n.mu.RLock()
+	for name, bag := range n.custom {
+		clonedBag, err := bag.Clone()
+		if err != nil {
+			n.mu.RUnlock()
+			return nil, err
+		}
+		customClone[name] = clonedBag
+	}
+	n.mu.RUnlock()
+
+	return &SyncNamespacedStateBag{
+		local:  localClone,
+		global: globalClone,
+		custom: customClone,
+	}, nil
+}
+
+// Merge merges another NamespacedStateBag into this one and returns itself.
+// It merges local, global, and custom namespaces separately.
+func (n *SyncNamespacedStateBag) Merge(other NamespacedStateBag) NamespacedStateBag {
+	if other == nil {
+		return n
+	}
+
+	// Merge local namespaces
+	n.Local().Merge(other.Local()) // use Local() to ensure lazy initialization
+
+	// Merge global namespaces
+	n.global.Merge(other.Global())
+
+	// Merge custom namespaces
+	if otherSync, ok := other.(*SyncNamespacedStateBag); ok {
+		otherSync.mu.RLock()
+		defer otherSync.mu.RUnlock()
+
+		n.mu.Lock()
+		defer n.mu.Unlock()
+
+		for name, otherBag := range otherSync.custom {
+			if existingBag, exists := n.custom[name]; exists {
+				// Merge with existing custom namespace
+				existingBag.Merge(otherBag)
+			} else {
+				// Add new custom namespace (clone to avoid sharing reference)
+				if clonedBag, err := otherBag.Clone(); err == nil {
+					n.custom[name] = clonedBag
+				}
+			}
+		}
+	}
+
+	return n
+}

--- a/state_namespaced_concurrency_test.go
+++ b/state_namespaced_concurrency_test.go
@@ -1,0 +1,356 @@
+package automa
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncNamespacedStateBag_Concurrent_Local verifies thread-safe access to Local() namespace
+func TestSyncNamespacedStateBag_Concurrent_Local(t *testing.T) {
+	ns := NewNamespacedStateBag(nil, nil)
+	const goroutines = 100
+	const operations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < operations; j++ {
+				// Concurrent writes to local namespace
+				local := ns.Local()
+				local.Set(Key("key"), id)
+
+				// Concurrent reads
+				_, ok := local.Get(Key("key"))
+				assert.True(t, ok)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify state is consistent after concurrent access
+	local := ns.Local()
+	assert.NotNil(t, local)
+	_, ok := local.Get(Key("key"))
+	assert.True(t, ok)
+}
+
+// TestSyncNamespacedStateBag_Concurrent_Global verifies thread-safe access to Global() namespace
+func TestSyncNamespacedStateBag_Concurrent_Global(t *testing.T) {
+	ns := NewNamespacedStateBag(nil, nil)
+	const goroutines = 100
+	const operations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < operations; j++ {
+				// Concurrent writes to global namespace
+				global := ns.Global()
+				global.Set(Key("global-key"), id)
+
+				// Concurrent reads
+				_, ok := global.Get(Key("global-key"))
+				assert.True(t, ok)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify state is consistent after concurrent access
+	global := ns.Global()
+	assert.NotNil(t, global)
+	_, ok := global.Get(Key("global-key"))
+	assert.True(t, ok)
+}
+
+// TestSyncNamespacedStateBag_Concurrent_WithNamespace verifies thread-safe access to custom namespaces
+func TestSyncNamespacedStateBag_Concurrent_WithNamespace(t *testing.T) {
+	ns := NewNamespacedStateBag(nil, nil)
+	const goroutines = 100
+	const operations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < operations; j++ {
+				// Concurrent access to same custom namespace
+				custom := ns.WithNamespace("shared-ns")
+				custom.Set(Key("custom-key"), id)
+
+				// Concurrent reads
+				_, ok := custom.Get(Key("custom-key"))
+				assert.True(t, ok)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify custom namespace exists and is accessible
+	custom := ns.WithNamespace("shared-ns")
+	assert.NotNil(t, custom)
+	_, ok := custom.Get(Key("custom-key"))
+	assert.True(t, ok)
+}
+
+// TestSyncNamespacedStateBag_Concurrent_MultipleNamespaces verifies thread-safe creation of multiple custom namespaces
+func TestSyncNamespacedStateBag_Concurrent_MultipleNamespaces(t *testing.T) {
+	ns := NewNamespacedStateBag(nil, nil)
+	const goroutines = 50
+	const namespacesPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < namespacesPerGoroutine; j++ {
+				// Create unique namespace per goroutine
+				nsName := Key("ns-" + string(rune(id)) + "-" + string(rune(j)))
+				custom := ns.WithNamespace(string(nsName))
+				custom.Set(Key("data"), id)
+
+				// Verify data
+				val, ok := custom.Get(Key("data"))
+				assert.True(t, ok)
+				assert.Equal(t, id, val)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all namespaces were created
+	// We expect goroutines * namespacesPerGoroutine unique namespaces
+	ns.mu.RLock()
+	customCount := len(ns.custom)
+	ns.mu.RUnlock()
+
+	assert.Equal(t, goroutines*namespacesPerGoroutine, customCount)
+}
+
+// TestSyncNamespacedStateBag_Concurrent_Clone verifies thread-safe cloning
+func TestSyncNamespacedStateBag_Concurrent_Clone(t *testing.T) {
+	ns := NewNamespacedStateBag(nil, nil)
+
+	// Populate with data
+	ns.Local().Set("local-key", "local-value")
+	ns.Global().Set("global-key", "global-value")
+	ns.WithNamespace("custom").Set("custom-key", "custom-value")
+
+	const goroutines = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	clones := make([]NamespacedStateBag, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			// Concurrent clones
+			cloned, err := ns.Clone()
+			require.NoError(t, err)
+			clones[id] = cloned
+
+			// Verify cloned data
+			assert.Equal(t, "local-value", cloned.Local().String("local-key"))
+			assert.Equal(t, "global-value", cloned.Global().String("global-key"))
+			assert.Equal(t, "custom-value", cloned.WithNamespace("custom").String("custom-key"))
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all clones are independent
+	for i, cloned := range clones {
+		assert.NotNil(t, cloned, "clone %d should not be nil", i)
+
+		// Modify clone
+		cloned.Local().Set("modified", i)
+
+		// Verify original is not affected
+		_, ok := ns.Local().Get("modified")
+		assert.False(t, ok, "original should not see clone modifications")
+	}
+}
+
+// TestSyncNamespacedStateBag_Concurrent_Merge verifies thread-safe merging
+func TestSyncNamespacedStateBag_Concurrent_Merge(t *testing.T) {
+	ns1 := NewNamespacedStateBag(nil, nil)
+	ns1.Local().Set("key1", "value1")
+	ns1.Global().Set("global1", "gvalue1")
+
+	const goroutines = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+
+			// Create a new state bag to merge
+			other := NewNamespacedStateBag(nil, nil)
+			other.Local().Set(Key("local-"+string(rune(id))), id)
+			other.Global().Set(Key("global-"+string(rune(id))), id)
+
+			// Concurrent merge
+			_, err := ns1.Merge(other)
+			require.NoError(t, err)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify merged data contains original keys
+	assert.Equal(t, "value1", ns1.Local().String("key1"))
+	assert.Equal(t, "gvalue1", ns1.Global().String("global1"))
+}
+
+// TestSyncNamespacedStateBag_Concurrent_MixedOperations verifies thread-safety with mixed operations
+func TestSyncNamespacedStateBag_Concurrent_MixedOperations(t *testing.T) {
+	ns := NewNamespacedStateBag(nil, nil)
+	const goroutines = 50
+	const operations = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 5) // 5 different operation types
+
+	// Concurrent Local() access
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < operations; j++ {
+				ns.Local().Set(Key("local"), id)
+				ns.Local().Get(Key("local"))
+			}
+		}(i)
+	}
+
+	// Concurrent Global() access
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < operations; j++ {
+				ns.Global().Set(Key("global"), id)
+				ns.Global().Get(Key("global"))
+			}
+		}(i)
+	}
+
+	// Concurrent WithNamespace() access
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < operations; j++ {
+				ns.WithNamespace("custom").Set(Key("custom"), id)
+				ns.WithNamespace("custom").Get(Key("custom"))
+			}
+		}(i)
+	}
+
+	// Concurrent Clone()
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < operations; j++ {
+				_, _ = ns.Clone()
+			}
+		}()
+	}
+
+	// Concurrent Merge()
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < operations; j++ {
+				other := NewNamespacedStateBag(nil, nil)
+				other.Local().Set(Key("merge"), id)
+				_, _ = ns.Merge(other)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify state is still accessible after concurrent operations
+	assert.NotNil(t, ns.Local())
+	assert.NotNil(t, ns.Global())
+	assert.NotNil(t, ns.WithNamespace("custom"))
+}
+
+// TestSyncNamespacedStateBag_Concurrent_LocalLazyInit verifies thread-safe lazy initialization of Local()
+func TestSyncNamespacedStateBag_Concurrent_LocalLazyInit(t *testing.T) {
+	// Create without local namespace (nil)
+	ns := NewNamespacedStateBag(nil, nil)
+
+	const goroutines = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			// All goroutines concurrently trigger lazy init
+			local := ns.Local()
+			local.Set(Key("key"), id)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify local was initialized (exactly once is guaranteed by sync.Once)
+	assert.NotNil(t, ns.local)
+
+	// Verify local is accessible and contains data
+	local := ns.Local()
+	_, ok := local.Get(Key("key"))
+	assert.True(t, ok)
+}
+
+// TestSyncNamespacedStateBag_Concurrent_MergeMultipleSources verifies thread-safe merge from multiple sources
+func TestSyncNamespacedStateBag_Concurrent_MergeMultipleSources(t *testing.T) {
+	target := NewNamespacedStateBag(nil, nil)
+	target.Local().Set("target-key", "target-value")
+
+	const sources = 50
+
+	var wg sync.WaitGroup
+	wg.Add(sources)
+
+	for i := 0; i < sources; i++ {
+		go func(id int) {
+			defer wg.Done()
+
+			source := NewNamespacedStateBag(nil, nil)
+			source.Local().Set(Key("source-"+string(rune(id))), id)
+			source.Global().Set(Key("global-"+string(rune(id))), id)
+			source.WithNamespace("custom").Set(Key("custom-"+string(rune(id))), id)
+
+			_, err := target.Merge(source)
+			require.NoError(t, err)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify target still has original key
+	assert.Equal(t, "target-value", target.Local().String("target-key"))
+}

--- a/state_namespaced_test.go
+++ b/state_namespaced_test.go
@@ -185,7 +185,8 @@ func TestNamespacedStateBag_Merge(t *testing.T) {
 		ns2.Local().Set("key2", "value2")
 		ns2.Local().Set("shared-key", "merged")
 
-		result := ns1.Merge(ns2)
+		result, err := ns1.Merge(ns2)
+		require.NoError(t, err)
 
 		// Verify it returns itself
 		assert.Same(t, ns1, result)
@@ -279,7 +280,8 @@ func TestNamespacedStateBag_Merge(t *testing.T) {
 		ns := NewNamespacedStateBag(nil, nil)
 		ns.Local().Set("key", "value")
 
-		result := ns.Merge(nil)
+		result, err := ns.Merge(nil)
+		require.NoError(t, err)
 
 		assert.Same(t, ns, result)
 		assert.Equal(t, "value", ns.Local().String("key"), "original data should be unchanged")

--- a/state_namespaced_test.go
+++ b/state_namespaced_test.go
@@ -673,3 +673,24 @@ func TestNamespacedStateBag_RollbackStateIsolation(t *testing.T) {
 		assert.Equal(t, "step1-data", rollbackValue)
 	})
 }
+
+// Create a mock NamespacedStateBag implementation
+type mockNamespacedStateBag struct{}
+
+func (m *mockNamespacedStateBag) Local() StateBag                    { return &SyncStateBag{} }
+func (m *mockNamespacedStateBag) Global() StateBag                   { return &SyncStateBag{} }
+func (m *mockNamespacedStateBag) WithNamespace(name string) StateBag { return &SyncStateBag{} }
+func (m *mockNamespacedStateBag) Clone() (NamespacedStateBag, error) { return m, nil }
+func (m *mockNamespacedStateBag) Merge(other NamespacedStateBag) (NamespacedStateBag, error) {
+	return m, nil
+}
+
+func TestSyncNamespacedStateBag_Merge_TypeCheck(t *testing.T) {
+	ns := NewNamespacedStateBag(nil, nil)
+	mock := &mockNamespacedStateBag{}
+
+	// ✅ Should return error for non-*SyncNamespacedStateBag
+	_, err := ns.Merge(mock)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be *SyncNamespacedStateBag")
+}

--- a/state_namespaced_test.go
+++ b/state_namespaced_test.go
@@ -1,0 +1,673 @@
+package automa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamespacedStateBag_BasicOperations(t *testing.T) {
+	t.Run("local and global isolation", func(t *testing.T) {
+		ns := NewNamespacedStateBag(nil, nil)
+
+		// Write to local
+		ns.Local().Set("local-key", "local-value")
+
+		// Write to global
+		ns.Global().Set("global-key", "global-value")
+
+		// Verify local has only local key
+		val, ok := ns.Local().Get("local-key")
+		assert.True(t, ok)
+		assert.Equal(t, "local-value", val)
+
+		_, ok = ns.Local().Get("global-key")
+		assert.False(t, ok, "local should not see global-only keys")
+
+		// Verify global has only global key
+		val, ok = ns.Global().Get("global-key")
+		assert.True(t, ok)
+		assert.Equal(t, "global-value", val)
+
+		_, ok = ns.Global().Get("local-key")
+		assert.False(t, ok, "global should not see local-only keys")
+	})
+
+	t.Run("custom namespace isolation", func(t *testing.T) {
+		ns := NewNamespacedStateBag(nil, nil)
+
+		ns.WithNamespace("ns1").Set("key", "value1")
+		ns.WithNamespace("ns2").Set("key", "value2")
+
+		val1 := ns.WithNamespace("ns1").String("key")
+		val2 := ns.WithNamespace("ns2").String("key")
+
+		assert.Equal(t, "value1", val1)
+		assert.Equal(t, "value2", val2)
+	})
+
+	t.Run("clone creates independent copy", func(t *testing.T) {
+		original := NewNamespacedStateBag(nil, nil)
+
+		// Set values in all namespaces
+		original.Local().Set("local-key", "local-value")
+		original.Global().Set("global-key", "global-value")
+		original.WithNamespace("custom").Set("custom-key", "custom-value")
+
+		// Clone the state
+		cloned, err := original.Clone()
+		require.NoError(t, err)
+		require.NotNil(t, cloned)
+
+		// Verify cloned values match original
+		assert.Equal(t, "local-value", cloned.Local().String("local-key"))
+		assert.Equal(t, "global-value", cloned.Global().String("global-key"))
+		assert.Equal(t, "custom-value", cloned.WithNamespace("custom").String("custom-key"))
+
+		// Modify original
+		original.Local().Set("local-key", "modified-local")
+		original.Global().Set("global-key", "modified-global")
+		original.WithNamespace("custom").Set("custom-key", "modified-custom")
+
+		// Verify clone is not affected
+		assert.Equal(t, "local-value", cloned.Local().String("local-key"))
+		assert.Equal(t, "global-value", cloned.Global().String("global-key"))
+		assert.Equal(t, "custom-value", cloned.WithNamespace("custom").String("custom-key"))
+
+		// Modify clone
+		cloned.Local().Set("new-key", "new-value")
+
+		// Verify original is not affected
+		_, ok := original.Local().Get("new-key")
+		assert.False(t, ok, "original should not see new keys in clone")
+	})
+}
+
+func TestWorkflow_NamespacedState_StepIsolation(t *testing.T) {
+	t.Run("steps have isolated local state", func(t *testing.T) {
+		wb := NewWorkflowBuilder().WithId("test-workflow")
+
+		// Step 1: writes to local state
+		step1 := NewStepBuilder().WithId("step1").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				stp.State().Local().Set("my-key", "step1-value")
+				return SuccessReport(stp)
+			})
+
+		// Step 2: writes to local state with same key
+		var step2LocalValue string
+		step2 := NewStepBuilder().WithId("step2").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				stp.State().Local().Set("my-key", "step2-value")
+				step2LocalValue = stp.State().Local().String("my-key")
+				return SuccessReport(stp)
+			})
+
+		// Step 3: verify isolation
+		step3 := NewStepBuilder().WithId("step3").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				// Should not see step1 or step2's local values
+				_, ok := stp.State().Local().Get("my-key")
+				assert.False(t, ok, "step3 should not see step1/step2 local state")
+				return SuccessReport(stp)
+			})
+
+		wb.Steps(step1, step2, step3)
+
+		wf, err := wb.Build()
+		require.NoError(t, err)
+
+		report := wf.Execute(context.Background())
+
+		assert.True(t, report.IsSuccess())
+		assert.Equal(t, "step2-value", step2LocalValue)
+	})
+
+	t.Run("steps can read from shared global state", func(t *testing.T) {
+		wb := NewWorkflowBuilder().WithId("test-workflow")
+
+		// Step 1: writes to global state
+		step1 := NewStepBuilder().WithId("step1").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				stp.State().Global().Set("shared-config", "production")
+				stp.State().Global().Set("counter", 1)
+				return SuccessReport(stp)
+			})
+
+		// Step 2: reads from global and updates it
+		step2 := NewStepBuilder().WithId("step2").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				config := stp.State().Global().String("shared-config")
+				assert.Equal(t, "production", config)
+
+				counter := stp.State().Global().Int("counter")
+				assert.Equal(t, 1, counter)
+
+				stp.State().Global().Set("counter", counter+1)
+				return SuccessReport(stp)
+			})
+
+		// Step 3: sees updated global state
+		step3 := NewStepBuilder().WithId("step3").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				config := stp.State().Global().String("shared-config")
+				assert.Equal(t, "production", config)
+
+				counter := stp.State().Global().Int("counter")
+				assert.Equal(t, 2, counter)
+				return SuccessReport(stp)
+			})
+
+		wb.Steps(step1, step2, step3)
+
+		wf, err := wb.Build()
+		require.NoError(t, err)
+
+		report := wf.Execute(context.Background())
+
+		assert.True(t, report.IsSuccess())
+
+		// Verify workflow state has global values
+		assert.Equal(t, "production", wf.State().Global().String("shared-config"))
+		assert.Equal(t, 2, wf.State().Global().Int("counter"))
+	})
+}
+
+func TestNamespacedStateBag_Merge(t *testing.T) {
+	t.Run("merge local namespaces", func(t *testing.T) {
+		ns1 := NewNamespacedStateBag(nil, nil)
+		ns1.Local().Set("key1", "value1")
+		ns1.Local().Set("shared-key", "original")
+
+		ns2 := NewNamespacedStateBag(nil, nil)
+		ns2.Local().Set("key2", "value2")
+		ns2.Local().Set("shared-key", "merged")
+
+		result := ns1.Merge(ns2)
+
+		// Verify it returns itself
+		assert.Same(t, ns1, result)
+
+		// Verify local namespace has both keys
+		assert.Equal(t, "value1", ns1.Local().String("key1"))
+		assert.Equal(t, "value2", ns1.Local().String("key2"))
+		assert.Equal(t, "merged", ns1.Local().String("shared-key"), "shared key should be overwritten")
+	})
+
+	t.Run("merge global namespaces", func(t *testing.T) {
+		ns1 := NewNamespacedStateBag(nil, nil)
+		ns1.Global().Set("config", "production")
+		ns1.Global().Set("counter", 1)
+
+		ns2 := NewNamespacedStateBag(nil, nil)
+		ns2.Global().Set("counter", 5)
+		ns2.Global().Set("new-setting", "enabled")
+
+		ns1.Merge(ns2)
+
+		// Verify global namespace has merged values
+		assert.Equal(t, "production", ns1.Global().String("config"))
+		assert.Equal(t, 5, ns1.Global().Int("counter"), "counter should be updated")
+		assert.Equal(t, "enabled", ns1.Global().String("new-setting"))
+	})
+
+	t.Run("merge custom namespaces - add new", func(t *testing.T) {
+		ns1 := NewNamespacedStateBag(nil, nil)
+		ns1.WithNamespace("ns1").Set("key", "value1")
+
+		ns2 := NewNamespacedStateBag(nil, nil)
+		ns2.WithNamespace("ns2").Set("key", "value2")
+
+		ns1.Merge(ns2)
+
+		// Verify both custom namespaces exist
+		assert.Equal(t, "value1", ns1.WithNamespace("ns1").String("key"))
+		assert.Equal(t, "value2", ns1.WithNamespace("ns2").String("key"))
+	})
+
+	t.Run("merge custom namespaces - merge existing", func(t *testing.T) {
+		ns1 := NewNamespacedStateBag(nil, nil)
+		ns1.WithNamespace("shared").Set("key1", "value1")
+		ns1.WithNamespace("shared").Set("shared-key", "original")
+
+		ns2 := NewNamespacedStateBag(nil, nil)
+		ns2.WithNamespace("shared").Set("key2", "value2")
+		ns2.WithNamespace("shared").Set("shared-key", "merged")
+
+		ns1.Merge(ns2)
+
+		// Verify custom namespace has merged values
+		sharedNs := ns1.WithNamespace("shared")
+		assert.Equal(t, "value1", sharedNs.String("key1"))
+		assert.Equal(t, "value2", sharedNs.String("key2"))
+		assert.Equal(t, "merged", sharedNs.String("shared-key"))
+	})
+
+	t.Run("merge all namespaces together", func(t *testing.T) {
+		ns1 := NewNamespacedStateBag(nil, nil)
+		ns1.Local().Set("local1", "l1")
+		ns1.Global().Set("global1", "g1")
+		ns1.WithNamespace("custom1").Set("c1", "v1")
+		ns1.WithNamespace("shared").Set("s1", "original")
+
+		ns2 := NewNamespacedStateBag(nil, nil)
+		ns2.Local().Set("local2", "l2")
+		ns2.Global().Set("global2", "g2")
+		ns2.WithNamespace("custom2").Set("c2", "v2")
+		ns2.WithNamespace("shared").Set("s2", "merged")
+
+		ns1.Merge(ns2)
+
+		// Verify local namespace
+		assert.Equal(t, "l1", ns1.Local().String("local1"))
+		assert.Equal(t, "l2", ns1.Local().String("local2"))
+
+		// Verify global namespace
+		assert.Equal(t, "g1", ns1.Global().String("global1"))
+		assert.Equal(t, "g2", ns1.Global().String("global2"))
+
+		// Verify custom namespaces
+		assert.Equal(t, "v1", ns1.WithNamespace("custom1").String("c1"))
+		assert.Equal(t, "v2", ns1.WithNamespace("custom2").String("c2"))
+		assert.Equal(t, "original", ns1.WithNamespace("shared").String("s1"))
+		assert.Equal(t, "merged", ns1.WithNamespace("shared").String("s2"))
+	})
+
+	t.Run("merge with nil returns self", func(t *testing.T) {
+		ns := NewNamespacedStateBag(nil, nil)
+		ns.Local().Set("key", "value")
+
+		result := ns.Merge(nil)
+
+		assert.Same(t, ns, result)
+		assert.Equal(t, "value", ns.Local().String("key"), "original data should be unchanged")
+	})
+
+	t.Run("merge does not affect source", func(t *testing.T) {
+		ns1 := NewNamespacedStateBag(nil, nil)
+		ns1.Local().Set("key", "value1")
+
+		ns2 := NewNamespacedStateBag(nil, nil)
+		ns2.Local().Set("key", "value2")
+
+		ns1.Merge(ns2)
+
+		// Modify ns1 after merge
+		ns1.Local().Set("key", "modified")
+
+		// Verify ns2 is not affected
+		assert.Equal(t, "value2", ns2.Local().String("key"))
+	})
+
+	t.Run("merge custom namespaces are cloned not referenced", func(t *testing.T) {
+		ns1 := NewNamespacedStateBag(nil, nil)
+
+		ns2 := NewNamespacedStateBag(nil, nil)
+		ns2.WithNamespace("custom").Set("key", "original")
+
+		ns1.Merge(ns2)
+
+		// Modify ns2's custom namespace after merge
+		ns2.WithNamespace("custom").Set("key", "modified")
+
+		// Verify ns1's custom namespace is not affected
+		assert.Equal(t, "original", ns1.WithNamespace("custom").String("key"))
+	})
+}
+
+func TestNamespacedStateBag_RealWorldScenario_BindMount(t *testing.T) {
+	t.Run("multiple bind mount steps with local state isolation", func(t *testing.T) {
+		wb := NewWorkflowBuilder().WithId("bind-mount-workflow")
+
+		// Shared global configuration
+		wb.WithState(NewNamespacedStateBag(nil, nil))
+
+		// Setup global config that all steps can read
+		setupConfig := NewStepBuilder().WithId("setup-config").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				stp.State().Global().Set("env", "production")
+				stp.State().Global().Set("sandbox-dir", "/var/sandbox")
+				return SuccessReport(stp)
+			})
+
+		// Each bind mount step uses local state for its own bind mount
+		type BindMount struct {
+			Source string
+			Target string
+		}
+
+		var bindMount1, bindMount2 BindMount
+		var env1, env2 string
+		var executeMount1, executeMount2 BindMount
+
+		setupBindMount1 := NewStepBuilder().WithId("setup-bind-mount-1").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				// Read shared config from global
+				env1 = stp.State().Global().String("env")
+				sandboxDir := stp.State().Global().String("sandbox-dir")
+
+				// Store bind mount in local state (isolated)
+				bindMount := BindMount{
+					Source: sandboxDir + "/app1",
+					Target: "/mnt/app1",
+				}
+				executeMount1 = bindMount
+				stp.State().Local().Set("bind-mount", bindMount)
+
+				return SuccessReport(stp)
+			}).
+			WithRollback(func(ctx context.Context, stp Step) *Report {
+				// Read from local state
+				if val, ok := stp.State().Local().Get("bind-mount"); ok {
+					bindMount1 = val.(BindMount)
+				}
+				return SuccessReport(stp)
+			})
+
+		setupBindMount2 := NewStepBuilder().WithId("setup-bind-mount-2").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				// Read same shared config from global
+				env2 = stp.State().Global().String("env")
+				sandboxDir := stp.State().Global().String("sandbox-dir")
+
+				// Store different bind mount in local state (isolated)
+				bindMount := BindMount{
+					Source: sandboxDir + "/app2",
+					Target: "/mnt/app2",
+				}
+				executeMount2 = bindMount
+				stp.State().Local().Set("bind-mount", bindMount)
+
+				return SuccessReport(stp)
+			}).
+			WithRollback(func(ctx context.Context, stp Step) *Report {
+				// Read from local state
+				if val, ok := stp.State().Local().Get("bind-mount"); ok {
+					bindMount2 = val.(BindMount)
+				}
+				return SuccessReport(stp)
+			})
+
+		wb.Steps(setupConfig, setupBindMount1, setupBindMount2)
+		wf, err := wb.Build()
+		require.NoError(t, err)
+
+		// Execute workflow
+		report := wf.Execute(context.Background())
+		assert.True(t, report.IsSuccess())
+
+		// Verify both steps read same global config
+		assert.Equal(t, "production", env1)
+		assert.Equal(t, "production", env2)
+
+		// Verify execution set the values correctly
+		assert.Equal(t, "/var/sandbox/app1", executeMount1.Source)
+		assert.Equal(t, "/mnt/app1", executeMount1.Target)
+		assert.Equal(t, "/var/sandbox/app2", executeMount2.Source)
+		assert.Equal(t, "/mnt/app2", executeMount2.Target)
+
+		// Trigger rollback to verify local state isolation
+		rollbackReport := wf.Rollback(context.Background())
+		assert.True(t, rollbackReport.IsSuccess())
+
+		// Verify each step retrieved its own bind mount during rollback
+		assert.Equal(t, "/var/sandbox/app1", bindMount1.Source)
+		assert.Equal(t, "/mnt/app1", bindMount1.Target)
+		assert.Equal(t, "/var/sandbox/app2", bindMount2.Source)
+		assert.Equal(t, "/mnt/app2", bindMount2.Target)
+	})
+}
+
+func TestNamespacedStateBag_CustomNamespacePerStep(t *testing.T) {
+	t.Run("steps use custom namespaces for isolation", func(t *testing.T) {
+		wb := NewWorkflowBuilder().WithId("custom-namespace-workflow")
+
+		type Config struct {
+			Host string
+			Port int
+		}
+
+		var config1, config2 Config
+
+		// Step 1 uses custom namespace "database-1"
+		step1 := NewStepBuilder().WithId("setup-db1").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				cfg := Config{Host: "db1.example.com", Port: 5432}
+				stp.State().WithNamespace("database-1").Set("config", cfg)
+				return SuccessReport(stp)
+			}).
+			WithRollback(func(ctx context.Context, stp Step) *Report {
+				if val, ok := stp.State().WithNamespace("database-1").Get("config"); ok {
+					config1 = val.(Config)
+				}
+				return SuccessReport(stp)
+			})
+
+		// Step 2 uses custom namespace "database-2"
+		step2 := NewStepBuilder().WithId("setup-db2").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				cfg := Config{Host: "db2.example.com", Port: 3306}
+				stp.State().WithNamespace("database-2").Set("config", cfg)
+				return SuccessReport(stp)
+			}).
+			WithRollback(func(ctx context.Context, stp Step) *Report {
+				if val, ok := stp.State().WithNamespace("database-2").Get("config"); ok {
+					config2 = val.(Config)
+				}
+				return SuccessReport(stp)
+			})
+
+		wb.Steps(step1, step2)
+		wf, err := wb.Build()
+		require.NoError(t, err)
+
+		// Execute and rollback
+		executeReport := wf.Execute(context.Background())
+		assert.True(t, executeReport.IsSuccess())
+
+		rollbackReport := wf.Rollback(context.Background())
+		assert.True(t, rollbackReport.IsSuccess())
+
+		// Verify each step accessed its own namespace
+		assert.Equal(t, "db1.example.com", config1.Host)
+		assert.Equal(t, 5432, config1.Port)
+		assert.Equal(t, "db2.example.com", config2.Host)
+		assert.Equal(t, 3306, config2.Port)
+	})
+}
+
+func TestNamespacedStateBag_NoUnintentionalOverwrite(t *testing.T) {
+	t.Run("steps cannot overwrite each other's local state", func(t *testing.T) {
+		wb := NewWorkflowBuilder().WithId("no-overwrite-workflow")
+
+		var step1Value, step2Value, step3Value string
+
+		// All steps use same key "KEY1" but in local namespace
+		step1 := NewStepBuilder().WithId("step1").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				stp.State().Local().Set("KEY1", "Value-Step1")
+				step1Value = stp.State().Local().String("KEY1")
+				return SuccessReport(stp)
+			})
+
+		step2 := NewStepBuilder().WithId("step2").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				stp.State().Local().Set("KEY1", "Value-Step2")
+				step2Value = stp.State().Local().String("KEY1")
+
+				// Verify step2 doesn't see step1's value
+				assert.NotEqual(t, "Value-Step1", step2Value)
+				return SuccessReport(stp)
+			})
+
+		step3 := NewStepBuilder().WithId("step3").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				stp.State().Local().Set("KEY1", "Value-Step3")
+				step3Value = stp.State().Local().String("KEY1")
+
+				// Verify step3 doesn't see step1 or step2's values
+				assert.NotEqual(t, "Value-Step1", step3Value)
+				assert.NotEqual(t, "Value-Step2", step3Value)
+				return SuccessReport(stp)
+			})
+
+		wb.Steps(step1, step2, step3)
+		wf, err := wb.Build()
+		require.NoError(t, err)
+
+		report := wf.Execute(context.Background())
+		assert.True(t, report.IsSuccess())
+
+		// Verify each step had its own isolated value
+		assert.Equal(t, "Value-Step1", step1Value)
+		assert.Equal(t, "Value-Step2", step2Value)
+		assert.Equal(t, "Value-Step3", step3Value)
+	})
+
+	t.Run("global state can be intentionally shared and overwritten", func(t *testing.T) {
+		wb := NewWorkflowBuilder().WithId("shared-global-workflow")
+
+		var step1GlobalValue, step2GlobalValue, step3GlobalValue string
+
+		// All steps use same key "KEY1" in global namespace
+		step1 := NewStepBuilder().WithId("step1").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				stp.State().Global().Set("KEY1", "Initial-Value")
+				step1GlobalValue = stp.State().Global().String("KEY1")
+				return SuccessReport(stp)
+			})
+
+		step2 := NewStepBuilder().WithId("step2").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				// Should see step1's value
+				step2GlobalValue = stp.State().Global().String("KEY1")
+
+				// Update global state
+				stp.State().Global().Set("KEY1", "Updated-By-Step2")
+				return SuccessReport(stp)
+			})
+
+		step3 := NewStepBuilder().WithId("step3").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				// Should see step2's updated value
+				step3GlobalValue = stp.State().Global().String("KEY1")
+				return SuccessReport(stp)
+			})
+
+		wb.Steps(step1, step2, step3)
+		wf, err := wb.Build()
+		require.NoError(t, err)
+
+		report := wf.Execute(context.Background())
+		assert.True(t, report.IsSuccess())
+
+		// Verify global state was shared and updated
+		assert.Equal(t, "Initial-Value", step1GlobalValue)
+		assert.Equal(t, "Initial-Value", step2GlobalValue)
+		assert.Equal(t, "Updated-By-Step2", step3GlobalValue)
+	})
+}
+
+func TestNamespacedStateBag_LocalVsGlobalClearSemantics(t *testing.T) {
+	t.Run("same key in local and global returns different values", func(t *testing.T) {
+		wb := NewWorkflowBuilder().WithId("clear-semantics-workflow")
+
+		step := NewStepBuilder().WithId("test-step").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				// Set same key in different namespaces
+				stp.State().Local().Set("KEY1", "Local-Value")
+				stp.State().Global().Set("KEY1", "Global-Value")
+
+				// Verify they return different values
+				localValue := stp.State().Local().String("KEY1")
+				globalValue := stp.State().Global().String("KEY1")
+
+				assert.Equal(t, "Local-Value", localValue)
+				assert.Equal(t, "Global-Value", globalValue)
+				assert.NotEqual(t, localValue, globalValue)
+
+				return SuccessReport(stp)
+			})
+
+		wb.Steps(step)
+		wf, err := wb.Build()
+		require.NoError(t, err)
+
+		report := wf.Execute(context.Background())
+		assert.True(t, report.IsSuccess())
+	})
+
+	t.Run("custom namespace independent from local and global", func(t *testing.T) {
+		wb := NewWorkflowBuilder().WithId("custom-independent-workflow")
+
+		step := NewStepBuilder().WithId("test-step").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				// Set same key in all three namespace types
+				stp.State().Local().Set("KEY1", "Local-Value")
+				stp.State().Global().Set("KEY1", "Global-Value")
+				stp.State().WithNamespace("custom").Set("KEY1", "Custom-Value")
+
+				// Verify they're all independent
+				localValue := stp.State().Local().String("KEY1")
+				globalValue := stp.State().Global().String("KEY1")
+				customValue := stp.State().WithNamespace("custom").String("KEY1")
+
+				assert.Equal(t, "Local-Value", localValue)
+				assert.Equal(t, "Global-Value", globalValue)
+				assert.Equal(t, "Custom-Value", customValue)
+
+				return SuccessReport(stp)
+			})
+
+		wb.Steps(step)
+		wf, err := wb.Build()
+		require.NoError(t, err)
+
+		report := wf.Execute(context.Background())
+		assert.True(t, report.IsSuccess())
+	})
+}
+
+func TestNamespacedStateBag_RollbackStateIsolation(t *testing.T) {
+	t.Run("rollback receives correct local state snapshot", func(t *testing.T) {
+		wb := NewWorkflowBuilder().WithId("rollback-isolation-workflow").WithExecutionMode(RollbackOnError)
+
+		var rollbackValue string
+		var rollbackExecuted bool
+
+		step1 := NewStepBuilder().WithId("step1").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				stp.State().Local().Set("data", "step1-data")
+				return SuccessReport(stp)
+			}).
+			WithRollback(func(ctx context.Context, stp Step) *Report {
+				// Should see step1's local data during rollback
+				rollbackExecuted = true
+				rollbackValue = stp.State().Local().String("data")
+				return SuccessReport(stp)
+			})
+
+		step2 := NewStepBuilder().WithId("step2").
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				stp.State().Local().Set("data", "step2-data")
+				// Simulate failure to trigger rollback
+				return FailureReport(stp, WithError(IllegalArgument.New("simulated failure")))
+			})
+
+		wb.Steps(step1, step2)
+		wf, err := wb.Build()
+		require.NoError(t, err)
+
+		// Execute will fail on step2, triggering rollback
+		report := wf.Execute(context.Background())
+		assert.False(t, report.IsSuccess())
+
+		// Verify rollback was executed
+		assert.True(t, rollbackExecuted, "step1 rollback should have been executed")
+
+		// Verify step1's rollback saw its own local data, not step2's
+		assert.Equal(t, "step1-data", rollbackValue)
+	})
+}

--- a/state_test.go
+++ b/state_test.go
@@ -124,7 +124,8 @@ func TestSyncStateBag_Merge(t *testing.T) {
 	bag2.Set("b", 20)
 	bag2.Set("c", 30)
 
-	bag1.Merge(bag2)
+	_, err := bag1.Merge(bag2)
+	require.NoError(t, err)
 	assert.Equal(t, 1, IntFromState(bag1, "a"))
 	assert.Equal(t, 20, IntFromState(bag1, "b"))
 	assert.Equal(t, 30, IntFromState(bag1, "c"))
@@ -133,7 +134,8 @@ func TestSyncStateBag_Merge(t *testing.T) {
 func TestSyncStateBag_Merge_NilOther(t *testing.T) {
 	bag := &SyncStateBag{}
 	bag.Set("x", 100)
-	result := bag.Merge(nil)
+	result, err := bag.Merge(nil)
+	require.NoError(t, err)
 	assert.Equal(t, bag, result)
 	assert.Equal(t, 100, IntFromState(result, "x"))
 }

--- a/step_builder.go
+++ b/step_builder.go
@@ -62,7 +62,7 @@ func (s *StepBuilder) WithAsyncCallbacks(enable bool) *StepBuilder {
 	return s
 }
 
-func (s *StepBuilder) WithState(state StateBag) *StepBuilder {
+func (s *StepBuilder) WithState(state NamespacedStateBag) *StepBuilder {
 	s.Step.state = state
 	return s
 }
@@ -109,11 +109,12 @@ func (s *StepBuilder) BuildAndCopy() (Step, error) {
 	s.Step.onFailure = finishedStep.onFailure
 	s.Step.enableAsyncCallbacks = finishedStep.enableAsyncCallbacks
 
+	// Clone the NamespacedStateBag (clones local, global, and custom namespaces)
 	var err error
 	if finishedStep.state != nil {
 		s.Step.state, err = finishedStep.state.Clone()
 		if err != nil {
-			return nil, errorx.IllegalState.Wrap(err, "failed to clone state bag for step %q", finishedStep.id)
+			return nil, errorx.IllegalState.Wrap(err, "failed to clone state for step %q", finishedStep.id)
 		}
 	} else {
 		s.Step.state = nil

--- a/step_builder_test.go
+++ b/step_builder_test.go
@@ -95,7 +95,7 @@ func TestStepBuilder_WithAsyncCallbacks(t *testing.T) {
 }
 
 func TestStepBuilder_WithState(t *testing.T) {
-	state := &SyncStateBag{}
+	state := NewNamespacedStateBag(nil, nil)
 	builder := NewStepBuilder().
 		WithId("step_state").
 		WithExecute(dummyExecute).
@@ -109,7 +109,7 @@ func TestStepBuilder_Build_ResetsAllFields(t *testing.T) {
 		WithId("step1").
 		WithExecute(dummyExecute).
 		WithAsyncCallbacks(true).
-		WithState(&SyncStateBag{})
+		WithState(NewNamespacedStateBag(nil, nil))
 
 	step, err := builder.Build()
 	assert.NoError(t, err)
@@ -126,7 +126,7 @@ func TestStepBuilder_BuildAndCopy_RetainsFields(t *testing.T) {
 		WithId("step1").
 		WithExecute(dummyExecute).
 		WithAsyncCallbacks(true).
-		WithState(&SyncStateBag{})
+		WithState(NewNamespacedStateBag(nil, nil))
 
 	step, err := builder.BuildAndCopy()
 	assert.NoError(t, err)

--- a/step_default.go
+++ b/step_default.go
@@ -17,17 +17,18 @@ type defaultStep struct {
 	onCompletion         OnCompletionFunc
 	onFailure            OnFailureFunc
 	enableAsyncCallbacks bool
-	state                StateBag
+	state                NamespacedStateBag
 }
 
-func (s *defaultStep) State() StateBag {
+func (s *defaultStep) State() NamespacedStateBag {
 	if s.state == nil {
-		s.state = &SyncStateBag{} // lazy initialization
+		// lazy initialization with empty local and global namespaces
+		s.state = NewNamespacedStateBag(nil, nil)
 	}
 	return s.state
 }
 
-func (s *defaultStep) WithState(st StateBag) Step {
+func (s *defaultStep) WithState(st NamespacedStateBag) Step {
 	// avoid redundant assignment when same state is provided
 	if s.state == st {
 		return s

--- a/step_default_test.go
+++ b/step_default_test.go
@@ -3,11 +3,12 @@ package automa
 import (
 	"context"
 	"errors"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultStep_Prepare(t *testing.T) {
@@ -120,9 +121,8 @@ func TestDefaultStep_Rollback_Skipped(t *testing.T) {
 func TestDefaultStep_State_LazyInit(t *testing.T) {
 	step := newDefaultStep()
 	assert.NotNil(t, step.State())
-	assert.Equal(t, 0, step.State().Size())
-	step.State().Set("foo", "bar")
-	val, ok := step.State().Get("foo")
+	step.State().Local().Set("foo", "bar")
+	val, ok := step.State().Local().Get("foo")
 	assert.True(t, ok)
 	assert.Equal(t, "bar", val)
 }

--- a/workflow.go
+++ b/workflow.go
@@ -10,6 +10,13 @@ import (
 // workflow provides orchestration primitives for composing and executing
 // Steps with structured reporting, error handling and rollback support.
 //
+// Thread-safety:
+//   - Workflow instances are NOT thread-safe and must not be shared across goroutines.
+//   - Each workflow instance is designed for single execution. Create a new instance for
+//     concurrent executions.
+//   - Callbacks (onCompletion, onFailure) may run asynchronously but operate on cloned
+//     reports, ensuring the workflow instance itself is not accessed concurrently.
+//
 // Overview:
 //   - A workflow exposes a workflow-level StateBag via Workflow.State() that represents
 //     workflow-wide state.
@@ -37,12 +44,15 @@ import (
 //     applicable, per-step rollback reports.
 type workflow struct {
 	id                   string
-	state                StateBag
+	state                NamespacedStateBag
 	logger               zerolog.Logger
 	steps                []Step
 	executionMode        TypeMode
 	rollbackMode         TypeMode
 	enableAsyncCallbacks bool
+
+	// preserve step states after execution for potential rollback; keyed by step ID
+	lastExecutionStates map[string]NamespacedStateBag
 
 	// callbacks and hooks
 	prepare      PrepareFunc
@@ -51,7 +61,7 @@ type workflow struct {
 	onFailure    OnFailureFunc
 }
 
-func (w *workflow) WithState(s StateBag) Step {
+func (w *workflow) WithState(s NamespacedStateBag) Step {
 	if w.state == s {
 		// avoid redundant assignment when same state is provided
 		return w
@@ -102,7 +112,7 @@ func RunWorkflow(ctx context.Context, wb *WorkflowBuilder) *Report {
 }
 
 // rollbackFrom rollbacks the workflow backward from the given index to the start.
-func (w *workflow) rollbackFrom(ctx context.Context, index int, states []StateBag) map[string]*Report {
+func (w *workflow) rollbackFrom(ctx context.Context, index int, states map[string]NamespacedStateBag) map[string]*Report {
 	stepReports := map[string]*Report{}
 	startTime := time.Now()
 
@@ -110,21 +120,21 @@ func (w *workflow) rollbackFrom(ctx context.Context, index int, states []StateBa
 		step := w.steps[i]
 
 		// choose snapshot if provided, otherwise use workflow state
-		var state StateBag
-		if states != nil && i < len(states) && states[i] != nil {
-			state = states[i]
+		var state NamespacedStateBag
+		if states != nil {
+			if snapshot, ok := states[step.Id()]; ok {
+				state = snapshot
+			} else {
+				state = w.State()
+			}
 		} else {
 			state = w.State()
 		}
 
-		// pass the chosen state in context for the rollback
-		stepCtx := context.WithValue(ctx, KeyState, state.
-			Set(KeyId, w.Id()).
-			Set(KeyIsWorkflow, true).
-			Set(KeyStartTime, startTime),
-		)
+		// Update the step's state to the snapshot before calling Rollback
+		step = step.WithState(state)
 
-		rollbackReport := step.Rollback(stepCtx)
+		rollbackReport := step.Rollback(ctx)
 
 		if rollbackReport == nil {
 			rollbackReport = FailureReport(step,
@@ -178,9 +188,10 @@ func (w *workflow) Steps() []Step {
 	return w.steps
 }
 
-func (w *workflow) State() StateBag {
+func (w *workflow) State() NamespacedStateBag {
 	if w.state == nil {
-		w.state = &SyncStateBag{} // lazy initialization
+		// lazy initialization with empty local and global namespaces
+		w.state = NewNamespacedStateBag(nil, nil)
 	}
 
 	return w.state
@@ -189,23 +200,65 @@ func (w *workflow) State() StateBag {
 // Execute runs the workflow by executing each step in sequence.
 //
 // Preparation and state handling:
-//   - If a workflow-level `prepare` hook is configured it is invoked first with the incoming `ctx` and the
+//  1. If a workflow-level `prepare` hook is configured it is invoked first with the incoming `ctx` and the
 //     workflow instance. The returned context (if non-nil) is used for step preparation and execution.
-//   - The workflow exposes a shared `StateBag` via `w.State()` that represents workflow-wide state.
-//   - For ordinary steps the shared `StateBag` is used as-is (state is shared between workflow and step).
-//   - For steps that are themselves workflows (detected with `IsWorkflow(step)`), `Execute` clones the
-//     workflow state by calling `StateBag.Clone()` and provides the cloned `StateBag` to the sub-workflow.
-//     This prevents unintended state sharing and isolates sub-workflow mutations from the parent workflow.
-//   - If cloning the state fails or context preparation fails, the step is treated as failed and a failure `Report`
-//     is produced; the step is not executed.
-//   - After state preparation each step's `Prepare` hook is invoked; the context returned by the step's
-//     `Prepare` (if any) is used for the step's execution.
-//     A nil `Report` from a step is treated as a failure.
+//  2. The workflow exposes a shared `NamespacedStateBag` via `w.State()` that represents workflow-wide state.
+//  3. For ordinary steps, a new `NamespacedStateBag` is created with:
+//     a. An empty local namespace (isolated to the step)
+//     b. A shared global namespace (points to the workflow's global state)
+//  4. For steps that are themselves workflows (detected with `IsWorkflow(step)`), `Execute` creates a new
+//     `NamespacedStateBag` with:
+//     a. An empty local namespace (isolated to the sub-workflow)
+//     b. A cloned global namespace (inherits parent's shared state but prevents mutations from
+//     propagating back to the parent workflow)
+//  5. This ensures sub-workflows have access to parent's global state but cannot mutate it, while
+//     ordinary steps share the global namespace and can mutate it (visible to later steps).
+//
+// State snapshot and rollback:
+//  1. After each step executes (successfully or not), its state is cloned and stored in `stepStates`
+//     (keyed by step ID) for potential rollback.
+//  2. State cloning ensures immutable snapshots (global state is shared across steps, so cloning
+//     prevents later mutations from affecting earlier snapshots).
+//  3. If state cloning fails, the step's current (non-cloned) state reference is stored instead. This:
+//     a. Ensures rollback can access the step's actual execution state (including partial success)
+//     b. Accepts the risk that later steps may mutate this state before rollback occurs
+//     c. Is safer than falling back to workflow state, which may be stale or incomplete
+//     d. A warning is logged when state cloning fails
+//     e. The step is NOT failed due to cloning failure - this ensures rollback can still be
+//     triggered if `executionMode` is `RollbackOnError` and the step fails for other reasons
+//  4. When `executionMode` is `RollbackOnError` and a step fails, rollback is triggered immediately for
+//     the failed step and all previously executed steps (from `index` down to 0). This ensures:
+//     a. The failed step can clean up any partial work it completed before failing
+//     b. All successfully executed steps are rolled back in reverse order
+//     c. Each step's rollback receives its captured state snapshot (cloned or non-cloned reference)
+//  5. Rollback reports are attached to the corresponding step reports via `stepReport.Rollback`.
 //
 // Execution semantics:
-//   - Execution behavior respects `w.executionMode` (StopOnError, ContinueOnError, RollbackOnError).
-//   - When rollback is required, rollback reports from executed steps are attached to the corresponding
+//  1. Execution behavior respects `w.executionMode`:
+//     a. `StopOnError`: Stop immediately when a step fails, no rollback
+//     b. `ContinueOnError`: Continue executing remaining steps even if one fails
+//     c. `RollbackOnError`: Rollback the failed step and all previously executed steps, then stop
+//  2. When rollback is performed, rollback reports from executed steps are attached to the corresponding
 //     step reports and returned as part of the workflow `Report`.
+//  3. The workflow completes successfully only if all steps succeed; otherwise returns a failure `Report`.
+//  4. State cloning failures are logged as warnings but do not fail the step. This ensures that if
+//     `executionMode` is `RollbackOnError` and the step fails for execution-related reasons, rollback
+//     can still be triggered using the non-cloned state reference. Without this behavior, cloning
+//     failures would prevent rollback and leave state inconsistent.
+//
+// State management and persistence:
+//  1. The workflow exposes a shared `NamespacedStateBag` via `w.State()` that represents workflow-wide state.
+//  2. Steps can access and mutate state during execution via `step.State()`.
+//  3. For persistence needs (e.g., saving state to disk, database), users should handle this in their
+//     step implementations or workflow callbacks (onCompletion, onFailure):
+//     a. Write state to files/databases within step.Execute()
+//     b. Use onCompletion callback to persist final workflow state
+//     c. Attach custom metadata to reports via Meta field for tracking
+//  4. After execution (successful or failed), state snapshots are preserved internally via
+//     `w.lastExecutionStates` (keyed by step ID) for potential manual rollback via `Rollback()`.
+//  5. State cloning failures result in non-cloned state references being stored; rollback will use these
+//     references but they may have been mutated by later steps (only if execution continued past the
+//     point of cloning failure).
 func (w *workflow) Execute(ctx context.Context) *Report {
 	startTime := time.Now()
 
@@ -221,39 +274,53 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 	var hasFailed bool
 
 	// capture per-step state snapshots for rollback
-	stepStates := make([]StateBag, 0, len(w.steps))
+	stepStates := make(map[string]NamespacedStateBag, len(w.steps))
 
 	for index, step := range w.steps {
 		var report *Report
 		stepStart := time.Now()
 
 		stepCtx := ctx
-		var stepState StateBag
+		var stepState NamespacedStateBag
 		var statePrepError error
 		var ctxPrepError error
 
-		// prepare step state (start from current workflow state)
-		stepState = w.State()
-		if IsWorkflow(step) { // clone state for sub-workflows
-			stepState, statePrepError = stepState.Clone()
+		// prepare step state with namespace support
+		if IsWorkflow(step) {
+			var clonedGlobal StateBag
+			// Sub-workflows get a new NamespacedStateBag with:
+			// - Empty local namespace (isolated to the sub-workflow)
+			// - Cloned global namespace (inherits parent's shared state)
+			clonedGlobal, statePrepError = w.State().Global().Clone()
 			if statePrepError != nil {
 				report = FailureReport(step,
 					WithWorkflow(w),
 					WithStartTime(stepStart),
 					WithActionType(ActionExecute),
 					WithError(StepExecutionError.
-						Wrap(statePrepError, "workflow %q step %q failed to clone state for sub-workflow execution", w.id, step.Id()).
+						Wrap(statePrepError, "workflow %q step %q failed to clone global state for sub-workflow execution", w.id, step.Id()).
 						WithProperty(StepIdProperty, step.Id()),
 					))
-			}
-		}
 
-		// attach snapshot for possible rollback (keeps alignment even if nil)
-		stepStates = append(stepStates, stepState)
+				// Fall back to empty state for consistency since we always assume there is a state attached to the step
+				// when calling Prepare and Execute, even though sub-workflow won't have access to parent's global state
+				// in this case.
+				stepState = NewNamespacedStateBag(nil, nil)
+			} else {
+				stepState = NewNamespacedStateBag(nil, clonedGlobal)
+			}
+		} else {
+			// Ordinary steps get namespaced state with:
+			// - Empty local namespace (isolated to this step)
+			// - Shared global namespace (points to workflow's global state)
+			stepState = NewNamespacedStateBag(nil, w.State().Global())
+		}
 
 		// make sure step has its state before calling Prepare so Prepare can access it.
 		// It also ensures during Execute the step has the correct state
-		step = step.WithState(stepState)
+		if stepState != nil {
+			step = step.WithState(stepState)
+		}
 
 		// prepare step context
 		if statePrepError == nil {
@@ -285,6 +352,25 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 			}
 		}
 
+		// Capture state snapshot after step processing (successful or failed)
+		if state := step.State(); state != nil {
+			clonedState, err := state.Clone()
+			if err != nil {
+				// State cloning failed; log warning and store non-cloned reference
+				// Do NOT fail the step - this would prevent rollback and leave state inconsistent
+				w.logger.Warn().
+					Err(err).
+					Str("workflowId", w.id).
+					Str("stepId", step.Id()).
+					Msg("failed to clone state for rollback snapshot; using current state reference (may be mutated by later steps before rollback)")
+
+				// Store non-cloned state for rollback
+				stepStates[step.Id()] = state
+			} else {
+				stepStates[step.Id()] = clonedState
+			}
+		}
+
 		// collect step report
 		stepReports = append(stepReports, report)
 
@@ -295,7 +381,8 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 			if w.executionMode == StopOnError {
 				break
 			} else if w.executionMode == RollbackOnError {
-				// perform rollback using recorded per-step states
+				// Perform rollback using recorded per-step states
+				// Rollback from index (include the failed step for cleanup)
 				rollbackReports := w.rollbackFrom(stepCtx, index, stepStates)
 
 				// Attach rollback reports to corresponding step reports
@@ -309,6 +396,10 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 			}
 		}
 	}
+
+	// Preserve state snapshots for potential manual rollback later
+	// (even if workflow failed, manual Rollback() can use these snapshots)
+	w.lastExecutionStates = stepStates
 
 	if hasFailed {
 		var failedStepIDs []string
@@ -386,13 +477,9 @@ func (w *workflow) Rollback(ctx context.Context) *Report {
 	}
 
 	startTime := time.Now()
-	stepCtx := context.WithValue(ctx, KeyState, w.State().
-		Set(KeyId, w.Id()).
-		Set(KeyIsWorkflow, true).
-		Set(KeyStartTime, startTime),
-	)
-	// call with nil states so rollbackFrom falls back to current workflow state
-	rollbackReports := w.rollbackFrom(stepCtx, len(w.steps)-1, nil)
+
+	// Use preserved states from last execution, fall back to nil if none available
+	rollbackReports := w.rollbackFrom(ctx, len(w.steps)-1, w.lastExecutionStates)
 
 	var stepReports []*Report
 	for _, step := range w.steps {

--- a/workflow.go
+++ b/workflow.go
@@ -353,6 +353,8 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		}
 
 		// Capture state snapshot after step processing (successful or failed)
+		// Clone() creates an immutable snapshot by deep-cloning all namespaces (local, global, custom).
+		// This ensures later steps cannot mutate earlier snapshots, enabling deterministic rollback.
 		if state := step.State(); state != nil {
 			clonedState, err := state.Clone()
 			if err != nil {

--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -157,6 +157,31 @@ func (wb *WorkflowBuilder) WithState(state NamespacedStateBag) *WorkflowBuilder 
 	return wb
 }
 
+// WithStatePreservation configures whether step states are preserved for rollback.
+//
+// When true (default):
+//   - State is cloned and stored for each step after execution
+//   - Rollback steps receive their execution-time state snapshots (local + global + custom namespaces)
+//   - Higher memory usage due to deep state cloning
+//
+// When false:
+//   - State is NOT cloned or stored for rollback
+//   - Rollback steps receive workflow.State() (global state only)
+//   - Per-step local namespaces are NOT available during rollback
+//   - Lower memory usage (no cloning or storage overhead)
+//
+// Use preservation=false when:
+//
+//   - Rollback steps are idempotent (don't need per-step state)
+//   - Rollback only needs global state
+//   - Rollback uses external state (database, files, APIs)
+//   - executionMode is StopOnError or ContinueOnError (no rollback triggered)
+//
+// Keep preservation=true (default) when:
+//
+//   - Rollback needs per-step local namespaces
+//   - Rollback needs exact state snapshot from execution time
+//   - Multiple steps might mutate shared state before rollback
 func (wb *WorkflowBuilder) WithStatePreservation(enable bool) *WorkflowBuilder {
 	wb.workflow.preserveStatesForRollback = enable
 	return wb

--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -152,7 +152,7 @@ func (wb *WorkflowBuilder) WithPrepare(prepareFunc PrepareFunc) *WorkflowBuilder
 	return wb
 }
 
-func (wb *WorkflowBuilder) WithState(state StateBag) *WorkflowBuilder {
+func (wb *WorkflowBuilder) WithState(state NamespacedStateBag) *WorkflowBuilder {
 	wb.workflow.state = state
 	return wb
 }

--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -157,6 +157,11 @@ func (wb *WorkflowBuilder) WithState(state NamespacedStateBag) *WorkflowBuilder 
 	return wb
 }
 
+func (wb *WorkflowBuilder) WithStatePreservation(enable bool) *WorkflowBuilder {
+	wb.workflow.preserveStatesForRollback = enable
+	return wb
+}
+
 func (wb *WorkflowBuilder) WithRollback(rollback RollbackFunc) *WorkflowBuilder {
 	wb.workflow.rollback = rollback
 	return wb

--- a/workflow_state_preservation_test.go
+++ b/workflow_state_preservation_test.go
@@ -1,0 +1,134 @@
+package automa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflow_StatePreservation_Enabled(t *testing.T) {
+	wb := NewWorkflowBuilder().WithId("test-workflow").
+		WithStatePreservation(true) // explicitly enable (default)
+
+	step1 := NewStepBuilder().WithId("step1").
+		WithExecute(func(ctx context.Context, stp Step) *Report {
+			stp.State().Local().Set("data", "step1-data")
+			return SuccessReport(stp)
+		})
+
+	step2 := NewStepBuilder().WithId("step2").
+		WithExecute(func(ctx context.Context, stp Step) *Report {
+			stp.State().Local().Set("data", "step2-data")
+			return SuccessReport(stp)
+		})
+
+	wb.Steps(step1, step2)
+	wf, err := wb.Build()
+	require.NoError(t, err)
+
+	// Execute workflow
+	report := wf.Execute(context.Background())
+	assert.True(t, report.IsSuccess())
+
+	// Verify state snapshots were preserved
+	typedWf := wf.(*workflow)
+	assert.NotNil(t, typedWf.lastExecutionStates)
+	assert.Equal(t, 2, len(typedWf.lastExecutionStates))
+	assert.Contains(t, typedWf.lastExecutionStates, "step1")
+	assert.Contains(t, typedWf.lastExecutionStates, "step2")
+}
+
+func TestWorkflow_StatePreservation_Disabled(t *testing.T) {
+	wb := NewWorkflowBuilder().WithId("test-workflow").
+		WithStatePreservation(false) // disable state preservation
+
+	step1 := NewStepBuilder().WithId("step1").
+		WithExecute(func(ctx context.Context, stp Step) *Report {
+			stp.State().Local().Set("data", "step1-data")
+			return SuccessReport(stp)
+		})
+
+	step2 := NewStepBuilder().WithId("step2").
+		WithExecute(func(ctx context.Context, stp Step) *Report {
+			stp.State().Local().Set("data", "step2-data")
+			return SuccessReport(stp)
+		})
+
+	wb.Steps(step1, step2)
+	wf, err := wb.Build()
+	require.NoError(t, err)
+
+	// Execute workflow
+	report := wf.Execute(context.Background())
+	assert.True(t, report.IsSuccess())
+
+	// Verify state snapshots were NOT preserved
+	typedWf := wf.(*workflow)
+	assert.Nil(t, typedWf.lastExecutionStates)
+}
+
+func TestWorkflow_StatePreservation_Default(t *testing.T) {
+	// Test that default is enabled (backward compatibility)
+	wb := NewWorkflowBuilder().WithId("test-workflow")
+	// Don't call WithStatePreservation - use default
+
+	step1 := NewStepBuilder().WithId("step1").
+		WithExecute(func(ctx context.Context, stp Step) *Report {
+			stp.State().Local().Set("data", "step1-data")
+			return SuccessReport(stp)
+		})
+
+	wb.Steps(step1)
+	wf, err := wb.Build()
+	require.NoError(t, err)
+
+	// Execute workflow
+	report := wf.Execute(context.Background())
+	assert.True(t, report.IsSuccess())
+
+	// Verify state snapshots were preserved (default behavior)
+	typedWf := wf.(*workflow)
+	assert.NotNil(t, typedWf.lastExecutionStates)
+	assert.Equal(t, 1, len(typedWf.lastExecutionStates))
+}
+
+func TestWorkflow_StatePreservation_DisabledRollback(t *testing.T) {
+	wb := NewWorkflowBuilder().WithId("test-workflow").
+		WithStatePreservation(false). // disable state preservation
+		WithExecutionMode(RollbackOnError)
+
+	var rollbackCalled bool
+
+	step1 := NewStepBuilder().WithId("step1").
+		WithExecute(func(ctx context.Context, stp Step) *Report {
+			stp.State().Local().Set("data", "step1-data")
+			return SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp Step) *Report {
+			rollbackCalled = true
+			// With state preservation disabled, rollback uses workflow state (not snapshot)
+			return SuccessReport(stp)
+		})
+
+	step2 := NewStepBuilder().WithId("step2").
+		WithExecute(func(ctx context.Context, stp Step) *Report {
+			return FailureReport(stp, WithError(IllegalArgument.New("simulated failure")))
+		})
+
+	wb.Steps(step1, step2)
+	wf, err := wb.Build()
+	require.NoError(t, err)
+
+	// Execute workflow - step2 fails, triggers rollback
+	report := wf.Execute(context.Background())
+	assert.False(t, report.IsSuccess())
+
+	// Verify rollback was called (even with state preservation disabled)
+	assert.True(t, rollbackCalled)
+
+	// Verify no state snapshots were preserved
+	typedWf := wf.(*workflow)
+	assert.Nil(t, typedWf.lastExecutionStates)
+}


### PR DESCRIPTION
## Description

This pull request introduces namespace-aware state management for workflow steps, enhancing both flexibility and thread-safety in state handling. The changes replace the previous state bag interface with a new `NamespacedStateBag`, allowing separation of local, global, and custom state namespaces. Additionally, the implementation and tests ensure robust concurrent access and merging, and documentation has been added to clarify state preservation configuration.

Namespace-aware state management:

* Introduced the `NamespacedStateBag` interface, supporting local, global, and custom namespaces for step state isolation and sharing. The `Step` interface and related builder methods now use `NamespacedStateBag` instead of `StateBag`. (`automa.go`, `step_builder.go`) [[1]](diffhunk://#diff-2f78a604a2a388d0cd14602cb33e14d37d22b5a98b276f6774a39cbcd2c49d83L13-R21) [[2]](diffhunk://#diff-de7fbc5fe7dcf3fe1020642b6d29bc5047a74e96a7db21e1157221bc840cc214L65-R65)
* Added `SyncNamespacedStateBag` as the thread-safe implementation, including methods for lazy initialization, deep cloning, and merging of namespaces. (`state_namespaced.go`)

Thread-safety and concurrency improvements:

* Comprehensive concurrency tests for `SyncNamespacedStateBag` covering local, global, custom, clone, and merge operations to ensure thread-safe state management. (`state_namespaced_concurrency_test.go`)

State bag interface and method updates:

* Updated `StateBag.Merge` and `StateBag.Clone` to return errors, improving error handling for state operations. (`automa.go`, `state.go`, `state_test.go`) [[1]](diffhunk://#diff-2f78a604a2a388d0cd14602cb33e14d37d22b5a98b276f6774a39cbcd2c49d83L25-R32) [[2]](diffhunk://#diff-320959764bfa2277e0bdd4eaa741f02891d123c42150d4ccb76de0bdbf6e591aL78-R87) [[3]](diffhunk://#diff-864944c880a2e4db1b8f93f33a58303d840fb4b6c50147cc2f915c6d48f7bf2cL127-R128) [[4]](diffhunk://#diff-864944c880a2e4db1b8f93f33a58303d840fb4b6c50147cc2f915c6d48f7bf2cL136-R138)
* Step builder now clones the entire `NamespacedStateBag` (all namespaces) when copying steps, ensuring isolation between workflow instances. (`step_builder.go`)

Documentation:

* Added a new guide explaining state preservation configuration, including memory and rollback tradeoffs for workflows. (`docs/state-preservation.md`)


## ⚠️ Breaking Changes

### `StateBag.Merge()` signature changed
**Before:** `Merge(other StateBag) StateBag`  
**After:** `Merge(other StateBag) (StateBag, error)`

### `State()` / `WithState()` now use `NamespacedStateBag`
**Before:** `State() StateBag`  
**After:** `State() NamespacedStateBag`

### Migration
Replace direct state access:
```go
// Before
step.State().Set("key", value)
step.State().Get("key")

// After (local namespace)
step.State().Local().Set("key", value)
step.State().Local().Get("key")

// After (shared across steps)
step.State().Global().Set("key", value)
```

### Related Issues

* Closes #71 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
