### PR TITLE
docs: add specification docs

### DIFF
--- a/docs/durability.md
+++ b/docs/durability.md
@@ -1,0 +1,333 @@
+# Durable Workflows (Design)
+
+> Status: **proposed** — design under review, not yet implemented.
+
+This document describes a design for adding **crash recovery** to automa: the
+ability for a workflow to survive a process crash, restart, or power loss and
+then either **resume forward** from where it stopped or **compensate backward**
+(roll back) — without re-running already-completed work and without standing up
+any external infrastructure.
+
+## What automa offers with this feature
+
+- **Zero-infrastructure durability.** Persistence is a single local file (or an
+  embedded store). There is no server to run, no database to operate, and no
+  network dependency. A workflow's recoverable state travels with the binary.
+- **Crash recovery for sequential sagas.** If the process dies mid-workflow, a
+  later invocation reads the journal and continues: it resumes the remaining
+  steps, or compensates the completed ones, according to the configured
+  execution mode.
+- **Built on what automa already has.** The existing `NamespacedStateBag`,
+  `Report`, and `TypeMode` types already serialize to JSON/YAML. The durable
+  journal is largely a composition of these existing, tested pieces.
+- **No new programming model.** Steps remain `Prepare`/`Execute`/`Rollback`.
+  The only new obligations are an idempotency contract and keeping
+  resume-relevant data in the state bag (see [Contract](#contract-for-step-authors)).
+
+## When to use it
+
+Durability earns its (small) complexity when **all** of the following hold:
+
+- The workflow runs in a **single process** and is **short-to-medium length**
+  (tens of steps, not thousands).
+- Steps are **expensive, slow, or externally observable** — redoing them from
+  scratch is costly or unsafe (e.g. provisioning cloud resources, running a
+  multi-stage data migration, an installer that mutates a machine).
+- Partial progress is **worth preserving** across a crash rather than restarting
+  from zero.
+- The set of steps is **statically determined** — the same workflow definition
+  (same step IDs, same order) is available when the process restarts.
+
+### Good fits
+
+- Provisioning / infrastructure setup tools.
+- Database or data migrations with multiple stages.
+- Installers and machine-setup orchestration.
+- Any CLI that performs a sequence of mutating operations that should be
+  resumable or cleanly undone after an interruption.
+
+### Not a fit (use plain `Execute`, or another tool)
+
+- Workflows whose steps are **generated dynamically** from runtime data that is
+  not reconstructible from persisted state.
+- **Long-lived** workflows that must wait for hours/days across restarts (this
+  needs durable timers — out of scope; see [Non-goals](#non-goals)).
+- **Multi-process / distributed** execution where work is dispatched to a pool
+  of workers.
+- Workflows where every step is already trivially idempotent and cheap to redo —
+  in that case, just re-run from the start; durability adds no value.
+
+## Design overview
+
+automa persists **state** (a snapshot of where the saga is), not an event
+history. Recovery works by **re-attaching the same workflow definition** (which
+lives in the caller's code) to the persisted state and continuing from a cursor.
+
+This implies the central constraint of the design:
+
+> The workflow **topology** (the ordered list of step IDs) must be the same when
+> a workflow is resumed as it was when it first ran. The journal is only
+> meaningful against the workflow definition that produced it.
+
+Because the workflow definition is code in the same binary, this is a natural
+fit for the single-process tools that are automa's target. A resume validates
+that the rebuilt topology matches the journal and refuses to proceed otherwise.
+
+## The journal
+
+One file per workflow run. It is a **snapshot** (the whole state is rewritten on
+each transition) rather than an append-only log. For short workflows the cost of
+rewriting is negligible and the implementation is far simpler to reason about.
+
+```go
+type Phase string
+
+const (
+    PhaseForward      Phase = "forward"      // executing steps
+    PhaseCompensating Phase = "compensating" // rolling back
+    PhaseDone         Phase = "done"
+)
+
+type StepState string
+
+const (
+    StepPending     StepState = "pending"
+    StepStarted     StepState = "started"     // written before Execute (write-ahead)
+    StepCompleted   StepState = "completed"   // written after a successful Execute
+    StepFailed      StepState = "failed"
+    StepCompensated StepState = "compensated" // written after Rollback
+)
+
+type Journal struct {
+    Version       int           `json:"version"`
+    WorkflowID    string        `json:"workflow_id"`
+    ExecutionMode TypeMode      `json:"execution_mode"`
+    RollbackMode  TypeMode      `json:"rollback_mode"`
+    Phase         Phase         `json:"phase"`
+    Cursor        int           `json:"cursor"` // index currently being worked on
+    Global        StateBag      `json:"global"` // shared state (already serializable)
+    Steps         []StepJournal `json:"steps"`  // one per step, in workflow order
+}
+
+type StepJournal struct {
+    ID       string             `json:"id"`
+    State    StepState          `json:"state"`
+    Snapshot NamespacedStateBag `json:"snapshot,omitempty"` // execution-time state, for rollback
+    Report   *Report            `json:"report,omitempty"`
+}
+```
+
+## Durable write
+
+The journal must survive a crash *at any point*, including mid-write. A naive
+overwrite can leave a corrupt, half-written file — which is worse than no
+durability. The write is therefore: marshal → write to a temp file →
+`fsync` → atomically `rename` over the target.
+
+```go
+func (j *Journal) persist(path string) error {
+    data, err := json.Marshal(j)
+    if err != nil {
+        return err
+    }
+
+    tmp := path + ".tmp"
+    f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+    if err != nil {
+        return err
+    }
+    if _, err := f.Write(data); err != nil {
+        _ = f.Close()
+        return err
+    }
+    if err := f.Sync(); err != nil { // fsync: survive power loss, not just process crash
+        _ = f.Close()
+        return err
+    }
+    if err := f.Close(); err != nil {
+        return err
+    }
+    return os.Rename(tmp, path) // atomic on POSIX: a reader sees old-or-new, never torn
+}
+```
+
+`Rename` is atomic on POSIX filesystems, so a concurrent or post-crash reader
+always observes either the previous complete journal or the new complete
+journal, never a partial one.
+
+## Write points in the execution loop
+
+The persist calls slot into the existing `Execute` loop
+([`workflow.go`](../workflow.go)) at points where the engine already clones state
+and builds reports. Per step `i`:
+
+```
+── forward phase ──
+1. Steps[i].State = Started; Cursor = i;            persist()   ← WRITE-AHEAD (before side effect)
+2. step.WithState(...); step.Prepare(ctx)
+3. report = step.Execute(ctx)
+4. Steps[i].State = Completed | Failed
+   Steps[i].Snapshot = clone(step.State())                       (already computed today)
+   Steps[i].Report   = report
+   Global            = w.State().Global()
+                                                     persist()   ← COMMIT POINT (after side effect)
+5. on failure + RollbackOnError:
+   Phase = Compensating;                             persist()
+
+── compensating phase (rollbackFrom) ──
+for i := Cursor; i >= 0; i-- {
+    if Steps[i].State == Compensated { continue }                 ← idempotent resume
+    step.WithState(Steps[i].Snapshot); step.Rollback(ctx)
+    Steps[i].State = Compensated;                    persist()    ← per-compensation commit
+}
+
+── done ──
+Phase = Done;                                        persist()    (or delete the journal file)
+```
+
+This is two `fsync`s per step (write-ahead + commit). For the target workload
+(tens of steps) the overhead is immaterial.
+
+The **write-ahead** record in step 1 is what makes recovery decidable: after a
+crash, a step marked `Started` but not `Completed` is the ambiguous case (its
+side effect may or may not have happened), and is handled by the idempotency
+contract below.
+
+## Recovery / `Resume`
+
+`Resume` is the new public entry point. The caller re-supplies the workflow
+definition (the same builder/code); automa rehydrates state onto it and
+continues.
+
+```go
+func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string) *Report {
+    j, err := loadJournal(journalPath)
+    // missing file  → start a fresh run (write a new journal)
+    // corrupt file  → fail loudly; do NOT silently restart (could double-execute side effects)
+
+    wf := wb.Build()
+    if err := validateTopology(wf, j); err != nil {
+        return failure(...) // step IDs / order changed since the journal was written
+    }
+
+    wf.rehydrateGlobal(j.Global)
+
+    switch j.Phase {
+    case PhaseForward:
+        // Re-run any Started-but-not-Completed step (idempotency required),
+        // then continue forward from the first incomplete step.
+        return wf.executeFrom(ctx, j.firstIncompleteIndex(), j)
+    case PhaseCompensating:
+        // Continue rolling back from Cursor, skipping steps already Compensated.
+        return wf.compensateFrom(ctx, j.Cursor, j)
+    case PhaseDone:
+        return j.finalReport()
+    }
+}
+```
+
+`validateTopology` compares the rebuilt step IDs and order against the journal.
+A mismatch (the workflow definition changed between crash and resume) is an
+error, not a silent restart — this is the single-process analogue of workflow
+versioning, and it is intentionally strict.
+
+## Worked example: crash and resume
+
+Consider a 4-step provisioning workflow run with `WithJournal("setup.journal")`:
+
+```
+1. create-network
+2. create-database     ← expensive; allocates a managed instance
+3. create-cache
+4. wire-config
+```
+
+**First run, crashes mid step 2.** The journal on disk, immediately before the
+crash, is:
+
+```jsonc
+{
+  "phase": "forward", "cursor": 1,
+  "steps": [
+    { "id": "create-network",  "state": "completed", "snapshot": {…} },
+    { "id": "create-database", "state": "started" },   // write-ahead record
+    { "id": "create-cache",    "state": "pending" },
+    { "id": "wire-config",     "state": "pending" }
+  ]
+}
+```
+
+`create-network` committed. `create-database` was marked `started` *before* its
+side effect ran, then the process died — we do not know whether the database was
+actually allocated.
+
+**Resume.** The caller re-runs the same binary, which rebuilds the identical
+workflow and calls `ResumeWorkflow(ctx, wb, "setup.journal")`:
+
+1. Load journal, `validateTopology` passes (same 4 step IDs, same order).
+2. Rehydrate global state (so `create-network`'s outputs are visible).
+3. Phase is `forward`; the first incomplete step is index 1.
+4. **`create-database` is re-executed** — it was `started`, not `completed`.
+   This is the step whose idempotency matters: it must check "does this database
+   already exist?" and either adopt the existing instance or create one, so that
+   running it a second time is equivalent to running it once.
+5. Steps 3 and 4 then run normally. `create-network` is **never touched** — the
+   expensive completed work is preserved.
+
+**Contrast — what a non-idempotent step costs.** If `create-database` blindly
+issued "allocate a new instance" with no existence check, the resume would
+allocate a *second* database. Nothing in the engine can prevent this; only the
+step's own idempotency can. This is the entire reason for the contract below.
+
+## Contract for step authors
+
+Durability shifts a small amount of responsibility onto the workflow author.
+These obligations must be documented prominently and, where feasible, enforced:
+
+1. **Steps must be idempotent.** A step marked `Started` but not `Completed` is
+   re-executed on resume, because the engine cannot know whether its side effect
+   completed before the crash. Running a step twice must be equivalent to
+   running it once.
+2. **Compensations (rollbacks) must be idempotent.** Same reasoning during the
+   compensating phase.
+3. **Resume-relevant data must live in the state bag.** Anything a step needs in
+   order to resume or to compensate (resource IDs, handles, prior outputs) must
+   be written to `State().Global()` or the step's namespaces — not held in step
+   closures or struct fields, which do not survive the process.
+4. **Topology must be reconstructible.** The same ordered set of step IDs must be
+   produced by the caller's code at resume time. If steps are derived from
+   runtime data, that data must itself be persisted (e.g. in global state) so the
+   topology is deterministic across restarts.
+
+## Non-goals
+
+These are explicitly **out of scope** for this design. Some may be added later as
+independent features; none are required for crash recovery of sequential sagas.
+
+- **Durable timers / long sleeps across restarts** (e.g. "wait 3 days").
+- **Distributed or multi-process execution** / worker pools.
+- **Signals, queries, or other external interaction** with a running workflow.
+- **Dynamic topology** that cannot be reconstructed from persisted state.
+- **Append-only log / compaction.** The snapshot model is sufficient for the
+  target workload; a WAL can be introduced later if a long-running use case
+  appears, behind the same `Resume` API.
+
+## Backward compatibility
+
+- Durability is **opt-in**. Workflows constructed today and run via `Execute` /
+  `RunWorkflow` are unchanged and write nothing to disk.
+- A workflow becomes durable by configuring a journal location (e.g.
+  `WithJournal(path)` on the builder) and invoking via `ResumeWorkflow`.
+- The journal format carries a `Version` field so the on-disk schema can evolve.
+
+## Open questions
+
+- Storage backend: start with a plain JSON file (snapshot) — should an embedded
+  KV (e.g. BoltDB) be offered as an alternative for many concurrent workflow
+  runs?
+- Journal lifecycle: delete on `PhaseDone`, or retain for audit and let the
+  caller prune?
+- Where should `WithJournal` live on the builder, and how is the path namespaced
+  per run (workflow ID + run ID)?
+- How strictly should `validateTopology` treat additive changes (e.g. new steps
+  appended after the last completed one)?

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,0 +1,64 @@
+# automa Specifications
+
+> Status: **proposed** — spec-first effort, under review.
+
+automa is intended to exist in more than one language (Go first, then others such
+as Kotlin, Python, and Rust) for the same audience and use cases described in
+[docs/README.md](../README.md).
+
+For a multi-language project the **product is the specification**, not any single
+implementation. Two runtimes that both "implement the Saga pattern" are worthless
+to a user if a workflow — especially a *durable* one — behaves differently
+depending on the language it happens to be written in. The specifications in this
+directory define the behavior that every conformant implementation MUST exhibit,
+so that:
+
+- a journal written by one implementation can be understood (and, where the
+  topology allows, reasoned about) by another, and
+- the resume/recovery semantics are identical everywhere, and
+- the obligations placed on workflow authors (e.g. idempotency) are one promise,
+  not a per-language footnote.
+
+## Principles
+
+1. **Spec first, implementation second.** Observable behavior is defined here in
+   language-neutral terms. The Go implementation is the **first conformant
+   implementation**, not the definition. Where the Go code and a spec disagree,
+   the spec is authoritative and the code is a bug.
+2. **On-disk formats are contracts.** Any artifact written to disk or exchanged
+   between processes (the durability journal, the report tree) has a versioned,
+   language-neutral schema. Field names and value enumerations are fixed by the
+   spec, not by a language's default serializer.
+3. **Conformance is testable.** Each spec is accompanied by language-neutral
+   **conformance fixtures** (input artifacts + expected outcomes, expressed as
+   plain JSON). Every implementation MUST pass the shared fixtures. The fixtures
+   are the source of truth for cross-language agreement.
+4. **The core stays small.** The smaller the specified core, the cheaper it is to
+   keep N implementations in agreement. Features outside the core (durable
+   timers, distributed execution, signals) are explicitly out of scope until and
+   unless they are specified here.
+
+## Conformance keywords
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHOULD**,
+**SHOULD NOT**, **MAY**, and **OPTIONAL** in these documents are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+## Specifications
+
+| Spec | Status | Description |
+|------|--------|-------------|
+| [Core](core-spec.md) | proposed | The saga model: step lifecycle, workflow execution loop, execution/rollback modes, composability, state model, and report tree. The foundation all implementations MUST satisfy. |
+| [Durability](durability-spec.md) | proposed | **Extends Core.** Journal format, execution state machine, persistence ordering, and resume/recovery semantics for crash-recoverable sequential sagas. |
+
+Specs layer: **Core** is the foundation; **Durability** is an extension built on
+top of it. Future features (timeouts, retries, backoff, parallelism) are expected
+to be additional extensions, each with its own spec and conformance fixtures, so
+the core stays small and stable.
+
+## Relationship to design docs
+
+`docs/durability.md` is the **design rationale** (why the feature exists, what it
+offers, the tradeoffs). This directory holds the **normative specification** (what
+an implementation MUST do). When they differ, the spec governs behavior; the
+design doc governs intent.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -52,9 +52,30 @@ interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 | [Durability](durability-spec.md) | proposed | **Extends Core.** Journal format, execution state machine, persistence ordering, and resume/recovery semantics for crash-recoverable sequential sagas. |
 
 Specs layer: **Core** is the foundation; **Durability** is an extension built on
-top of it. Future features (timeouts, retries, backoff, parallelism) are expected
-to be additional extensions, each with its own spec and conformance fixtures, so
-the core stays small and stable.
+top of it. Future features are additional extensions, each with its own spec and
+conformance fixtures, so the core stays small and stable.
+
+### Extension roadmap and ordering
+
+Extensions are added **only after core v1 and durability v1 are frozen** and the
+Go reference implementation passes their conformance fixtures. Planned order, by
+increasing risk to the core model:
+
+1. **Timeout** — per-step / per-workflow deadline. Orthogonal: a timed-out step
+   is simply a failure and flows through the existing mode/rollback machinery.
+2. **Retry / backoff** — execution-layer extension. Its main interaction is the
+   idempotency contract already defined by durability (a retried step has the
+   same obligation as a resumed one).
+3. **Branching / looping** — **deferred until there is concrete demand.** These
+   make topology conditional/dynamic, which conflicts with durability's core
+   constraint that topology is a static, reconstructible, ordered list. They MUST
+   NOT be added without a topology-model revision that durability can survive
+   (e.g. journaling the branch taken / iteration index). The target use cases
+   (CLI, provisioning, migration) are overwhelmingly linear, so this is low
+   priority.
+
+Parallel/concurrent step execution is likewise a post-v1 extension, not a core
+v1 concern.
 
 ## Relationship to design docs
 

--- a/docs/spec/core-spec.md
+++ b/docs/spec/core-spec.md
@@ -1,0 +1,465 @@
+# automa Core Specification
+
+> Status: **proposed** — normative spec, under review.
+> Version: **core model v1**
+
+This document is the **normative, language-neutral** specification for automa's
+core saga model: the step lifecycle, the workflow execution loop, execution and
+rollback modes, composability, the state model, and the report tree. It is the
+foundation every conformant implementation (Go first, then others) MUST satisfy.
+The [durability spec](durability-spec.md) is an **extension** layered on top of
+this core.
+
+Conformance keywords (**MUST**, **SHOULD**, **MAY**, …) are interpreted per
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119); see [README](README.md).
+
+This spec is **derived from** the Go reference implementation but is written to
+be correct in its own right. Where it intentionally departs from the current Go
+behavior, the divergence is called out inline as:
+
+> **⚠ Spec decision (differs from current Go implementation).** … The Go
+> implementation is to be adapted to match this spec.
+
+A consolidated list of such decisions is in §11.
+
+---
+
+## 1. Scope
+
+This spec covers the **single-process, sequential saga** model:
+
+- Steps and their lifecycle (§3).
+- Workflows: an ordered list of steps, executed in order, compensated in reverse
+  (§4, §5).
+- Execution modes and rollback modes (§5).
+- Composability: a workflow is itself a step (§6).
+- The state model and its serialization contract (§7).
+- The report tree and its serialization contract (§8).
+- Registry of step builders (§9).
+
+It does **not** cover (each MAY be a separate, versioned spec later): durability
+and resume (see [durability-spec.md](durability-spec.md)), timeouts, retries,
+backoff, parallel/concurrent step execution, distributed execution, signals.
+
+## 2. Terminology
+
+- **Implementation** — a language binding of automa.
+- **Step** — the smallest unit of work; has a unique ID and up to three lifecycle
+  phases (§3).
+- **Workflow** — a step that owns an ordered list of child steps and drives their
+  execution (§4). A workflow IS a step (§6).
+- **Topology** — the ordered list of a workflow's child step IDs, plus its
+  execution mode and rollback mode.
+- **Report** — the structured, serializable record of an outcome (§8).
+- **State bag** — a key-value store; **namespaced state bag** — the partitioned
+  per-step view of state (§7).
+- **Compensation / rollback** — undoing a completed step's work.
+
+## 3. Step
+
+### 3.1 Identity
+
+- Every step MUST have a non-empty, unique **ID** within its owning workflow.
+- An implementation MUST reject (at build/validation time) a workflow containing
+  a step with an empty ID or a duplicate ID.
+
+### 3.2 Lifecycle phases
+
+A step has three phases. Each is OPTIONAL to define; an undefined phase has the
+default behavior below.
+
+| Phase | Purpose | If not defined |
+|-------|---------|----------------|
+| **Prepare** | Enrich context, validate preconditions, pre-populate local state. Runs before Execute. | No-op; context passes through unchanged. |
+| **Execute** | Perform the step's primary work. Produce a report. | **Not allowed** — a step MUST define Execute (§3.2.1). |
+| **Rollback** | Undo Execute's work (compensation). | No-op; produces a **skipped** outcome. |
+
+#### 3.2.1 Execute is required
+
+- A step **MUST** define an Execute function. A step without Execute is invalid
+  and MUST be rejected at build/validation time (alongside the empty/duplicate-ID
+  checks of §3.1). This matches the principle that every step is a unit of *work*;
+  no-op grouping is expressed with a sub-workflow (§6), not an empty step.
+- The `skipped` status (§3.4) therefore arises only when a step's own Execute
+  logic decides no work is needed (e.g. "already provisioned"), or when an
+  undefined Rollback runs — never from a missing Execute.
+
+### 3.3 Phase contract
+
+- **Prepare** receives an execution context and returns a (possibly enriched)
+  context plus an optional error. A non-nil error MUST abort the step and be
+  treated by the workflow as a **step failure** (§5).
+  - The context returned by Prepare MUST be the context passed to that step's
+    Execute (and, where applicable, Rollback).
+- **Execute** receives the prepared context and MUST produce a non-nil report.
+  - If an implementation's Execute can return "no report," the engine MUST
+    synthesize a **failure** report rather than treat it as success.
+- **Rollback** receives the context and MUST produce a non-nil report; a missing
+  report MUST be synthesized as a **failure**.
+- **Rollback MUST be idempotent** — it MAY be invoked more than once for the same
+  step (e.g. a manual rollback after an automatic one, or a resumed compensation
+  under the durability extension).
+
+### 3.4 Step outcome (status)
+
+Every phase produces a report with exactly one **status**:
+
+| Status | Meaning |
+|--------|---------|
+| `success` | The phase completed without error. |
+| `failed` | The phase encountered an error. |
+| `skipped` | The phase performed no work (e.g. no Execute defined, or the step determined the work was already done). |
+
+- A report is **failed** if its status is `failed` **or** it carries a non-nil
+  error. (Status `success` with an attached error MUST be treated as failed.)
+- A report is **successful** only if status is `success` **and** it carries no
+  error.
+- `skipped` is **not** a failure: the workflow continues past a skipped step.
+
+### 3.5 Single-use and statefulness
+
+- A step instance is **single-use within one workflow execution**: it is owned
+  and driven by exactly one execution at a time and MUST NOT be shared across
+  concurrent executions.
+- The engine attaches a per-step state view to the step before Prepare (§7.3).
+
+  > **⚠ Spec decision (differs from current Go implementation).** The Go `Step`
+  > interface documents `WithState` as returning "a shallow copy of the step,"
+  > but both concrete implementations mutate in place and return the same
+  > instance. This spec does **not** require copy-on-attach; it requires only
+  > that, after the engine attaches state to a step, calls to that step's
+  > `State()` observe the attached bag, and that step instances are single-use
+  > (above). The misleading "shallow copy" wording MUST be corrected in the Go
+  > implementation to match this contract. *(See review issues #80–#84.)*
+
+## 4. Workflow execution
+
+### 4.1 Ordering
+
+- A workflow executes its steps **strictly sequentially**, in topology order,
+  one at a time. There is no concurrency between steps in core model v1.
+- Compensation (rollback) proceeds in **reverse** topology order.
+
+### 4.2 Workflow-level prepare
+
+- A workflow MAY define a workflow-level prepare hook, run once before any step.
+- If the workflow-level prepare fails, **no steps execute** and **no rollback
+  occurs** (nothing has run yet). The workflow produces a failure report whose
+  action is **prepare** (§8.3).
+
+### 4.3 Per-step execution loop
+
+For each step at index `i` in topology order:
+
+1. Construct and attach the step's state view (§7.3).
+2. Run the step's Prepare.
+   - On Prepare failure → record a **failed** step report (action = **prepare**,
+     see decision below) and apply the execution mode (§5) as for any failure.
+
+     > **⚠ Spec decision (differs from current Go implementation).** The Go loop
+     > records a step-Prepare failure with action **execute**. This spec requires
+     > action **prepare** for a Prepare-phase failure, so the report faithfully
+     > identifies the phase that failed. Implementations MUST be adapted.
+3. Run the step's Execute; collect its report. (Execute is always defined, §3.2.1.)
+4. Apply the execution mode based on the report's failed/not-failed status (§5).
+
+### 4.4 Workflow result
+
+- A workflow report is **successful** iff every executed step is non-failed
+  (success or skipped).
+- Otherwise the workflow report is **failed** and MUST include the IDs of the
+  failed steps and the per-step reports (§8).
+
+## 5. Execution and rollback modes
+
+Two independent modes are configured per workflow. Both are serialized as the
+lowercase strings below.
+
+### 5.1 Execution mode
+
+`execution_mode` governs what happens when a step's Execute (or Prepare) fails.
+
+| Value (string) | On step failure |
+|----------------|-----------------|
+| `stop` | Halt immediately. Skip all remaining steps. **No rollback.** (Default.) |
+| `continue` | Record the failure and **continue** executing remaining steps. No rollback. The workflow result is failed if any step failed. |
+| `rollback` | Halt, then **compensate** the failed step and all previously executed steps in reverse order (§5.3), then stop. |
+
+- The default execution mode is `stop`.
+- The exact decision is a pure function of `(execution_mode, step failed?)`:
+
+```
+step failed?  no  → proceed to next step (any mode)
+step failed?  yes → stop      : break, no rollback
+                    continue  : continue to next step
+                    rollback  : run compensation from i..0, then break
+```
+
+### 5.2 Rollback mode
+
+`rollback_mode` governs what happens when a **compensation** (a step's Rollback)
+itself fails, during a `rollback`-mode compensation pass.
+
+| Value (string) | On compensation failure |
+|----------------|--------------------------|
+| `continue` | Continue compensating the remaining (lower-index) steps. (Default.) |
+| `stop` | Stop the compensation pass immediately. |
+
+- The default rollback mode is `continue`.
+- `rollback_mode` is only consulted when `execution_mode` is `rollback`.
+
+  > **⚠ Spec decision (differs from current Go implementation).** Go's
+  > `TypeMode` allows `rollback` as a *rollback_mode* value (the enum is shared).
+  > This spec restricts `rollback_mode` to `{ continue, stop }`; `rollback` as a
+  > rollback_mode is meaningless and MUST be rejected at validation time.
+
+### 5.3 Compensation pass
+
+When `execution_mode` is `rollback` and step `i` fails:
+
+1. Compensation runs from index `i` down to `0` (the **failed step is included**,
+   so it can clean up partial work it performed before failing).
+2. Each step's Rollback receives that step's **execution-time state snapshot**
+   (§7.4), not the current live state.
+3. A step that was **skipped** (never executed) MUST NOT be compensated; its
+   Rollback MUST NOT be invoked.
+
+   > **⚠ Spec decision (differs from current Go implementation).** The Go
+   > `rollbackFrom` loop invokes `Rollback` on *every* step from `i` down to `0`
+   > unconditionally (a no-op Rollback merely returns skipped, but a *defined*
+   > Rollback on a step whose Execute never ran would still fire). This spec
+   > requires compensation to be limited to steps that actually executed
+   > (status `success` or `failed`), never `skipped`/`pending` steps. This is
+   > also required for correct durability resume. Implementations MUST be
+   > adapted to track per-step execution status and skip non-executed steps.
+
+4. Each compensation produces a rollback report; these are attached under the
+   corresponding step's report (§8.2).
+
+### 5.4 Manual rollback
+
+- An implementation MAY expose a direct "rollback the whole workflow" operation
+  independent of an execution failure.
+- If invoked, it compensates steps in reverse order using the most recent
+  execution-time snapshots if available, otherwise the current workflow state.
+- The §5.3 rule (do not compensate non-executed steps) applies equally.
+
+## 6. Composability
+
+- A workflow **is** a step: it satisfies the same lifecycle contract (§3) and
+  MAY be included as a child step of another workflow.
+- A nested (sub-)workflow:
+  - Receives an **isolated** view of state: a fresh local namespace and a
+    **deep clone** of the parent's global namespace (§7.3). Mutations inside the
+    sub-workflow MUST NOT propagate back to the parent's global state.
+  - Produces a workflow report that nests as one entry in the parent's
+    `StepReports` (§8.2).
+#### 6.1 Mode inheritance
+
+- A nested workflow **inherits its parent's** execution mode and rollback mode:
+  during assembly, the parent's modes are propagated to its child workflows, so
+  the entire tree executes under one consistent error-handling policy.
+- This is a deliberate uniformity guarantee: an operator configuring a top-level
+  workflow as `rollback` gets rollback semantics throughout the tree without
+  having to set the mode on every nested workflow.
+- A nested workflow's modes as configured on its own builder are therefore
+  advisory: they MAY be set for documentation or for standalone execution of that
+  workflow, but when it runs as a child its parent's modes apply.
+
+  > **Note.** The current Go `WorkflowBuilder` doc comment contradicts the actual
+  > overwrite behavior. The behavior (parent overrides) is correct per this spec;
+  > the **doc comment** MUST be corrected to match.
+
+- **Nested compensation.** When a parent compensates a child-workflow step, the
+  child workflow's own compensation logic runs (it rolls back its own steps in
+  reverse). How the nested rollback report is represented under the parent is
+  defined in §8.2.
+
+## 7. State model
+
+### 7.1 State bag
+
+- A **state bag** is a key-value store (string keys → arbitrary values).
+- It MUST support: get (raw), set, delete, clear, list keys, size, snapshot of
+  items, merge, and deep clone.
+- It MUST be serializable to and from a language-neutral object form (§7.5).
+
+### 7.2 Namespaces
+
+A **namespaced state bag** partitions state into:
+
+| Namespace | Visibility |
+|-----------|-----------|
+| **Local** | Private to one step. Never visible to any other step. |
+| **Global** | Shared across all steps in a workflow. Writes by one step are visible to subsequent steps. |
+| **Custom (named)** | An isolated, explicitly named partition, created on first access. Isolated from Local, Global, and other custom namespaces. |
+
+### 7.3 State injection (per step)
+
+Before a step's Prepare, the engine MUST attach a namespaced state bag built as
+follows:
+
+- **Ordinary step:** fresh empty **Local**; **Global** is the *same shared*
+  global bag as the workflow's (mutations are visible to later steps).
+- **Sub-workflow step:** fresh empty **Local**; **Global** is a *deep clone* of
+  the workflow's global bag (isolation, per §6).
+
+Custom namespaces are created on demand within a step's own bag and are scoped to
+that step's bag (they are not shared across steps).
+
+> **Note (portability hazard, not yet a decision).** The current model does not
+> propagate custom namespaces from the workflow to a step's injected bag, nor
+> across steps. This is intentional today, but cross-language implementations
+> MUST agree on it. It is captured as an open question in §10.
+
+### 7.4 Execution-time snapshots
+
+- After each step is processed (whether it succeeded or failed), the engine
+  SHOULD capture a **deep-cloned snapshot** of that step's state (Local + Global
+  + custom namespaces at that moment), keyed by step ID, for use during
+  compensation (§5.3).
+- Snapshot capture MAY be disabled as an optimization. When disabled,
+  compensation receives the current workflow (global) state instead of a
+  per-step snapshot, and per-step Local namespaces are not available during
+  compensation. Implementations that offer this toggle MUST document the
+  tradeoff. (Default: snapshots enabled.)
+- If snapshot cloning fails, the engine MUST NOT fail the step for that reason
+  alone; it SHOULD fall back to retaining a non-cloned reference and log a
+  warning, so that compensation can still be attempted.
+
+### 7.5 Serialization contract (cross-language)
+
+This is the part most likely to diverge across languages and is therefore
+normative:
+
+- A state bag serializes to a JSON object: key (string) → value.
+- After a JSON round-trip, numeric values MAY be decoded as floating point.
+  Implementations MUST provide **coercing typed accessors** (integer, float,
+  bool, string) that recover the intended type from the round-tripped value.
+- Implementations MUST agree on numeric range/precision behavior so that a state
+  bag written by one language loads losslessly in another. The boundary rules
+  (e.g. large 64-bit integers vs. float64 mantissa) MUST be specified and shared
+  as conformance fixtures (§7.6 references `state-numeric-boundaries.md`).
+- `null` / nil values MUST be storable and MUST be distinguishable from an absent
+  key.
+
+### 7.6 Reference
+
+The existing design docs `state-serialization.md`, `state-numeric-boundaries.md`,
+and `state-preservation.md` describe the Go behavior. The normative cross-language
+rules (and their fixtures) are owned by this spec; those docs are the rationale.
+
+## 8. Report
+
+The report is automa's primary observability primitive and a key differentiator:
+it is a fully serializable tree describing an entire run. Its schema is therefore
+a cross-language contract.
+
+### 8.1 Report fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `id` | string | The step or workflow ID that produced the report. |
+| `isWorkflow` | bool | True if produced by a workflow. |
+| `action` | string | Phase that produced it: `prepare` / `execute` / `rollback`. |
+| `status` | string | `success` / `failed` / `skipped`. |
+| `startTime`, `endTime` | timestamp | Phase wall-clock bounds. |
+| `detail` | string, optional | Human-readable context. |
+| `error` | string, optional | Failure message (the error rendered as a string). |
+| `metadata` | object, optional | String→string structured diagnostics. |
+| `steps` | array, optional | Child step reports (workflow reports only), in execution order. |
+| `rollback` | object, optional | Nested rollback report tree (§8.2). |
+| `executionMode`, `rollbackMode` | string, optional | Modes in effect when produced. |
+
+- `action`, `status`, `executionMode`, and `rollbackMode` MUST serialize as the
+  lowercase string forms defined in this spec, never as numeric ordinals.
+
+  > **⚠ Spec decision (differs from current Go implementation).** Go's
+  > `TypeAction` and `TypeStatus` silently map *unknown* string values to a
+  > default on unmarshal (`action`→`prepare`, etc.), unlike `TypeMode` which
+  > errors. For a cross-language wire contract this is unsafe: an unknown enum
+  > value MUST be a decode error, not a silent default, so format drift is
+  > caught. Implementations MUST be adapted to fail on unknown enum values for
+  > all three enums.
+
+### 8.2 Nesting
+
+- A **workflow report** nests its per-step reports under `steps`, in execution
+  order.
+- When a step is itself a sub-workflow, that sub-workflow's report is the entry
+  under the parent's `steps`.
+- When compensation runs, the rollback outcomes are nested under the `rollback`
+  field of the report for the step that triggered the rollback. The rollback
+  report is itself a (workflow-shaped) report whose `steps` are the per-step
+  rollback reports, in compensation order (reverse execution order).
+
+### 8.3 Action and status invariants
+
+- A `prepare`-phase failure MUST carry action `prepare` (§4.3 decision).
+- An `execute`-phase report MUST carry action `execute`.
+- A rollback report MUST carry action `rollback`.
+- `isFailed` ≡ (`status == failed`) OR (`error` present).
+- `isSuccess` ≡ (`status == success`) AND (no `error`).
+
+## 9. Registry (optional component)
+
+- A **registry** is a thread-safe store of named step **builders**, enabling
+  workflows to be assembled by ID rather than by direct constructor reference.
+- Registry semantics:
+  - Adding a builder whose ID already exists MUST fail, and a batch add MUST be
+    atomic (all-or-nothing).
+  - Lookups by ID return the builder or a not-found indication.
+- The registry is OPTIONAL for conformance; it is an assembly convenience, not
+  part of the execution model.
+
+## 10. Open questions
+
+These MUST be resolved before core model v1 is frozen, because they affect
+cross-language behavior:
+
+1. **Custom namespace propagation (§7.3).** Should custom namespaces ever be
+   shared across steps or inherited by sub-workflows, or remain strictly
+   step-scoped? Current behavior is strictly step-scoped.
+2. **Numeric precision boundaries (§7.5).** The exact rule for 64-bit integers
+   that exceed float64's exact-integer range, across languages that lack a
+   distinct integer type after JSON decode.
+3. **Timestamp format.** `startTime`/`endTime` wire format (RFC 3339 string vs.
+   epoch) and required precision, for cross-language report exchange.
+4. **Metadata value typing.** Metadata is currently string→string. Should values
+   be allowed to be arbitrary JSON, or remain strings for portability?
+5. **Sub-workflow rollback report shape (§8.2).** Pin the exact nesting for a
+   compensated child workflow before claiming nested durability.
+
+## 11. Consolidated spec decisions (Go to be adapted)
+
+Each is a place where this spec is written "the right way" and the Go reference
+implementation is to be adapted (or the decision confirmed before freezing):
+
+| # | Decision | §  |
+|---|----------|----|
+| D2 | `WithState` contract: attach-and-observe + single-use; fix the misleading "shallow copy" docs. | 3.5 |
+| D3 | Step **Prepare** failure reports action `prepare`, not `execute`. | 4.3 |
+| D4 | `rollback_mode` restricted to `{ continue, stop }`; reject `rollback`. | 5.2 |
+| D5 | Compensation MUST skip non-executed (`skipped`/`pending`) steps. | 5.3 |
+| D7 | Report enums (`action`, `status`) MUST fail on unknown values on decode, like `mode`. | 8.1 |
+
+**Resolved to match current behavior (no code change to logic; docs only):**
+
+| # | Decision | §  |
+|---|----------|----|
+| D1 | A step **MUST** define Execute; a no-execute step is a validation error. | 3.2.1 |
+| D6 | Nested workflows **inherit** the parent's modes (parent overrides). Fix the contradicting builder doc comment. | 6.1 |
+
+## 12. Conformance
+
+- Cross-language agreement is verified by shared fixtures under
+  `docs/spec/conformance/`, of two kinds:
+  - **Behavior fixtures** — a workflow definition (steps with declared
+    success/fail/skip outcomes) + the expected report tree and execution order,
+    for each mode combination. These verify §4–§6 and §8 identically across
+    implementations without real side effects.
+  - **Serialization fixtures** — state bags and report trees in JSON that every
+    implementation MUST load and re-serialize equivalently (§7.5, §8).
+- The **Go** implementation is the first conformant implementation and a
+  reference, not the definition. A divergence between Go behavior and this spec
+  is a Go bug (or a §11 item pending adaptation), not a spec amendment.

--- a/docs/spec/core-spec.md
+++ b/docs/spec/core-spec.md
@@ -291,26 +291,47 @@ A **namespaced state bag** partitions state into:
 | Namespace | Visibility |
 |-----------|-----------|
 | **Local** | Private to one step. Never visible to any other step. |
-| **Global** | Shared across all steps in a workflow. Writes by one step are visible to subsequent steps. |
-| **Custom (named)** | An isolated, explicitly named partition, created on first access. Isolated from Local, Global, and other custom namespaces. |
+| **Global** | The default shared room: shared across all steps in a workflow. Writes by one step are visible to subsequent steps. |
+| **Custom (named)** | A **named shared room**: shared across all steps in the workflow under an explicit name, created on first access. A sibling of Global, not a child of it. Isolated from Local and from *other* named rooms, but **not** isolated between steps. |
+
+#### 7.2.1 Custom namespaces are shared, named rooms
+
+- Global and the custom namespaces together form the workflow's **shared state
+  space**. Global is the default unnamed room; `WithNamespace(name)` is a named
+  room. Both are shared across all steps in the workflow.
+- A step that writes to `WithNamespace("database-primary")` publishes data that
+  any later step reading the same named room observes. This is the intended use:
+  a reusable step instance publishes under a distinct name (e.g.
+  `"database-primary"` vs `"database-replica"`) so a consuming step can read the
+  right instance's data without the flat-Global key collisions that would
+  otherwise occur.
+- **Collisions within a named room are by design, not prevented.** Multiple steps
+  writing the same key in the same named room overwrite each other, exactly as in
+  Global. Authors SHOULD use a key convention (e.g. a prefix) to avoid accidental
+  collisions, and MAY deliberately overwrite to let a set of cooperating steps
+  reuse values written by another step. The engine does not arbitrate.
+- Named rooms are isolated **from each other** and from Local; they are not
+  isolated **between steps** (that is the whole point — they are shared).
 
 ### 7.3 State injection (per step)
 
 Before a step's Prepare, the engine MUST attach a namespaced state bag built as
-follows:
+follows. "Shared state space" means **Global plus all named rooms** (§7.2.1):
 
-- **Ordinary step:** fresh empty **Local**; **Global** is the *same shared*
-  global bag as the workflow's (mutations are visible to later steps).
-- **Sub-workflow step:** fresh empty **Local**; **Global** is a *deep clone* of
-  the workflow's global bag (isolation, per §6).
+- **Ordinary step:** fresh empty **Local**; the *same shared* state space as the
+  workflow's — both Global and the named rooms are shared by reference, so writes
+  to either are visible to later steps.
+- **Sub-workflow step:** fresh empty **Local**; a *deep clone* of the workflow's
+  entire shared state space — both Global and every named room are cloned, so the
+  sub-workflow inherits the parent's shared state but its mutations (to Global or
+  any named room) MUST NOT propagate back to the parent (isolation, per §6).
 
-Custom namespaces are created on demand within a step's own bag and are scoped to
-that step's bag (they are not shared across steps).
-
-> **Note (portability hazard, not yet a decision).** The current model does not
-> propagate custom namespaces from the workflow to a step's injected bag, nor
-> across steps. This is intentional today, but cross-language implementations
-> MUST agree on it. It is captured as an open question in §10.
+> **Resolved (was an open question).** Custom namespaces are workflow-scoped
+> shared named rooms, propagated to every step's injected bag by reference and
+> deep-cloned for sub-workflows alongside Global. This realizes the
+> `"database-primary"` use case the model was designed for. The previous
+> step-private behavior (review issue #83) is to be changed; the Go
+> implementation MUST be adapted (§11, D8).
 
 ### 7.4 Execution-time snapshots
 
@@ -336,10 +357,18 @@ normative:
 - After a JSON round-trip, numeric values MAY be decoded as floating point.
   Implementations MUST provide **coercing typed accessors** (integer, float,
   bool, string) that recover the intended type from the round-tripped value.
-- Implementations MUST agree on numeric range/precision behavior so that a state
-  bag written by one language loads losslessly in another. The boundary rules
-  (e.g. large 64-bit integers vs. float64 mantissa) MUST be specified and shared
-  as conformance fixtures (§7.6 references `state-numeric-boundaries.md`).
+- **Numeric precision policy (normative).** JSON has a single number type, and a
+  round-trip through floating point can represent integers exactly only up to
+  2^53. Values beyond that range (e.g. large 64-bit IDs) CANNOT be guaranteed to
+  survive a round-trip as numbers across languages.
+  - For values that must round-trip losslessly and exceed the safe integer
+    range, authors SHOULD store them as **strings** (e.g. a 64-bit ID as
+    `"9007199254740993"`), and use the string accessor to read them back.
+  - Implementations MUST document this limitation prominently. An author who
+    stores a large value as a JSON *number* accepts the precision risk; the
+    engine does not silently widen or arbitrate.
+  - The exact safe-integer boundary and the recommended string convention MUST be
+    shared as conformance fixtures so every language agrees on the cutoff.
 - `null` / nil values MUST be storable and MUST be distinguishable from an absent
   key.
 
@@ -363,7 +392,7 @@ a cross-language contract.
 | `isWorkflow` | bool | True if produced by a workflow. |
 | `action` | string | Phase that produced it: `prepare` / `execute` / `rollback`. |
 | `status` | string | `success` / `failed` / `skipped`. |
-| `startTime`, `endTime` | timestamp | Phase wall-clock bounds. |
+| `startTime`, `endTime` | RFC 3339 string (ms precision, tz designator) | Phase wall-clock bounds, e.g. `2026-06-17T10:30:00.123Z` (§10.4). |
 | `detail` | string, optional | Human-readable context. |
 | `error` | string, optional | Failure message (the error rendered as a string). |
 | `metadata` | object, optional | String→string structured diagnostics. |
@@ -414,21 +443,26 @@ a cross-language contract.
 
 ## 10. Open questions
 
-These MUST be resolved before core model v1 is frozen, because they affect
-cross-language behavior:
+**Resolved (folded into the spec):**
 
-1. **Custom namespace propagation (§7.3).** Should custom namespaces ever be
-   shared across steps or inherited by sub-workflows, or remain strictly
-   step-scoped? Current behavior is strictly step-scoped.
-2. **Numeric precision boundaries (§7.5).** The exact rule for 64-bit integers
-   that exceed float64's exact-integer range, across languages that lack a
-   distinct integer type after JSON decode.
-3. **Timestamp format.** `startTime`/`endTime` wire format (RFC 3339 string vs.
-   epoch) and required precision, for cross-language report exchange.
-4. **Metadata value typing.** Metadata is currently string→string. Should values
-   be allowed to be arbitrary JSON, or remain strings for portability?
-5. **Sub-workflow rollback report shape (§8.2).** Pin the exact nesting for a
-   compensated child workflow before claiming nested durability.
+1. **Custom namespace propagation (§7.2.1, §7.3).** *Resolved:* workflow-scoped
+   shared named rooms, deep-cloned for sub-workflows. (D8.)
+2. **Numeric precision boundaries (§7.5).** *Resolved:* document the 2^53
+   boundary; recommend string-typed numerics for values beyond it; authors using
+   JSON numbers accept the risk.
+3. **Metadata value typing (§8.1).** *Resolved:* `string → string` (matches
+   solo-provisioner usage; maximizes portability).
+4. **Timestamp format (§8.1).** *Resolved:* `startTime`/`endTime` serialize as
+   **RFC 3339 / ISO 8601 strings with millisecond precision and a timezone
+   designator** (e.g. `2026-06-17T10:30:00.123Z`).
+5. **Sub-workflow rollback report shape (§8.2).** *Resolved:* a compensated child
+   workflow's rollback report nests **inline** under the parent step's `rollback`
+   field, recursively — a child's rollback is itself a workflow-shaped report.
+
+**Still open:**
+
+- None blocking core v1. (Conformance fixtures must encode the numeric boundary
+  and the timestamp format precisely; see §12.)
 
 ## 11. Consolidated spec decisions (Go to be adapted)
 
@@ -442,6 +476,7 @@ implementation is to be adapted (or the decision confirmed before freezing):
 | D4 | `rollback_mode` restricted to `{ continue, stop }`; reject `rollback`. | 5.2 |
 | D5 | Compensation MUST skip non-executed (`skipped`/`pending`) steps. | 5.3 |
 | D7 | Report enums (`action`, `status`) MUST fail on unknown values on decode, like `mode`. | 8.1 |
+| D8 | Custom namespaces become **workflow-scoped shared named rooms** (propagated by reference to steps, deep-cloned for sub-workflows), replacing the current step-private behavior. | 7.2.1, 7.3 |
 
 **Resolved to match current behavior (no code change to logic; docs only):**
 

--- a/docs/spec/durability-spec.md
+++ b/docs/spec/durability-spec.md
@@ -1,0 +1,385 @@
+# automa Durability Specification
+
+> Status: **proposed** — normative spec, under review.
+> Version: **journal schema v1**
+
+This document is the **normative, language-neutral** specification for automa's
+crash-recovery durability. It defines the on-disk journal format, the execution
+state machine, the persistence ordering, and the resume semantics that every
+conformant implementation MUST exhibit.
+
+This spec **extends** the [core spec](core-spec.md). It reuses the core's
+definitions of step, lifecycle phases, execution/rollback modes, state bag, and
+report tree without redefining them; it adds persistence and resume on top. Where
+a term here is undefined, it is defined in the core spec.
+
+The conformance keywords (**MUST**, **SHOULD**, **MAY**, …) are interpreted per
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119); see [README](README.md).
+
+For the *rationale* behind this design (what it offers, the tradeoffs, the worked
+crash-and-resume walkthrough), see [docs/durability.md](../durability.md). Where
+that design doc and this spec disagree, **this spec governs behavior**.
+
+---
+
+## 1. Scope
+
+This spec covers crash recovery for **sequential sagas**: an ordered list of
+steps executed in order, with compensation (rollback) in reverse order. It
+specifies:
+
+- the journal artifact (§3) and its lifecycle,
+- the step and workflow state machines (§4),
+- the persistence ordering relative to step side effects (§5),
+- the resume algorithm (§6),
+- the obligations on workflow authors (§7),
+- conformance fixtures (§8).
+
+It does **not** cover: durable timers / long sleeps across restarts, distributed
+or multi-process execution, signals/queries, or dynamically generated topology.
+These are out of scope for journal schema v1.
+
+## 2. Terminology
+
+- **Implementation** — a language binding of automa (Go, Kotlin, Python, Rust, …).
+- **Workflow definition / topology** — the ordered list of step IDs, the
+  execution mode, and the rollback mode, as constructed in caller code.
+- **Run** — a single attempt to execute a workflow definition, identified by a
+  workflow ID. A run MAY span multiple processes (an original attempt plus one or
+  more resumes).
+- **Journal** — the persisted, language-neutral record of a run's progress (§3).
+- **Side effect** — any externally observable action a step performs (creating a
+  resource, mutating a machine, writing to a remote system).
+- **Commit point** — the moment the journal records a step as `completed`.
+- **Write-ahead record** — the journal write that marks a step `started` *before*
+  its side effect runs.
+
+## 3. The journal
+
+### 3.1 Encoding
+
+- The journal MUST be encoded as **UTF-8 JSON**.
+- Object keys are **exactly** as specified in §3.3 (snake_case). Implementations
+  MUST NOT rename keys to match a language's idioms in the on-disk form.
+- Unknown keys encountered on read MUST be **ignored** (forward compatibility),
+  except that an unknown `version` MUST be handled per §3.5.
+- Enumerated string values (§4) are **lowercase** and fixed by this spec.
+
+### 3.2 Identity and granularity
+
+- There is **one journal per run**.
+- The journal is a **snapshot**: the entire journal is rewritten on each
+  transition (it is not an append-only log). Recovery granularity is therefore
+  the **step boundary** — an implementation MUST NOT claim to resume into the
+  middle of a step's execution.
+
+### 3.3 Schema (journal v1)
+
+```jsonc
+{
+  "version": 1,                       // integer; schema version (§3.5)
+  "workflow_id": "setup_local_dev",   // string; identifies the run's workflow
+  "execution_mode": "RollbackOnError",// string; one of the execution modes (§4.3)
+  "rollback_mode":  "StopOnError",    // string; one of the rollback modes (§4.3)
+  "phase":  "forward",                // string; workflow phase (§4.1)
+  "cursor": 1,                        // integer; index of the step currently worked on
+  "global": { /* state bag */ },      // object; shared (global) state, serialized
+  "steps": [                          // array; one entry per step, in topology order
+    {
+      "id": "create-network",         // string; step ID (MUST match topology)
+      "state": "completed",           // string; step state (§4.2)
+      "snapshot": { /* state bag */ },// object, OPTIONAL; per-step execution state for rollback
+      "report":   { /* report */ }    // object, OPTIONAL; the step's report tree
+    }
+  ]
+}
+```
+
+Field requirements:
+
+- `version`, `workflow_id`, `execution_mode`, `rollback_mode`, `phase`,
+  `cursor`, and `steps` are **REQUIRED**.
+- `steps` MUST contain exactly one entry per step in the workflow definition,
+  in topology order. `steps[i].id` MUST equal the i-th step ID of the topology.
+- `snapshot` and `report` are **OPTIONAL** per step and MAY be omitted when not
+  yet produced (e.g. a `pending` step). `snapshot`, when present, is the state
+  captured for use during compensation.
+- `global` MAY be an empty object but the key SHOULD be present.
+- The serialization of `global`, `snapshot`, and `report` is governed by their
+  own (existing) language-neutral schemas (state bag, report tree). This spec
+  treats them as opaque nested objects and constrains only their placement.
+
+### 3.4 Cursor
+
+- `cursor` is the index into `steps` of the step the run is currently working on.
+- In `forward` phase, `cursor` is the index of the most recently `started` step.
+- In `compensating` phase, `cursor` is the index from which compensation
+  proceeds downward (toward 0).
+- In `done` phase, `cursor` is unconstrained and MUST be ignored by readers.
+
+### 3.5 Versioning
+
+- An implementation MUST read its own `version` and any lower version it declares
+  support for.
+- On encountering a `version` it does not support, an implementation MUST fail
+  loudly (§6.2) and MUST NOT attempt to resume. Silent restart is forbidden
+  because it risks re-executing side effects.
+
+### 3.6 Durable write (atomicity)
+
+A journal write MUST be **atomic** with respect to crashes, including crashes
+during the write itself. A reader (including a post-crash reader) MUST observe
+either the complete previous journal or the complete new journal, never a torn
+or partial file.
+
+The REQUIRED procedure is:
+
+1. Serialize the journal to bytes.
+2. Write the bytes to a temporary file in the **same directory** as the target.
+3. Flush the temporary file's data to stable storage (`fsync` or the platform
+   equivalent) **before** the rename. This is REQUIRED to survive power loss, not
+   merely process crash.
+4. Atomically rename the temporary file over the target path.
+
+Implementations on POSIX filesystems MUST use `rename(2)` (atomic). Implementations
+on platforms without an atomic same-volume rename MUST use the closest equivalent
+that preserves the all-or-nothing guarantee.
+
+## 4. State machine
+
+### 4.1 Workflow phases
+
+```
+forward ──▶ done
+   │
+   └──▶ compensating ──▶ done
+```
+
+| Phase | Meaning |
+|-------|---------|
+| `forward` | Executing steps in topology order. |
+| `compensating` | Rolling back completed steps in reverse order. |
+| `done` | Terminal. The run is finished (success, fully compensated, or terminally failed per mode). |
+
+- A run starts in `forward`.
+- A run enters `compensating` only when a step fails **and** the execution mode is
+  `RollbackOnError` (§4.3).
+- `done` is terminal; once written, no further step transitions occur for the run.
+
+### 4.2 Step states
+
+```
+pending ──▶ started ──▶ completed
+                  │
+                  └────▶ failed
+
+completed ──▶ compensated      (during compensating phase)
+```
+
+| State | Meaning |
+|-------|---------|
+| `pending` | Not yet started. |
+| `started` | Write-ahead record written; side effect MAY or MAY NOT have run. |
+| `completed` | Execute succeeded; commit point recorded. |
+| `failed` | Execute failed. |
+| `compensated` | Rollback for this step completed. |
+
+- A step found in `started` but not `completed` after a crash is the **ambiguous
+  case**: its side effect's completion is unknown. It MUST be re-executed on
+  resume (§6.3), which is why §7 requires step idempotency.
+- A `skipped` outcome (e.g. a step the engine deliberately did not run) MAY be
+  represented; if so it MUST be treated as not requiring compensation. (Skip
+  semantics are governed by the engine's execution-mode rules and are not
+  expanded here.)
+
+### 4.3 Modes
+
+The journal records two modes, both as strings:
+
+- `execution_mode` ∈ { `StopOnError`, `ContinueOnError`, `RollbackOnError` }.
+- `rollback_mode` ∈ { `StopOnError`, `ContinueOnError` }.
+
+These values MUST be spelled exactly as above (matching automa's existing
+`TypeMode` values). The modes recorded in the journal MUST equal the modes of the
+workflow definition supplied at resume (§6.2 topology validation includes mode
+agreement).
+
+## 5. Persistence ordering
+
+The following ordering is **normative**. It is what makes recovery decidable.
+Per step at index `i` in `forward` phase:
+
+```
+F1. steps[i].state = "started"; cursor = i;   PERSIST   ← write-ahead, BEFORE side effect
+F2. run the step's prepare (if any)
+F3. run the step's execute  (THE SIDE EFFECT happens here)
+F4. steps[i].state   = "completed" | "failed"
+    steps[i].snapshot = <execution-time state>          (when completed, for rollback)
+    steps[i].report   = <step report>
+    global            = <current global state>
+                                               PERSIST   ← commit point, AFTER side effect
+F5. on failure with execution_mode = RollbackOnError:
+    phase = "compensating"; cursor = i;        PERSIST
+```
+
+Per step at index `i` in `compensating` phase (iterating `cursor → 0`):
+
+```
+C1. if steps[i].state == "compensated": skip (idempotent resume)
+C2. restore the step's snapshot; run the step's rollback (THE COMPENSATING SIDE EFFECT)
+C3. steps[i].state = "compensated"; cursor = i;   PERSIST   ← per-compensation commit
+```
+
+On completion:
+
+```
+D1. phase = "done";                                PERSIST   (the journal MAY then be deleted, §6.5)
+```
+
+Requirements:
+
+- F1 MUST happen, and its PERSIST MUST be durable (§3.6), **before** F3 runs the
+  side effect. An implementation MUST NOT run a step's side effect before its
+  `started` record is durably written.
+- F4's PERSIST MUST happen **after** the side effect returns and **before** the
+  next step's F1.
+- In `compensating` phase, each step's `compensated` record (C3) MUST be durably
+  written before proceeding to the next-lower index, so an interrupted rollback
+  resumes without repeating already-compensated steps.
+
+## 6. Resume
+
+### 6.1 Entry
+
+Resume is the public recovery entry point. The caller MUST re-supply the same
+workflow definition (the same builder/code that produced the original run); the
+implementation rehydrates the journal onto it and continues.
+
+A resume:
+
+1. Loads the journal (§6.2).
+2. Validates topology and modes against the supplied definition (§6.2).
+3. Rehydrates `global` onto the workflow.
+4. Dispatches on `phase` (§6.3, §6.4, §6.5).
+
+### 6.2 Loading and validation
+
+- **Missing journal** → the implementation MUST treat this as a fresh run: begin
+  in `forward` at index 0 and write a new journal. (Resume of a never-started run
+  is a normal start.)
+- **Corrupt or unreadable journal**, or **unsupported `version`** → the
+  implementation MUST fail loudly and MUST NOT resume or restart. Silently
+  restarting could re-execute side effects.
+- **Topology / mode mismatch** → if the supplied definition's ordered step IDs,
+  `execution_mode`, or `rollback_mode` do not equal those recorded in the
+  journal, the implementation MUST refuse to resume and report the mismatch. This
+  is the single-process analogue of workflow versioning; it is intentionally
+  strict. Implementations MAY offer an explicit, opt-in relaxation for additive
+  changes (e.g. steps appended after the last completed step), but the default
+  MUST be strict refusal.
+
+### 6.3 Forward resume (`phase == "forward"`)
+
+1. Identify the first step not in state `completed` (the lowest index whose state
+   is `pending`, `started`, or `failed`).
+2. If that step is in state `started` (ambiguous case), it MUST be **re-executed**
+   — the side effect's completion before the crash is unknown. Re-execution
+   relies on step idempotency (§7).
+3. Continue executing forward from that index per §5, honoring `execution_mode`.
+4. Steps already in state `completed` MUST NOT be re-executed.
+
+### 6.4 Compensation resume (`phase == "compensating"`)
+
+1. Continue compensating from `cursor` downward toward index 0 per §5 (C1–C3).
+2. Steps already in state `compensated` MUST be skipped.
+3. Honoring `rollback_mode` governs whether a failed compensation stops the
+   rollback or continues to lower indices.
+
+### 6.5 Done (`phase == "done"`)
+
+- The run is terminal. Resume MUST return the recorded final result and MUST NOT
+  execute or compensate any step.
+- An implementation MAY delete the journal on reaching `done` (D1). If it does,
+  a subsequent resume sees a missing journal and treats it as a fresh run (§6.2);
+  implementations that rely on idempotent steps tolerate this, but implementations
+  SHOULD document their journal-retention choice.
+
+## 7. Workflow-author contract
+
+Durability shifts a bounded, well-defined set of obligations onto the workflow
+author. These are **part of the spec** because they are a cross-language promise
+to users, identical in every implementation. Implementations MUST document them
+prominently.
+
+1. **Steps MUST be idempotent.** A step found `started`-but-not-`completed` is
+   re-executed on resume (§6.3). Running a step twice MUST be equivalent to
+   running it once.
+2. **Compensations MUST be idempotent.** A compensation MAY be retried across a
+   crash during the `compensating` phase.
+3. **Resume-relevant data MUST live in serialized state.** Anything a step needs
+   to resume or to compensate (resource IDs, handles, prior outputs) MUST be
+   written to global state or the step's namespaced state (which is persisted),
+   not held only in in-memory closures or fields that do not survive the process.
+4. **Topology MUST be reconstructible.** The same ordered set of step IDs (and
+   the same modes) MUST be produced by the caller's code at resume time. If steps
+   are derived from runtime data, that data MUST itself be persisted so the
+   topology is deterministic across restarts.
+
+## 8. Conformance
+
+### 8.1 Fixtures
+
+Cross-language agreement is verified by **shared conformance fixtures**: plain
+JSON, no language dependency. Fixtures live under `docs/spec/conformance/` and
+are of two kinds:
+
+- **Journal fixtures** — a `journal.json` plus assertions about how a conformant
+  reader MUST classify it (phase, first-incomplete index, which steps re-run,
+  which are skipped). These verify the §6 resume *decision logic* without running
+  side effects.
+- **Round-trip fixtures** — a `journal.json` that every implementation MUST be
+  able to load and re-serialize to a byte-equivalent (modulo insignificant JSON
+  whitespace and key-order-independent) journal, verifying schema agreement (§3).
+
+Each implementation MUST include a test harness that loads every fixture and
+asserts the expected outcome. Adding a behavior to the spec REQUIRES adding or
+updating a fixture.
+
+### 8.2 What conformance does and does not prove
+
+- Fixtures prove **schema agreement** and **resume decision agreement** across
+  implementations — the parts that must be identical for a journal to be portable
+  and for recovery to be predictable.
+- Fixtures do **not** prove that a given workflow's steps are idempotent (§7);
+  that is the author's responsibility and is outside what the engine can verify.
+
+### 8.3 Reference implementation
+
+The **Go** implementation is the first conformant implementation. It is a
+*reference*, not the definition: a divergence between the Go behavior and this
+spec is a bug in the Go implementation, not an amendment to the spec.
+
+## 9. Non-goals (journal schema v1)
+
+Explicitly out of scope; each MAY be specified later as a separate, versioned
+addition, but none is required for crash recovery of sequential sagas:
+
+- Durable timers / long sleeps across restarts.
+- Distributed or multi-process execution / worker pools.
+- Signals, queries, or other interaction with a running workflow.
+- Dynamically generated topology not reconstructible from persisted state.
+- Append-only log / compaction (the snapshot model is sufficient for the target
+  workload).
+
+## 10. Open questions
+
+- **Run-ID namespacing.** How is the journal path namespaced per run
+  (workflow ID + generated run ID)? Affects concurrent runs of the same workflow.
+- **Storage backend.** v1 is a single JSON file. Should an embedded KV store be
+  offered as an alternative for many concurrent runs, behind the same semantics?
+- **Report nesting for sub-workflows.** A step MAY itself be a workflow. How is a
+  nested run's journal represented — inline under the parent step, or as a linked
+  child journal? (Must be pinned before sub-workflow durability is claimed.)
+- **State-bag numeric/precision portability.** Cross-language number handling for
+  the serialized state bag (see `docs/state-numeric-boundaries.md`) MUST be
+  reconciled so a journal written by one language loads losslessly in another.

--- a/docs/spec/durability-spec.md
+++ b/docs/spec/durability-spec.md
@@ -83,7 +83,9 @@ These are out of scope for journal schema v1.
   "rollback_mode":  "StopOnError",    // string; one of the rollback modes (§4.3)
   "phase":  "forward",                // string; workflow phase (§4.1)
   "cursor": 1,                        // integer; index of the step currently worked on
-  "global": { /* state bag */ },      // object; shared (global) state, serialized
+  "shared": { /* namespaced bag */ }, // object; the workflow's shared state space:
+                                       //   Global + all named rooms (§ core 7.2.1).
+                                       //   Excludes per-step Local (captured per step).
   "steps": [                          // array; one entry per step, in topology order
     {
       "id": "create-network",         // string; step ID (MUST match topology)
@@ -104,10 +106,12 @@ Field requirements:
 - `snapshot` and `report` are **OPTIONAL** per step and MAY be omitted when not
   yet produced (e.g. a `pending` step). `snapshot`, when present, is the state
   captured for use during compensation.
-- `global` MAY be an empty object but the key SHOULD be present.
-- The serialization of `global`, `snapshot`, and `report` is governed by their
-  own (existing) language-neutral schemas (state bag, report tree). This spec
-  treats them as opaque nested objects and constrains only their placement.
+- `shared` MAY be an empty object but the key SHOULD be present. It captures the
+  workflow's shared state space (Global + all named rooms, per core spec §7.2.1).
+- The serialization of `shared`, `snapshot`, and `report` is governed by their
+  own (existing) language-neutral schemas (namespaced state bag, report tree).
+  This spec treats them as opaque nested objects and constrains only their
+  placement.
 
 ### 3.4 Cursor
 
@@ -144,6 +148,63 @@ The REQUIRED procedure is:
 Implementations on POSIX filesystems MUST use `rename(2)` (atomic). Implementations
 on platforms without an atomic same-volume rename MUST use the closest equivalent
 that preserves the all-or-nothing guarantee.
+
+### 3.7 Identity, lifecycle, and retention
+
+#### 3.7.1 runID identifies one execution
+
+- `workflow_id` identifies a workflow **definition**; a **runID** identifies a
+  single **execution** of it.
+- The journal path is `<dir>/<workflowID>-<runID>.journal`, where `<dir>` is the
+  journal directory configured on the workflow. For v1 the runID is
+  **caller-supplied** (engine-generated run IDs are a later addition).
+- **To start a fresh execution, use a fresh runID.** Re-running "the same
+  workflow" is a new execution and MUST use a new runID, which yields a new
+  journal — so a prior run's journal can never be mistaken for the new run.
+- **Reusing a runID means "resume that specific execution."** This is the only
+  way a prior journal is consulted; it is intentional, never accidental, when the
+  runID convention above is followed.
+
+#### 3.7.2 Resume of a terminal journal is a safe no-op
+
+- A resume against a journal already in `phase: done` MUST return the recorded
+  final result and MUST execute and compensate **nothing** (§6.5). Therefore a
+  stale terminal journal can never cause double-execution; at worst it causes a
+  surprising no-op, which the retention policy and the fresh-runID rule prevent.
+- Corollary: **the journal is a recovery record, not a result cache.** Callers
+  obtain a run's result from that run's return value. An implementation MUST NOT
+  require a retained journal in order to surface a completed run's result.
+
+#### 3.7.3 Retention policy (configurable per workflow)
+
+Retention is configured on the workflow. The policy governs what happens to the
+journal when a run reaches a **terminal** outcome (completed successfully,
+fully compensated, or terminally failed):
+
+| Policy | On terminal outcome |
+|--------|---------------------|
+| `retain` (**default**) | Keep the journal for **all** terminal outcomes, including success. Provides a full audit trail. The caller prunes explicitly (§3.7.4). |
+| `delete_on_success` | Delete the journal on **successful** completion; retain it on failure or rollback (the cases worth inspecting/retrying). |
+| `delete_on_done` | Delete the journal on **any** terminal outcome. |
+
+- The default is `retain` — provisioning, migration, and installer tools commonly
+  want a durable record of even successful runs.
+- Any delete performed by a policy MUST be **crash-safe**: `done` is terminal and
+  idempotent, so a crash between the final commit and the delete leaves a valid
+  `done` journal that a later resume returns and MAY re-delete. Deletion MUST
+  occur only after the `done` state is durably persisted.
+
+#### 3.7.4 Pruning retained journals
+
+- Because the caller owns the journal directory, pruning is **explicit**, not
+  background magic. An implementation SHOULD offer a prune utility, e.g.
+  `PruneJournals(dir, policy)`, supporting at least:
+  - by **age** (older than a given duration), and
+  - by **status** (e.g. only `done`, or only successfully-completed).
+- A caller MAY equivalently delete journal files directly; each journal is a
+  self-contained file.
+- Implementations MUST document that journals accumulate under `retain` until
+  pruned, so operators size storage accordingly.
 
 ## 4. State machine
 
@@ -216,7 +277,7 @@ F3. run the step's execute  (THE SIDE EFFECT happens here)
 F4. steps[i].state   = "completed" | "failed"
     steps[i].snapshot = <execution-time state>          (when completed, for rollback)
     steps[i].report   = <step report>
-    global            = <current global state>
+    shared            = <current shared state space: Global + named rooms>
                                                PERSIST   ← commit point, AFTER side effect
 F5. on failure with execution_mode = RollbackOnError:
     phase = "compensating"; cursor = i;        PERSIST
@@ -233,7 +294,7 @@ C3. steps[i].state = "compensated"; cursor = i;   PERSIST   ← per-compensation
 On completion:
 
 ```
-D1. phase = "done";                                PERSIST   (the journal MAY then be deleted, §6.5)
+D1. phase = "done";                                PERSIST   (then apply retention policy, §3.7.3)
 ```
 
 Requirements:
@@ -259,7 +320,7 @@ A resume:
 
 1. Loads the journal (§6.2).
 2. Validates topology and modes against the supplied definition (§6.2).
-3. Rehydrates `global` onto the workflow.
+3. Rehydrates `shared` (Global + named rooms) onto the workflow.
 4. Dispatches on `phase` (§6.3, §6.4, §6.5).
 
 ### 6.2 Loading and validation
@@ -298,11 +359,11 @@ A resume:
 ### 6.5 Done (`phase == "done"`)
 
 - The run is terminal. Resume MUST return the recorded final result and MUST NOT
-  execute or compensate any step.
-- An implementation MAY delete the journal on reaching `done` (D1). If it does,
-  a subsequent resume sees a missing journal and treats it as a fresh run (§6.2);
-  implementations that rely on idempotent steps tolerate this, but implementations
-  SHOULD document their journal-retention choice.
+  execute or compensate any step (§3.7.2).
+- On reaching `done`, the configured **retention policy** (§3.7.3) is applied:
+  under the default `retain`, the journal is kept; under a delete policy it may be
+  removed, in which case a subsequent resume of the same runID sees a missing
+  journal and treats it as a fresh run (§6.2).
 
 ## 7. Workflow-author contract
 
@@ -373,13 +434,24 @@ addition, but none is required for crash recovery of sequential sagas:
 
 ## 10. Open questions
 
-- **Run-ID namespacing.** How is the journal path namespaced per run
-  (workflow ID + generated run ID)? Affects concurrent runs of the same workflow.
-- **Storage backend.** v1 is a single JSON file. Should an embedded KV store be
-  offered as an alternative for many concurrent runs, behind the same semantics?
-- **Report nesting for sub-workflows.** A step MAY itself be a workflow. How is a
+**Resolved (folded into the spec):**
+
+- **Run-ID namespacing.** *Resolved:* a workflow is made durable by supplying a
+  journal **directory**; the engine writes `<dir>/<workflowID>-<runID>.journal`.
+  For v1 the `runID` is **caller-supplied** (so concurrent runs of the same
+  workflow coexist); engine-generated run IDs are a later addition.
+- **Storage backend.** *Resolved for v1:* a single JSON file. An embedded KV
+  backend is deferred; the `Resume` API and journal semantics are backend-neutral
+  so it can be added later without breaking the contract.
+- **State-bag numeric/precision portability.** *Resolved:* governed by the core
+  spec's numeric policy (core §7.5) — document the 2^53 boundary, recommend
+  string-typed numerics beyond it. The shared state space serialized in the
+  journal follows the same rule.
+
+**Still open:**
+
+- **Sub-workflow journal nesting.** A step MAY itself be a workflow. How is a
   nested run's journal represented — inline under the parent step, or as a linked
-  child journal? (Must be pinned before sub-workflow durability is claimed.)
-- **State-bag numeric/precision portability.** Cross-language number handling for
-  the serialized state bag (see `docs/state-numeric-boundaries.md`) MUST be
-  reconciled so a journal written by one language loads losslessly in another.
+  child journal? This MUST be pinned before sub-workflow durability is claimed,
+  and depends on the core spec's resolved sub-workflow rollback-report shape
+  (core §8.2). Tracked in the durability spec issue (#91).


### PR DESCRIPTION
## Description

This pull request introduces two major documentation additions to the project: a detailed design proposal for adding crash recovery (durable workflows) and the foundation for formal, language-neutral specifications to guide multi-language implementations. The changes clarify both the intended behavior and the process for ensuring consistent, predictable workflow execution and recovery across different runtimes.

**Durability feature (crash recovery) design:**

* Adds `docs/durability.md`, a comprehensive design document for implementing crash recovery in automa workflows, including the journal file format, execution and recovery flow, durability contract for step authors, and open questions for future development.

**Specification and cross-language conformance:**

* Introduces `docs/spec/README.md`, outlining the project's spec-first approach for multi-language support, principles for specification and conformance, and an extension roadmap. This ensures that all implementations behave identically, especially regarding durability and state persistence.

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
