### PR TITLE
chore(deps): upgrade Go to 1.26.5 to align with org standard

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -6,7 +6,7 @@ on:
         description: "Go Version:"
         type: string
         required: false
-        default: "1.25.0"
+        default: "1.26.5"
       dry-run-enabled:
         description: "Perform Dry Run"
         type: boolean

--- a/.github/workflows/zxc-code-compiles.yaml
+++ b/.github/workflows/zxc-code-compiles.yaml
@@ -6,7 +6,7 @@ on:
         description: "Go Version:"
         type: string
         required: false
-        default: ">=1.25.0"
+        default: "1.26.5"
       custom-job-label:
         description: "Custom Job Label:"
         type: string

--- a/.github/workflows/zxc-unit-test.yaml
+++ b/.github/workflows/zxc-unit-test.yaml
@@ -6,7 +6,7 @@ on:
         description: "Go Version:"
         type: string
         required: false
-        default: ">=1.25.0"
+        default: "1.26.5"
       custom-job-label:
         description: "Custom Job Label:"
         type: string

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/automa-saga/automa
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/joomcode/errorx v1.2.0


### PR DESCRIPTION
## Summary

- Bumps `go` directive: `1.25.0` → `1.26.5`
- Updates all workflow `go-version` defaults to `1.26.5`

Aligns with the rest of the automa-saga org (`daemonkit`, `version` already on 1.26.5). Build and tests pass locally.

## Test plan
- [ ] `go build ./...` passes locally ✓
- [ ] CI passes