### PR TITLE
fix: align with spec, rollback_mode is restricted to continue and stop

### DIFF
--- a/type_action.go
+++ b/type_action.go
@@ -2,6 +2,7 @@ package automa
 
 import (
 	"encoding/json"
+	"errors"
 
 	"gopkg.in/yaml.v3"
 )
@@ -47,8 +48,9 @@ func (a TypeAction) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler. It accepts the string names
-// "prepare", "execute", and "rollback". Unrecognised values are silently
-// mapped to 0 (ActionPrepare) rather than returning an error.
+// "prepare", "execute", and "rollback". Because the report is a cross-language
+// wire contract, an unrecognised value returns an error rather than silently
+// defaulting, so that format drift is surfaced instead of hidden.
 func (a *TypeAction) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
@@ -62,7 +64,7 @@ func (a *TypeAction) UnmarshalJSON(data []byte) error {
 	case "rollback":
 		*a = ActionRollback
 	default:
-		*a = 0
+		return errors.New("unknown TypeAction")
 	}
 	return nil
 }
@@ -74,7 +76,7 @@ func (a TypeAction) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler. It accepts the same string names
-// as UnmarshalJSON. Unrecognised values are silently mapped to 0 (ActionPrepare).
+// as UnmarshalJSON and returns an error for unrecognised values.
 func (a *TypeAction) UnmarshalYAML(value *yaml.Node) error {
 	var s string
 	if err := value.Decode(&s); err != nil {
@@ -88,7 +90,7 @@ func (a *TypeAction) UnmarshalYAML(value *yaml.Node) error {
 	case "rollback":
 		*a = ActionRollback
 	default:
-		*a = 0
+		return errors.New("unknown TypeAction")
 	}
 	return nil
 }

--- a/type_action_test.go
+++ b/type_action_test.go
@@ -34,11 +34,10 @@ func TestTypeAction_MarshalJSON_UnmarshalJSON(t *testing.T) {
 		assert.Equal(t, tt.action, a)
 	}
 
-	// Test unknown value
+	// Unknown values must fail (D7): the report is a cross-language wire contract.
 	var a TypeAction
 	err := json.Unmarshal([]byte(`"unknown"`), &a)
-	assert.NoError(t, err)
-	assert.Equal(t, TypeAction(0), a)
+	assert.Error(t, err)
 }
 
 func TestTypeAction_MarshalYAML_UnmarshalYAML(t *testing.T) {
@@ -61,11 +60,10 @@ func TestTypeAction_MarshalYAML_UnmarshalYAML(t *testing.T) {
 		assert.Equal(t, tt.action, a)
 	}
 
-	// Test unknown value
+	// Unknown values must fail (D7): the report is a cross-language wire contract.
 	var a TypeAction
 	err := yaml.Unmarshal([]byte("unknown\n"), &a)
-	assert.NoError(t, err)
-	assert.Equal(t, TypeAction(0), a)
+	assert.Error(t, err)
 }
 
 func TestTypeAction_String_Prepare(t *testing.T) {
@@ -75,15 +73,13 @@ func TestTypeAction_String_Prepare(t *testing.T) {
 func TestTypeAction_UnmarshalJSON_Invalid(t *testing.T) {
 	var a TypeAction
 	err := json.Unmarshal([]byte(`"invalid"`), &a)
-	assert.NoError(t, err)
-	assert.Equal(t, TypeAction(0), a)
+	assert.Error(t, err)
 }
 
 func TestTypeAction_UnmarshalYAML_Invalid(t *testing.T) {
 	var a TypeAction
 	err := yaml.Unmarshal([]byte("invalid\n"), &a)
-	assert.NoError(t, err)
-	assert.Equal(t, TypeAction(0), a)
+	assert.Error(t, err)
 }
 
 func TestTypeAction_MarshalYAML_Prepare(t *testing.T) {

--- a/type_mode.go
+++ b/type_mode.go
@@ -17,8 +17,8 @@ import (
 //     (only relevant when executionMode is [RollbackOnError]).
 //
 // TypeMode is serialized as a human-readable string in JSON and YAML. Unknown
-// values are treated as errors during unmarshaling (unlike [TypeAction] and
-// [TypeStatus] which default silently).
+// values are treated as errors during unmarshaling, consistent with
+// [TypeAction] and [TypeStatus].
 type TypeMode uint8
 
 const (

--- a/type_status.go
+++ b/type_status.go
@@ -2,6 +2,7 @@ package automa
 
 import (
 	"encoding/json"
+	"errors"
 
 	"gopkg.in/yaml.v3"
 )
@@ -56,8 +57,9 @@ func (s TypeStatus) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler. It accepts the string names
-// "success", "failed", and "skipped". Unrecognised values are silently mapped
-// to 0 (zero/uninitialised) rather than returning an error.
+// "success", "failed", and "skipped". Because the report is a cross-language
+// wire contract, an unrecognised value returns an error rather than silently
+// defaulting, so that format drift is surfaced instead of hidden.
 func (s *TypeStatus) UnmarshalJSON(data []byte) error {
 	var str string
 	if err := json.Unmarshal(data, &str); err != nil {
@@ -71,7 +73,7 @@ func (s *TypeStatus) UnmarshalJSON(data []byte) error {
 	case "skipped":
 		*s = StatusSkipped
 	default:
-		*s = 0
+		return errors.New("unknown TypeStatus")
 	}
 	return nil
 }
@@ -83,7 +85,7 @@ func (s TypeStatus) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler. It accepts the same string names
-// as UnmarshalJSON. Unrecognised values are silently mapped to 0.
+// as UnmarshalJSON and returns an error for unrecognised values.
 func (s *TypeStatus) UnmarshalYAML(value *yaml.Node) error {
 	var str string
 	if err := value.Decode(&str); err != nil {
@@ -97,7 +99,7 @@ func (s *TypeStatus) UnmarshalYAML(value *yaml.Node) error {
 	case "skipped":
 		*s = StatusSkipped
 	default:
-		*s = 0
+		return errors.New("unknown TypeStatus")
 	}
 	return nil
 }

--- a/type_status_test.go
+++ b/type_status_test.go
@@ -36,11 +36,10 @@ func TestTypeStatus_MarshalJSON_UnmarshalJSON(t *testing.T) {
 		assert.Equal(t, tt.status, s)
 	}
 
-	// Unknown value
+	// Unknown values must fail (D7): the report is a cross-language wire contract.
 	var s TypeStatus
 	err := json.Unmarshal([]byte(`"unknown"`), &s)
-	assert.NoError(t, err)
-	assert.Equal(t, TypeStatus(0), s)
+	assert.Error(t, err)
 }
 
 func TestTypeStatus_MarshalYAML_UnmarshalYAML(t *testing.T) {
@@ -64,9 +63,8 @@ func TestTypeStatus_MarshalYAML_UnmarshalYAML(t *testing.T) {
 		assert.Equal(t, tt.status, s)
 	}
 
-	// Unknown value
+	// Unknown values must fail (D7): the report is a cross-language wire contract.
 	var s TypeStatus
 	err := yaml.Unmarshal([]byte("unknown\n"), &s)
-	assert.NoError(t, err)
-	assert.Equal(t, TypeStatus(0), s)
+	assert.Error(t, err)
 }

--- a/workflow.go
+++ b/workflow.go
@@ -402,7 +402,7 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 				report = FailureReport(step,
 					WithWorkflow(w),
 					WithStartTime(stepStart),
-					WithActionType(ActionExecute),
+					WithActionType(ActionPrepare),
 					WithError(StepExecutionError.
 						Wrap(ctxPrepError, "workflow %q step %q preparation failed", w.id, step.Id()).
 						WithProperty(StepIdProperty, step.Id()),

--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -166,11 +166,14 @@ func (wb *WorkflowBuilder) Validate() error {
 	}
 
 	// D4: rollbackMode only governs what happens when a compensation itself
-	// fails, so it is restricted to {continue, stop}. RollbackOnError
-	// ("rollback") is meaningless as a rollbackMode and must be rejected.
-	if wb.workflow.rollbackMode == RollbackOnError {
+	// fails, so it is restricted to {continue, stop}. Any other value
+	// (including RollbackOnError) is meaningless as a rollbackMode and must be rejected.
+	switch wb.workflow.rollbackMode {
+	case ContinueOnError, StopOnError:
+		// valid
+	default:
 		return IllegalArgument.New("invalid rollback_mode %q: must be one of %q or %q",
-			RollbackOnError, ContinueOnError, StopOnError)
+			wb.workflow.rollbackMode, ContinueOnError, StopOnError)
 	}
 
 	var errs []error

--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -165,6 +165,14 @@ func (wb *WorkflowBuilder) Validate() error {
 		return StepNotFound.New("no steps provided for workflow")
 	}
 
+	// D4: rollbackMode only governs what happens when a compensation itself
+	// fails, so it is restricted to {continue, stop}. RollbackOnError
+	// ("rollback") is meaningless as a rollbackMode and must be rejected.
+	if wb.workflow.rollbackMode == RollbackOnError {
+		return IllegalArgument.New("invalid rollback_mode %q: must be one of %q or %q",
+			RollbackOnError, ContinueOnError, StopOnError)
+	}
+
 	var errs []error
 	for id, builder := range wb.stepBuilders {
 		if err := builder.Validate(); err != nil {
@@ -230,6 +238,9 @@ func (wb *WorkflowBuilder) WithExecutionMode(mode TypeMode) *WorkflowBuilder {
 //
 // This mode is only relevant when [WithExecutionMode] is [RollbackOnError].
 // The same mode is propagated to nested sub-workflows at Build time.
+//
+// Only [ContinueOnError] and [StopOnError] are valid rollback modes;
+// passing [RollbackOnError] causes [Validate] (and therefore [Build]) to fail.
 func (wb *WorkflowBuilder) WithRollbackMode(mode TypeMode) *WorkflowBuilder {
 	wb.workflow.rollbackMode = mode
 	return wb

--- a/workflow_builder_test.go
+++ b/workflow_builder_test.go
@@ -198,12 +198,14 @@ func TestWorkflowBuilder_Validate_NoSteps(t *testing.T) {
 	assert.Contains(t, err.Error(), "no steps provided for workflow")
 }
 
-func TestWorkflowBuilder_Validate_RejectsRollbackAsRollbackMode(t *testing.T) {
-	wb := NewWorkflowBuilder().WithId("wf").WithRollbackMode(RollbackOnError)
-	wb.Steps(&mockStepBuilder{id: "step", valid: true})
-	err := wb.Validate()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid rollback_mode")
+func TestWorkflowBuilder_Validate_RejectsInvalidRollbackModes(t *testing.T) {
+	for _, mode := range []TypeMode{RollbackOnError, TypeMode(0), TypeMode(99)} {
+		wb := NewWorkflowBuilder().WithId("wf").WithRollbackMode(mode)
+		wb.Steps(&mockStepBuilder{id: "step", valid: true})
+		err := wb.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid rollback_mode")
+	}
 }
 
 func TestWorkflowBuilder_Validate_AllowsContinueAndStopRollbackModes(t *testing.T) {

--- a/workflow_builder_test.go
+++ b/workflow_builder_test.go
@@ -198,6 +198,22 @@ func TestWorkflowBuilder_Validate_NoSteps(t *testing.T) {
 	assert.Contains(t, err.Error(), "no steps provided for workflow")
 }
 
+func TestWorkflowBuilder_Validate_RejectsRollbackAsRollbackMode(t *testing.T) {
+	wb := NewWorkflowBuilder().WithId("wf").WithRollbackMode(RollbackOnError)
+	wb.Steps(&mockStepBuilder{id: "step", valid: true})
+	err := wb.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid rollback_mode")
+}
+
+func TestWorkflowBuilder_Validate_AllowsContinueAndStopRollbackModes(t *testing.T) {
+	for _, mode := range []TypeMode{ContinueOnError, StopOnError} {
+		wb := NewWorkflowBuilder().WithId("wf").WithRollbackMode(mode)
+		wb.Steps(&mockStepBuilder{id: "step", valid: true})
+		assert.NoError(t, wb.Validate())
+	}
+}
+
 func TestWorkflowBuilder_MethodChaining(t *testing.T) {
 	wb := NewWorkflowBuilder().
 		WithId("chain").
@@ -240,37 +256,42 @@ func TestWorkflowBuilder_NamedSteps_DuplicateIds(t *testing.T) {
 }
 
 func TestWorkflowBuilder_InheritModesForNestedWorkflow_OtherModes(t *testing.T) {
-	modes := []TypeMode{StopOnError, ContinueOnError, RollbackOnError}
+	// executionMode may be any of the three; rollbackMode is restricted to
+	// {continue, stop} per D4, so the two dimensions are exercised separately.
+	executionModes := []TypeMode{StopOnError, ContinueOnError, RollbackOnError}
+	rollbackModes := []TypeMode{ContinueOnError, StopOnError}
 
-	for _, mode := range modes {
-		t.Run(fmt.Sprintf("mode-%d", mode), func(t *testing.T) {
-			// parent workflow with explicit modes
-			wb := NewWorkflowBuilder().WithId("parent").
-				WithExecutionMode(mode).
-				WithRollbackMode(mode)
+	for _, execMode := range executionModes {
+		for _, rbMode := range rollbackModes {
+			t.Run(fmt.Sprintf("exec-%d-rb-%d", execMode, rbMode), func(t *testing.T) {
+				// parent workflow with explicit modes
+				wb := NewWorkflowBuilder().WithId("parent").
+					WithExecutionMode(execMode).
+					WithRollbackMode(rbMode)
 
-			// child workflow with defaults that should be overridden
-			child := newDefaultWorkflow()
-			child.id = "child"
-			child.executionMode = TypeMode(99) // sentinel to ensure override
-			child.rollbackMode = TypeMode(99)  // sentinel to ensure override
+				// child workflow with defaults that should be overridden
+				child := newDefaultWorkflow()
+				child.id = "child"
+				child.executionMode = TypeMode(99) // sentinel to ensure override
+				child.rollbackMode = TypeMode(99)  // sentinel to ensure override
 
-			b := &mockStepBuilder{id: "child", valid: true, buildStep: child}
-			wb.Steps(b)
+				b := &mockStepBuilder{id: "child", valid: true, buildStep: child}
+				wb.Steps(b)
 
-			wf, err := wb.Build()
-			assert.NoError(t, err)
-			assert.NotNil(t, wf)
+				wf, err := wb.Build()
+				assert.NoError(t, err)
+				assert.NotNil(t, wf)
 
-			parent := wf.(*workflow)
-			assert.Len(t, parent.steps, 1)
+				parent := wf.(*workflow)
+				assert.Len(t, parent.steps, 1)
 
-			nested, ok := parent.steps[0].(*workflow)
-			assert.True(t, ok)
+				nested, ok := parent.steps[0].(*workflow)
+				assert.True(t, ok)
 
-			// child should inherit parent's modes
-			assert.Equal(t, mode, nested.executionMode)
-			assert.Equal(t, mode, nested.rollbackMode)
-		})
+				// child should inherit parent's modes
+				assert.Equal(t, execMode, nested.executionMode)
+				assert.Equal(t, rbMode, nested.rollbackMode)
+			})
+		}
 	}
 }

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestWorkflow(id string, steps []Step) *workflow {
@@ -373,6 +374,25 @@ func TestRunWorkflow_PrepareError(t *testing.T) {
 	assert.NotNil(t, report)
 	assert.Equal(t, StatusFailed, report.Status)
 	assert.Contains(t, report.Error.Error(), "prepare failed")
+}
+
+func TestRunWorkflow_StepPrepareError_ReportsPrepareAction(t *testing.T) {
+	wb := NewWorkflowBuilder().WithId("wf").Steps(
+		NewStepBuilder().WithId("s1").
+			WithPrepare(func(ctx context.Context, stp Step) (context.Context, error) {
+				return nil, errors.New("step prepare failed")
+			}).
+			WithExecute(func(ctx context.Context, stp Step) *Report {
+				return StepSuccessReport("s1")
+			}),
+	)
+	report := RunWorkflow(context.Background(), wb)
+	assert.NotNil(t, report)
+	assert.Equal(t, StatusFailed, report.Status)
+	// D3: a Prepare-phase failure must be reported with action "prepare".
+	require.Len(t, report.StepReports, 1)
+	assert.Equal(t, ActionPrepare, report.StepReports[0].Action)
+	assert.Contains(t, report.StepReports[0].Error.Error(), "step prepare failed")
 }
 
 func TestWorkflow_HandleCompletion_Async(t *testing.T) {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -327,7 +327,8 @@ func TestWorkflow_Prepare_InjectsState(t *testing.T) {
 func TestRunWorkflow_Success(t *testing.T) {
 	wb := &WorkflowBuilder{
 		workflow: &workflow{
-			id: "wf",
+			id:           "wf",
+			rollbackMode: ContinueOnError,
 		},
 		stepSequence: []string{"s1"},
 		stepBuilders: map[string]Builder{
@@ -358,7 +359,8 @@ func TestRunWorkflow_BuildError(t *testing.T) {
 func TestRunWorkflow_PrepareError(t *testing.T) {
 	wb := &WorkflowBuilder{
 		workflow: &workflow{
-			id: "wf",
+			id:           "wf",
+			rollbackMode: ContinueOnError,
 			prepare: func(ctx context.Context, stp Step) (context.Context, error) {
 				return nil, errors.New("prepare failed")
 			},


### PR DESCRIPTION
Adapts the Go reference implementation to conform to the merged core-spec. Three independent spec-adaptation fixes, one commit each. Part of #85.

## Changes

| Issue | Decision | Change |
|-------|----------|--------|
| #92 | D3 (§4.3, §8.3) | A step whose **Prepare** phase fails is now reported with action `prepare` instead of `execute`, correctly identifying the phase that failed. |
| #93 | D4 (§5.2) | `rollback_mode` is restricted to `{continue, stop}`. Because `TypeMode` is a shared enum, `RollbackOnError` ("rollback") was syntactically accepted as a rollback mode where it is meaningless; `WorkflowBuilder.Validate` now rejects it. |
| #94 | D7 (§8.1) | `TypeAction` and `TypeStatus` now return a decode error on unknown JSON/YAML values instead of silently defaulting to their zero value, matching `TypeMode`. The report is a cross-language wire contract, so silent defaulting hid format drift. |

## Notes

- Each fix has a dedicated commit and regression tests.
- The #93 fix required updating a pre-existing nested-workflow inheritance test that conflated the execution-mode and rollback-mode dimensions (it fed `RollbackOnError` as a rollback mode); it now exercises the two dimensions separately.
- Full test suite passes.

Closes #92
Closes #93
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)