### PR TITLE
fix: execute() silently skips the workflow-level Prepare hook

### DIFF
--- a/workflow.go
+++ b/workflow.go
@@ -82,6 +82,10 @@ type workflow struct {
 	//   - Multiple steps might mutate shared state before rollback
 	preserveStatesForRollback bool
 
+	// prepared is set to true after Prepare has been called, preventing double-invocation
+	// when Execute is called via RunWorkflow (which calls Prepare explicitly before Execute).
+	prepared bool
+
 	// callbacks and hooks
 	prepare      PrepareFunc
 	rollback     RollbackFunc // optional user-defined rollback function for the entire workflow
@@ -212,6 +216,10 @@ func (w *workflow) Id() string {
 }
 
 func (w *workflow) Prepare(ctx context.Context) (context.Context, error) {
+	if w.prepared {
+		return ctx, nil
+	}
+
 	preparedCtx := ctx
 	if w.prepare != nil {
 		c, err := w.prepare(preparedCtx, w)
@@ -221,6 +229,7 @@ func (w *workflow) Prepare(ctx context.Context) (context.Context, error) {
 		preparedCtx = c // use the context returned by user prepare function
 	}
 
+	w.prepared = true
 	return preparedCtx, nil
 }
 
@@ -316,6 +325,22 @@ func (w *workflow) State() NamespacedStateBag {
 // - See WithStatePreservation() for detailed tradeoffs
 func (w *workflow) Execute(ctx context.Context) *Report {
 	startTime := time.Now()
+
+	// Reset prepared after Execute completes so that subsequent Execute calls re-run Prepare.
+	defer func() { w.prepared = false }()
+
+	preparedCtx, err := w.Prepare(ctx)
+	if err != nil {
+		return FailureReport(w,
+			WithWorkflow(w),
+			WithActionType(ActionPrepare),
+			WithStartTime(startTime),
+			WithError(StepExecutionError.
+				Wrap(err, "workflow %q preparation failed: %v", w.id, err).
+				WithProperty(StepIdProperty, w.id),
+			))
+	}
+	ctx = preparedCtx
 
 	if len(w.steps) == 0 {
 		w.log().Error("workflow has no steps to execute", "workflowId", w.id)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -315,6 +315,87 @@ func TestWorkflow_State_LazyInit(t *testing.T) {
 	assert.Equal(t, 0, state.Global().Size())
 }
 
+func TestWorkflow_Execute_InvokesPrepareHook(t *testing.T) {
+	prepared := false
+	step := &defaultStep{id: "s1", execute: func(ctx context.Context, stp Step) *Report {
+		return StepSuccessReport("s1")
+	}}
+	wf := newTestWorkflow("wf", []Step{step})
+	wf.prepare = func(ctx context.Context, stp Step) (context.Context, error) {
+		prepared = true
+		return ctx, nil
+	}
+
+	report := wf.Execute(context.Background())
+
+	assert.Equal(t, StatusSuccess, report.Status)
+	assert.True(t, prepared, "prepare hook should be called when Execute is invoked directly")
+}
+
+func TestRunWorkflow_PrepareHookCalledOnce(t *testing.T) {
+	callCount := 0
+	wb := &WorkflowBuilder{
+		workflow: &workflow{
+			id:           "wf",
+			rollbackMode: ContinueOnError,
+			prepare: func(ctx context.Context, stp Step) (context.Context, error) {
+				callCount++
+				return ctx, nil
+			},
+		},
+		stepSequence: []string{"s1"},
+		stepBuilders: map[string]Builder{
+			"s1": NewStepBuilder().WithId("s1").WithExecute(func(ctx context.Context, stp Step) *Report {
+				return StepSuccessReport("s1")
+			}),
+		},
+	}
+
+	report := RunWorkflow(context.Background(), wb)
+
+	assert.Equal(t, StatusSuccess, report.Status)
+	assert.Equal(t, 1, callCount, "prepare hook should be called exactly once even via RunWorkflow")
+}
+
+func TestWorkflow_Execute_PrepareError_ReturnsFailureReport(t *testing.T) {
+	step := &defaultStep{id: "s1", execute: func(ctx context.Context, stp Step) *Report {
+		return StepSuccessReport("s1")
+	}}
+	wf := newTestWorkflow("wf", []Step{step})
+	wf.prepare = func(ctx context.Context, stp Step) (context.Context, error) {
+		return nil, errors.New("prepare failed")
+	}
+
+	report := wf.Execute(context.Background())
+
+	assert.Equal(t, StatusFailed, report.Status)
+	assert.Equal(t, ActionPrepare, report.Action)
+	assert.Contains(t, report.Error.Error(), "prepare failed")
+}
+
+func TestWorkflow_Prepare_DoesNotMarkPreparedOnError(t *testing.T) {
+	callCount := 0
+	wf := &workflow{
+		id:     "wf",
+		logger: slog.New(slog.DiscardHandler),
+		prepare: func(ctx context.Context, stp Step) (context.Context, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, errors.New("transient error")
+			}
+			return ctx, nil
+		},
+	}
+
+	_, err := wf.Prepare(context.Background())
+	assert.Error(t, err)
+	assert.False(t, wf.prepared, "prepared should not be set when hook returns an error")
+
+	_, err = wf.Prepare(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount, "prepare hook should be called again after a previous failure")
+}
+
 func TestWorkflow_Prepare_InjectsState(t *testing.T) {
 	wf := &workflow{id: "wf"}
 	ctx := context.Background()


### PR DESCRIPTION
## Description

This pull request improves the workflow execution logic by ensuring the `Prepare` hook is always called before workflow execution, and that it is only called once per run. It also adds tests to verify this behavior, including error handling if preparation fails.

**Workflow execution improvements:**

* Added a `prepared` flag to the `workflow` struct to prevent the `Prepare` hook from being called multiple times during a single workflow run. (`workflow.go` [workflow.goR85-R88](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR85-R88))
* Updated the `Prepare` method to check and set the `prepared` flag, returning early if preparation has already occurred. (`workflow.go` [workflow.goR219-R223](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR219-R223))
* Modified the `Execute` method to always invoke `Prepare` before execution, and to return a failure report if preparation fails. (`workflow.go` [workflow.goR329-R341](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR329-R341))

**Testing enhancements:**

* Added tests to ensure that:
  - The `Prepare` hook is called when `Execute` is invoked directly.
  - The `Prepare` hook is only called once when running via `RunWorkflow`.
  - A failure in the `Prepare` hook results in a failure report. (`workflow_test.go` [workflow_test.goR318-R375](diffhunk://#diff-69a2723318db0a4416df092fc13f68f8e05454975c93b361dd777d7b19eb0e97R318-R375))

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
