### PR TITLE
fix: rollback should not be invoked on steps that never executed

### DIFF
--- a/runtime_value.go
+++ b/runtime_value.go
@@ -519,7 +519,7 @@ func IsNil[T any](v T) bool {
 		return true // treat zero reflect as nil
 	}
 	switch rv.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
 		return rv.IsNil()
 	default:
 		return false

--- a/state.go
+++ b/state.go
@@ -514,7 +514,7 @@ func normalizeFromState(v interface{}) (interface{}, error) {
 		if !rv.IsValid() {
 			return nil, errorx.IllegalArgument.New("invalid value: %v", v)
 		}
-		if rv.Kind() == reflect.Ptr {
+		if rv.Kind() == reflect.Pointer {
 			if rv.IsNil() {
 				return nil, nil
 			}

--- a/workflow.go
+++ b/workflow.go
@@ -53,6 +53,11 @@ type workflow struct {
 	// preserve step states after execution for potential rollback; keyed by step ID
 	lastExecutionStates map[string]NamespacedStateBag
 
+	// lastExecutedStepIDs tracks which step IDs actually reached Execute (i.e.,
+	// both statePrepError and ctxPrepError were nil). Steps that failed in Prepare
+	// are excluded so rollbackFrom can skip compensating them (spec D5 / §5.3).
+	lastExecutedStepIDs map[string]struct{}
+
 	// preserveStatesForRollback controls whether state snapshots are cloned and preserved
 	// after each step execution. When true (default), enables deterministic rollback but
 	// increases memory usage. When false, skips state cloning to reduce overhead.
@@ -144,12 +149,28 @@ func RunWorkflow(ctx context.Context, wb *WorkflowBuilder) *Report {
 }
 
 // rollbackFrom rollbacks the workflow backward from the given index to the start.
-func (w *workflow) rollbackFrom(ctx context.Context, index int, states map[string]NamespacedStateBag) map[string]*Report {
+// executedIDs restricts compensation to steps that actually ran Execute; nil is treated
+// as empty (nothing executed). Steps absent from executedIDs are skipped (spec D5 / §5.3):
+// compensating a step whose Execute never ran is incorrect because its rollback may assume
+// side-effects that were never produced.
+func (w *workflow) rollbackFrom(ctx context.Context, index int, states map[string]NamespacedStateBag, executedIDs map[string]struct{}) map[string]*Report {
 	stepReports := map[string]*Report{}
 	startTime := time.Now()
 
 	for i := index; i >= 0; i-- {
 		step := w.steps[i]
+
+		// Skip compensation for steps that never executed (spec D5 / §5.3).
+		// nil is treated as empty: no execution context means nothing to compensate.
+		if _, ran := executedIDs[step.Id()]; !ran {
+			w.log().Debug("skipping rollback for non-executed step", "workflowId", w.id, "stepId", step.Id(), "index", i)
+			stepReports[step.Id()] = SkippedReport(step,
+				WithWorkflow(w),
+				WithActionType(ActionRollback),
+				WithStartTime(startTime),
+			)
+			continue
+		}
 
 		// choose snapshot if provided, otherwise use workflow state
 		var state NamespacedStateBag
@@ -364,6 +385,9 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 	// capture per-step state snapshots for rollback
 	stepStates := make(map[string]NamespacedStateBag, len(w.steps))
 
+	// track which steps actually reached Execute (spec D5 / §5.3)
+	executedStepIDs := make(map[string]struct{}, len(w.steps))
+
 	for index, step := range w.steps {
 		var report *Report
 		stepStart := time.Now()
@@ -437,6 +461,7 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 
 		// execute step if preparation succeeded
 		if statePrepError == nil && ctxPrepError == nil {
+			executedStepIDs[step.Id()] = struct{}{}
 			report = step.Execute(stepCtx)
 			if report == nil {
 				w.log().Warn("step returned nil report from Execute; treating as failure",
@@ -505,7 +530,7 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 
 				// Perform rollback using recorded per-step states
 				// Rollback from index (include the failed step for cleanup)
-				rollbackReports := w.rollbackFrom(stepCtx, index, stepStates)
+				rollbackReports := w.rollbackFrom(stepCtx, index, stepStates, executedStepIDs)
 
 				// Attach rollback reports to corresponding step reports
 				for _, stepReport := range stepReports {
@@ -519,12 +544,15 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		}
 	}
 
-	// Preserve state snapshots for potential manual rollback later
-	// (even if workflow failed, manual Rollback() can use these snapshots)
-	// Only preserve if configured to reduce memory overhead when rollback isn't needed
+	// Preserve state snapshots and executed-step set for potential manual rollback later.
+	// Always clear lastExecutionStates first so stale snapshots from a prior execution
+	// (possibly run with preservation enabled) are never used when preservation is off.
 	if w.preserveStatesForRollback {
 		w.lastExecutionStates = stepStates
+	} else {
+		w.lastExecutionStates = nil
 	}
+	w.lastExecutedStepIDs = executedStepIDs
 
 	if hasFailed {
 		var failedStepIDs []string
@@ -617,8 +645,8 @@ func (w *workflow) Rollback(ctx context.Context) *Report {
 
 	w.log().Info("starting workflow rollback", "workflowId", w.id, "steps", len(w.steps))
 
-	// Use preserved states from last execution, fall back to nil if none available
-	rollbackReports := w.rollbackFrom(ctx, len(w.steps)-1, w.lastExecutionStates)
+	// Use preserved states and executed-step set from last execution.
+	rollbackReports := w.rollbackFrom(ctx, len(w.steps)-1, w.lastExecutionStates, w.lastExecutedStepIDs)
 
 	var stepReports []*Report
 	for _, step := range w.steps {
@@ -677,6 +705,9 @@ func newDefaultWorkflow() *workflow {
 		rollbackMode:              ContinueOnError,
 		logger:                    discardLogger,
 		preserveStatesForRollback: true, // default: enabled for backward compatibility
+		// Empty (not nil) so Rollback() called before Execute() compensates nothing.
+		// nil would bypass the D5 filter; a non-nil empty map correctly skips all steps.
+		lastExecutedStepIDs: make(map[string]struct{}),
 	}
 }
 

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -14,11 +14,12 @@ import (
 
 func newTestWorkflow(id string, steps []Step) *workflow {
 	return &workflow{
-		id:            id,
-		steps:         steps,
-		executionMode: StopOnError,
-		rollbackMode:  ContinueOnError,
-		logger:        slog.New(slog.DiscardHandler),
+		id:                  id,
+		steps:               steps,
+		executionMode:       StopOnError,
+		rollbackMode:        ContinueOnError,
+		logger:              slog.New(slog.DiscardHandler),
+		lastExecutedStepIDs: make(map[string]struct{}),
 	}
 }
 
@@ -153,14 +154,16 @@ func TestWorkflow_OnRollback(t *testing.T) {
 	rollbackCalled := make(map[string]bool)
 
 	step1 := &defaultStep{
-		id: "step1",
+		id:      "step1",
+		execute: func(ctx context.Context, stp Step) *Report { return StepSuccessReport("step1") },
 		rollback: func(ctx context.Context, stp Step) *Report {
 			rollbackCalled["step1"] = true
 			return StepSuccessReport("step1")
 		},
 	}
 	step2 := &defaultStep{
-		id: "step2",
+		id:      "step2",
+		execute: func(ctx context.Context, stp Step) *Report { return StepSuccessReport("step2") },
 		rollback: func(ctx context.Context, stp Step) *Report {
 			rollbackCalled["step2"] = true
 			return StepSuccessReport("step2")
@@ -168,6 +171,7 @@ func TestWorkflow_OnRollback(t *testing.T) {
 	}
 
 	wf := newTestWorkflow("wf", []Step{step1, step2})
+	wf.Execute(ctx) // steps must execute before they can be compensated (spec D5)
 	report := wf.Rollback(ctx)
 	assert.NotNil(t, report)
 	assert.Equal(t, StatusSuccess, report.Status)
@@ -221,8 +225,9 @@ func TestWorkflow_RollbackFrom_FailedRollback(t *testing.T) {
 	}
 
 	wf := newTestWorkflow("wf", []Step{step1, step2})
+	allExecuted := map[string]struct{}{"step1": {}, "step2": {}}
 
-	reports := wf.rollbackFrom(ctx, 1, nil)
+	reports := wf.rollbackFrom(ctx, 1, nil, allExecuted)
 	assert.Len(t, reports, 2)
 	assert.Equal(t, StatusFailed, reports["step1"].Status)
 	assert.Equal(t, failErr, reports["step1"].Error)
@@ -247,8 +252,9 @@ func TestWorkflow_RollbackFrom_ContinueOnError(t *testing.T) {
 
 	wf := newTestWorkflow("wf", []Step{step1, step2})
 	wf.rollbackMode = ContinueOnError
+	allExecuted := map[string]struct{}{"step1": {}, "step2": {}}
 
-	reports := wf.rollbackFrom(ctx, 1, nil)
+	reports := wf.rollbackFrom(ctx, 1, nil, allExecuted)
 	assert.Len(t, reports, 2)
 	assert.Equal(t, StatusFailed, reports["step1"].Status)
 	assert.Equal(t, failErr, reports["step1"].Error)
@@ -273,8 +279,9 @@ func TestWorkflow_RollbackFrom_StopOnError(t *testing.T) {
 
 	wf := newTestWorkflow("wf", []Step{step1, step2})
 	wf.rollbackMode = StopOnError
+	allExecuted := map[string]struct{}{"step1": {}, "step2": {}}
 
-	reports := wf.rollbackFrom(ctx, 1, nil)
+	reports := wf.rollbackFrom(ctx, 1, nil, allExecuted)
 	assert.Len(t, reports, 1)
 	assert.Equal(t, StatusFailed, reports["step2"].Status)
 	assert.Equal(t, failErr, reports["step2"].Error)
@@ -299,8 +306,9 @@ func TestWorkflow_RollbackFrom_SkippedStatus(t *testing.T) {
 
 	wf := newTestWorkflow("wf", []Step{step1, step2})
 	wf.rollbackMode = ContinueOnError
+	allExecuted := map[string]struct{}{"step1": {}, "step2": {}}
 
-	reports := wf.rollbackFrom(ctx, 1, nil)
+	reports := wf.rollbackFrom(ctx, 1, nil, allExecuted)
 	assert.Len(t, reports, 2)
 	assert.Equal(t, StatusSkipped, reports["step1"].Status)
 	assert.Equal(t, StatusFailed, reports["step2"].Status)
@@ -588,12 +596,14 @@ func TestWorkflow_Execute_NilReportFromStep(t *testing.T) {
 
 func TestWorkflow_Rollback_NilReportFromStep(t *testing.T) {
 	step := &defaultStep{
-		id: "step",
+		id:      "step",
+		execute: func(ctx context.Context, stp Step) *Report { return StepSuccessReport("step") },
 		rollback: func(ctx context.Context, stp Step) *Report {
 			return nil // Simulate buggy rollback
 		},
 	}
 	wf := newTestWorkflow("wf", []Step{step})
+	wf.Execute(context.Background()) // step must execute before it can be compensated (spec D5)
 	report := wf.Rollback(context.Background())
 	assert.NotNil(t, report)
 	assert.Equal(t, StatusSuccess, report.Status)
@@ -947,4 +957,51 @@ func TestWorkflow_ParentMutates_BetweenSubWorkflows(t *testing.T) {
 	assert.Equal(t, StatusSuccess, report.Status)
 	assert.Equal(t, "v1", seen1, "first sub-workflow should see v1")
 	assert.Equal(t, "v2", seen2, "second sub-workflow should see v2")
+}
+
+// TestWorkflow_RollbackSkipsPrepareFailed verifies spec D5 / §5.3: a step whose Prepare
+// fails (and whose Execute therefore never ran) must NOT have Rollback called.
+func TestWorkflow_RollbackSkipsPrepareFailed(t *testing.T) {
+	ctx := context.Background()
+
+	rollbackCalled := map[string]bool{}
+
+	s1 := &defaultStep{
+		id:      "s1",
+		execute: func(ctx context.Context, stp Step) *Report { return StepSuccessReport("s1") },
+		rollback: func(ctx context.Context, stp Step) *Report {
+			rollbackCalled["s1"] = true
+			return StepSuccessReport("s1")
+		},
+	}
+	// s2 fails in Prepare — Execute never runs
+	s2 := &defaultStep{
+		id: "s2",
+		prepare: func(ctx context.Context, stp Step) (context.Context, error) {
+			return ctx, errors.New("prepare failed")
+		},
+		rollback: func(ctx context.Context, stp Step) *Report {
+			rollbackCalled["s2"] = true
+			return StepSuccessReport("s2")
+		},
+	}
+
+	wf := newTestWorkflow("wf", []Step{s1, s2})
+	wf.executionMode = RollbackOnError
+
+	report := wf.Execute(ctx)
+
+	assert.Equal(t, StatusFailed, report.Status)
+	assert.True(t, rollbackCalled["s1"], "s1 executed and must be rolled back")
+	assert.False(t, rollbackCalled["s2"], "s2 never executed (Prepare failed) and must NOT be rolled back")
+
+	// s2's rollback report must be skipped, not a failure
+	var s2Rollback *Report
+	for _, sr := range report.StepReports {
+		if sr.Id == "s2" && sr.Rollback != nil {
+			s2Rollback = sr.Rollback
+		}
+	}
+	require.NotNil(t, s2Rollback, "s2 should have a rollback report")
+	assert.Equal(t, StatusSkipped, s2Rollback.Status)
 }


### PR DESCRIPTION
## Description

This pull request updates the workflow rollback logic to ensure that rollback is only performed for steps that actually executed, in compliance with spec D5 (§5.3). Steps that failed during the Prepare phase are now excluded from rollback, preventing their compensating actions from running. The PR also adds tracking for executed steps and updates tests to cover this behavior.

**Rollback logic improvements:**

* Added a `lastExecutedStepIDs` field to the `workflow` struct to track which steps actually reached `Execute`.
* Modified the `rollbackFrom` method to accept an `executedIDs` parameter and skip rollback for steps that did not execute, marking their rollback reports as `Skipped`.
* Updated the `Execute` method to track executed steps and pass them to `rollbackFrom` during rollback, ensuring only executed steps are compensated [[1]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR389-R391) [[2]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR465) [[3]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL508-R534) [[4]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL522-R553).
* Updated the `Rollback` method to use the new executed-step tracking when performing a manual rollback.

**Testing:**

* Added the test `TestWorkflow_RollbackSkipsPrepareFailed` to verify that steps failing in `Prepare` do not have their `Rollback` called, and their rollback report status is `Skipped`.
* Updated existing tests to use the new `rollbackFrom` signature [[1]](diffhunk://#diff-69a2723318db0a4416df092fc13f68f8e05454975c93b361dd777d7b19eb0e97L225-R225) [[2]](diffhunk://#diff-69a2723318db0a4416df092fc13f68f8e05454975c93b361dd777d7b19eb0e97L251-R251) [[3]](diffhunk://#diff-69a2723318db0a4416df092fc13f68f8e05454975c93b361dd777d7b19eb0e97L277-R277) [[4]](diffhunk://#diff-69a2723318db0a4416df092fc13f68f8e05454975c93b361dd777d7b19eb0e97L303-R303).

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
