### PR TITLE
feat: custom namespaces as workflow-scoped shared named rooms

### DIFF
--- a/docs/spec/core-spec.md
+++ b/docs/spec/core-spec.md
@@ -335,9 +335,9 @@ follows. "Shared state space" means **Global plus all named rooms** (§7.2.1):
 > **Resolved (was an open question).** Custom namespaces are workflow-scoped
 > shared named rooms, propagated to every step's injected bag by reference and
 > deep-cloned for sub-workflows alongside Global. This realizes the
-> `"database-primary"` use case the model was designed for. The previous
-> step-private behavior (review issue #83) is to be changed; the Go
-> implementation MUST be adapted (§11, D8) — tracked in #116.
+> `"database-primary"` use case the model was designed for. The earlier
+> step-private behavior (review issue #83) has been replaced; ✓ the Go reference
+> implementation conforms as of #116 (§11, D8).
 
 ### 7.4 Execution-time snapshots
 
@@ -485,12 +485,9 @@ implementation is (or is being) adapted to match.
 | D5 | Compensation MUST skip non-executed (`skipped`/`pending`) steps. | 5.3 | #84 |
 | D6 | Nested workflows **inherit** the parent's modes (parent overrides); fix the contradicting builder doc comment. | 6.1 | #82 |
 | D7 | Report enums (`action`, `status`) MUST fail on unknown values on decode, like `mode`. | 8.1 | #94 |
+| D8 | Custom namespaces are **workflow-scoped shared named rooms** — propagated to each step's injected bag by reference, deep-cloned for sub-workflows — replacing the earlier step-private behavior. | 7.2.1, 7.3 | #116 |
 
-**Still pending — Go adaptation not yet done:**
-
-| # | Decision | §  |
-|---|----------|----|
-| D8 | Custom namespaces become **workflow-scoped shared named rooms** (propagated by reference to steps, deep-cloned for sub-workflows), replacing the current step-private behavior. The Go engine currently builds per-step state as `NewNamespacedStateBag(nil, global)`, so custom namespaces remain step-private; this MUST be adapted before v1 freeze (tracked in #116). | 7.2.1, 7.3 |
+All spec decisions are now reflected in the Go reference implementation.
 
 ## 12. Conformance
 

--- a/state_namespaced.go
+++ b/state_namespaced.go
@@ -55,18 +55,70 @@ type SyncNamespacedStateBag struct {
 //	global.Set("env", "production")
 //	ns := automa.NewNamespacedStateBag(nil, global)
 func NewNamespacedStateBag(local, global StateBag) *SyncNamespacedStateBag {
+	return newNamespacedStateBag(local, global, nil)
+}
+
+// newNamespacedStateBag is the internal constructor that also accepts an initial
+// custom (named-room) map. The map is stored by reference, not copied: passing a
+// workflow's live custom map lets the engine share named rooms across the
+// workflow's steps exactly as it shares the Global bag (core-spec §7.3). Pass nil
+// to start with an empty, private named-room set. Either local or global may be
+// nil, in which case an empty *SyncStateBag is substituted.
+func newNamespacedStateBag(local, global StateBag, custom map[string]StateBag) *SyncNamespacedStateBag {
 	if global == nil {
 		global = &SyncStateBag{}
 	}
 	if local == nil {
 		local = &SyncStateBag{}
 	}
+	if custom == nil {
+		custom = make(map[string]StateBag)
+	}
 
 	return &SyncNamespacedStateBag{
 		local:  local,
 		global: global,
-		custom: make(map[string]StateBag),
+		custom: custom,
 	}
+}
+
+// customMapRef returns the live named-room map by reference so the engine can
+// share it across a workflow's steps (core-spec §7.3: named rooms are shared by
+// reference for ordinary steps). Because the returned map is shared, structural
+// changes (adding a room via WithNamespace) made through one step's bag become
+// visible to later steps and to the workflow. This is intended for engine use
+// within the sequential execution loop; callers outside that loop MUST treat the
+// map as shared state.
+func (n *SyncNamespacedStateBag) customMapRef() map[string]StateBag {
+	n.mu.Lock()
+	n.initLocked()
+	m := n.custom
+	n.mu.Unlock()
+	return m
+}
+
+// cloneCustom deep-clones every named room into a fresh map so that a
+// sub-workflow inherits the parent's named rooms but its mutations do not
+// propagate back (core-spec §7.3: named rooms are deep-cloned for sub-workflows).
+// The returned map and every bag in it are independent of the receiver.
+func (n *SyncNamespacedStateBag) cloneCustom() (map[string]StateBag, error) {
+	n.mu.Lock()
+	n.initLocked()
+	snapshot := make(map[string]StateBag, len(n.custom))
+	for name, bag := range n.custom {
+		snapshot[name] = bag
+	}
+	n.mu.Unlock()
+
+	clones := make(map[string]StateBag, len(snapshot))
+	for name, bag := range snapshot {
+		clone, err := bag.Clone()
+		if err != nil {
+			return nil, err
+		}
+		clones[name] = clone
+	}
+	return clones, nil
 }
 
 // initLocked lazily allocates nil fields so the zero value is always usable.

--- a/workflow.go
+++ b/workflow.go
@@ -276,16 +276,18 @@ func (w *workflow) State() NamespacedStateBag {
 //  1. If a workflow-level `prepare` hook is configured it is invoked first with the incoming `ctx` and the
 //     workflow instance. The returned context (if non-nil) is used for step preparation and execution.
 //  2. The workflow exposes a shared `NamespacedStateBag` via `w.State()` that represents workflow-wide state.
+//     Its shared state space is the global namespace plus every custom named room (core-spec §7.2.1).
 //  3. For ordinary steps, a new `NamespacedStateBag` is created with:
 //     a. An empty local namespace (isolated to the step)
-//     b. A shared global namespace (points to the workflow's global state)
+//     b. The workflow's shared global namespace and named rooms, both by reference (so a room
+//     created or written by one step is visible to later steps)
 //  4. For steps that are themselves workflows (detected with `IsWorkflow(step)`), `Execute` creates a new
 //     `NamespacedStateBag` with:
 //     a. An empty local namespace (isolated to the sub-workflow)
-//     b. A cloned global namespace (inherits parent's shared state but prevents mutations from
-//     propagating back to the parent workflow)
-//  5. This ensures sub-workflows have access to parent's global state but cannot mutate it, while
-//     ordinary steps share the global namespace and can mutate it (visible to later steps).
+//     b. A deep clone of the parent's shared state space (global namespace and every named room), so the
+//     sub-workflow inherits parent state but its mutations do not propagate back to the parent workflow
+//  5. This ensures sub-workflows have access to parent's shared state but cannot mutate it, while
+//     ordinary steps share it and can mutate it (visible to later steps).
 //
 // State snapshot and rollback:
 //  1. After each step executes (successfully or not), its state is cloned and stored in `stepStates`
@@ -400,41 +402,60 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		var statePrepError error
 		var ctxPrepError error
 
-		// prepare step state with namespace support
+		// prepare step state with namespace support (core-spec §7.3).
+		// The workflow's shared state space is Global plus every custom named
+		// room; both are propagated to each step's injected bag.
+		shared := w.State()
 		if IsWorkflow(step) {
-			var clonedGlobal StateBag
 			// Sub-workflows get a new NamespacedStateBag with:
 			// - Empty local namespace (isolated to the sub-workflow)
-			// - Cloned global namespace (inherits parent's shared state)
-			clonedGlobal, statePrepError = w.State().Global().Clone()
+			// - A deep clone of the parent's shared state space (Global and every
+			//   named room), so the sub-workflow inherits parent state but its
+			//   mutations do not propagate back to the parent (§6 isolation, §7.3).
+			var clonedGlobal StateBag
+			clonedGlobal, statePrepError = shared.Global().Clone()
+
+			var clonedCustom map[string]StateBag
+			if statePrepError == nil {
+				if s, ok := shared.(*SyncNamespacedStateBag); ok {
+					clonedCustom, statePrepError = s.cloneCustom()
+				}
+			}
+
 			if statePrepError != nil {
 				report = FailureReport(step,
 					WithWorkflow(w),
 					WithStartTime(stepStart),
 					WithActionType(ActionExecute),
 					WithError(StepExecutionError.
-						Wrap(statePrepError, "workflow %q step %q failed to clone global state for sub-workflow execution", w.id, step.Id()).
+						Wrap(statePrepError, "workflow %q step %q failed to clone shared state for sub-workflow execution", w.id, step.Id()).
 						WithProperty(StepIdProperty, step.Id()),
 					))
 
-				w.log().Warn("failed to clone global state for sub-workflow; falling back to empty state",
+				w.log().Warn("failed to clone shared state for sub-workflow; falling back to empty state",
 					"workflowId", w.id,
 					"stepId", step.Id(),
 					"error", statePrepError,
 				)
 
 				// Fall back to empty state for consistency since we always assume there is a state attached to the step
-				// when calling Prepare and Execute, even though sub-workflow won't have access to parent's global state
+				// when calling Prepare and Execute, even though sub-workflow won't have access to parent's shared state
 				// in this case.
 				stepState = NewNamespacedStateBag(nil, nil)
 			} else {
-				stepState = NewNamespacedStateBag(nil, clonedGlobal)
+				stepState = newNamespacedStateBag(nil, clonedGlobal, clonedCustom)
 			}
 		} else {
 			// Ordinary steps get namespaced state with:
 			// - Empty local namespace (isolated to this step)
-			// - Shared global namespace (points to workflow's global state)
-			stepState = NewNamespacedStateBag(nil, w.State().Global())
+			// - The workflow's shared Global bag (by reference)
+			// - The workflow's live named-room map (by reference), so a room
+			//   created or written by one step is visible to later steps (§7.3).
+			var customRooms map[string]StateBag
+			if s, ok := shared.(*SyncNamespacedStateBag); ok {
+				customRooms = s.customMapRef()
+			}
+			stepState = newNamespacedStateBag(nil, shared.Global(), customRooms)
 		}
 
 		// make sure step has its state before calling Prepare so Prepare can access it.

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -1005,3 +1005,74 @@ func TestWorkflow_RollbackSkipsPrepareFailed(t *testing.T) {
 	require.NotNil(t, s2Rollback, "s2 should have a rollback report")
 	assert.Equal(t, StatusSkipped, s2Rollback.Status)
 }
+
+// TestWorkflow_CustomNamespace_SharedAcrossSteps verifies core-spec §7.3 (D8):
+// a custom named room created/written by one ordinary step is observable by a
+// later ordinary step in the same workflow (rooms are shared by reference).
+func TestWorkflow_CustomNamespace_SharedAcrossSteps(t *testing.T) {
+	var observedHost string
+	var observed bool
+
+	wb := NewWorkflowBuilder().WithId("wf").Steps(
+		NewStepBuilder().WithId("publisher").WithExecute(func(ctx context.Context, stp Step) *Report {
+			stp.State().WithNamespace("db-primary").Set("host", "h1")
+			return StepSuccessReport("publisher")
+		}),
+		NewStepBuilder().WithId("consumer").WithExecute(func(ctx context.Context, stp Step) *Report {
+			observedHost, observed = stp.State().WithNamespace("db-primary").String("host")
+			return StepSuccessReport("consumer")
+		}),
+	)
+
+	report := RunWorkflow(context.Background(), wb)
+	require.NotNil(t, report)
+	assert.Equal(t, StatusSuccess, report.Status)
+
+	// The consumer must see the room the publisher created.
+	assert.True(t, observed, "later step should observe the named room written by an earlier step")
+	assert.Equal(t, "h1", observedHost)
+}
+
+// TestWorkflow_CustomNamespace_SubWorkflowIsolated verifies core-spec §7.3 (D8):
+// a sub-workflow receives a deep clone of the parent's shared state space, so it
+// inherits the parent's named rooms but its mutations do not propagate back.
+func TestWorkflow_CustomNamespace_SubWorkflowIsolated(t *testing.T) {
+	var childObservedHost string
+	var childObserved bool
+	var parentHostAfter string
+	var parentObservedAfter bool
+
+	sub := NewWorkflowBuilder().WithId("sub").Steps(
+		NewStepBuilder().WithId("mutator").WithExecute(func(ctx context.Context, stp Step) *Report {
+			// Inherited from the parent via deep clone.
+			childObservedHost, childObserved = stp.State().WithNamespace("db").String("host")
+			// Mutate the cloned room; this MUST NOT propagate back to the parent.
+			stp.State().WithNamespace("db").Set("host", "child")
+			return StepSuccessReport("mutator")
+		}),
+	)
+
+	wb := NewWorkflowBuilder().WithId("parent").Steps(
+		NewStepBuilder().WithId("seed").WithExecute(func(ctx context.Context, stp Step) *Report {
+			stp.State().WithNamespace("db").Set("host", "parent")
+			return StepSuccessReport("seed")
+		}),
+		sub,
+		NewStepBuilder().WithId("checker").WithExecute(func(ctx context.Context, stp Step) *Report {
+			parentHostAfter, parentObservedAfter = stp.State().WithNamespace("db").String("host")
+			return StepSuccessReport("checker")
+		}),
+	)
+
+	report := RunWorkflow(context.Background(), wb)
+	require.NotNil(t, report)
+	assert.Equal(t, StatusSuccess, report.Status)
+
+	// Sub-workflow inherited the parent's named room.
+	assert.True(t, childObserved, "sub-workflow should inherit the parent's named room")
+	assert.Equal(t, "parent", childObservedHost)
+
+	// Sub-workflow mutation did not leak back to the parent.
+	assert.True(t, parentObservedAfter)
+	assert.Equal(t, "parent", parentHostAfter, "sub-workflow mutation must not propagate back to parent")
+}


### PR DESCRIPTION


## Description

This pull request implements and documents the new workflow-scoped custom namespace ("named rooms") behavior, ensuring that named rooms are now shared by reference across ordinary steps and deep-cloned for sub-workflows, as required by the core spec (§7.2.1, §7.3, decision D8). The Go implementation is updated to conform to these requirements, and comprehensive tests are added to verify correct sharing and isolation of custom namespaces.

### Related Issues

Closes #116
Refs #83, #85

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
