### PR TITLE
fix: remove custom namespaces from state model (Local + Global only)

### DIFF
--- a/automa.go
+++ b/automa.go
@@ -17,8 +17,7 @@
 //
 // State is carried through a workflow via [NamespacedStateBag], which isolates
 // each step's private data (Local) from data that is intentionally shared
-// across all steps (Global) while also supporting arbitrary named partitions
-// (WithNamespace).
+// across all steps (Global).
 //
 // # Building workflows
 //
@@ -117,7 +116,7 @@ type Step interface {
 
 	// State returns the [NamespacedStateBag] attached to this step.
 	// Local() is private to this step; Global() is shared across all steps in
-	// the workflow; WithNamespace(name) provides an isolated named partition.
+	// the workflow.
 	State() NamespacedStateBag
 
 	// WithState attaches the provided [NamespacedStateBag] to the step in place
@@ -134,8 +133,8 @@ type Step interface {
 //
 // It is intentionally low-level: it has no notion of local vs. global scope.
 // Callers that need namespace isolation should work through
-// [NamespacedStateBag] and its Local(), Global(), and WithNamespace() methods
-// rather than operating on a StateBag directly.
+// [NamespacedStateBag] and its Local() and Global() methods rather than
+// operating on a StateBag directly.
 //
 // The primary implementation is [SyncStateBag].
 //
@@ -263,15 +262,14 @@ type StateBag interface {
 // two "setup-bind-mount" steps both writing "bind-mount-source" to the same
 // bag will have the second step silently overwrite the first step's value.
 //
-// NamespacedStateBag solves this by providing three distinct partitions:
+// NamespacedStateBag addresses this by separating step-private state from
+// intentionally shared state via two distinct partitions:
 //
 //   - Local — private to one step. The workflow gives each step its own
 //     local bag, so writes are never visible to any other step.
 //   - Global — shared across all steps in the workflow. Use this for
-//     configuration or counters that steps need to publish and consume.
-//   - Custom — an arbitrary named partition (e.g. "database-primary"). Use
-//     this when a reusable step implementation runs multiple times in the same
-//     workflow and each instance needs a collision-free namespace.
+//     configuration or results that steps need to publish and consume; choose
+//     distinct keys to avoid clobbering another step's value.
 //
 // # Usage
 //
@@ -280,12 +278,6 @@ type StateBag interface {
 //
 //	// Read from shared global state set by a previous step
 //	env, ok := stp.State().Global().String("env")
-//
-//	// Named partition for a reusable step
-//	stp.State().WithNamespace("database-primary").Set("conn", conn)
-//
-//	// Read back in Rollback (same namespace, same key)
-//	val, ok := stp.State().WithNamespace("database-primary").Get("conn")
 //
 // # Workflow integration
 //
@@ -308,26 +300,15 @@ type NamespacedStateBag interface {
 	// are immediately visible to subsequent steps that call Global().
 	Global() StateBag
 
-	// WithNamespace returns the StateBag for the named custom namespace,
-	// creating it on first access. The returned bag is stable: repeated calls
-	// with the same name return the same underlying bag.
-	//
-	// Custom namespaces are isolated from Local() and Global() and from each
-	// other. They are useful when a single step implementation is instantiated
-	// multiple times in one workflow.
-	WithNamespace(name string) StateBag
-
 	// Clone returns a fully independent deep copy of this NamespacedStateBag,
-	// including the local bag, the global bag, and all custom namespace bags.
-	// Mutations to the clone do not affect the original, and vice versa.
+	// including the local bag and the global bag. Mutations to the clone do not
+	// affect the original, and vice versa.
 	Clone() (NamespacedStateBag, error)
 
 	// Merge copies every namespace from other into this bag, overwriting
 	// conflicting keys. Each namespace kind is merged independently:
 	//   - Local bags are merged (other's keys overwrite matching keys here).
 	//   - Global bags are merged.
-	//   - Custom namespaces are merged by name: matching namespaces are merged,
-	//     new namespaces in other are deep-cloned and added.
 	//
 	// Returns the receiver and any error. Passing nil is a no-op.
 	Merge(other NamespacedStateBag) (NamespacedStateBag, error)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,7 +85,6 @@ Automa uses a **namespaced state bag** design for flexible state management.
 ├─────────────────────────────────────────────────┤
 │  + Local() StateBag                             │
 │  + Global() StateBag                            │
-│  + WithNamespace(name) StateBag                 │
 │  + Clone() (NamespacedStateBag, error)          │
 │  + Merge(other) (NamespacedStateBag, error)     │
 └─────────────────────────────────────────────────┘
@@ -97,7 +96,6 @@ Automa uses a **namespaced state bag** design for flexible state management.
 ├─────────────────────────────────────────────────┤
 │  - local: StateBag                              │
 │  - global: StateBag                             │
-│  - custom: map[string]StateBag                  │
 │  - mu: sync.RWMutex                             │
 ├─────────────────────────────────────────────────┤
 │  Thread-safe implementation                     │
@@ -110,7 +108,6 @@ Automa uses a **namespaced state bag** design for flexible state management.
 
 1. **Local**: Step-private state (isolated, not visible to other steps)
 2. **Global**: Workflow-shared state (visible to all steps)
-3. **Custom**: Named namespaces for specific use cases
 
 **State Flow:**
 
@@ -256,7 +253,6 @@ Step1.WithState(workflow.State()) → Step1.Rollback()
 Thread-safe via `sync.RWMutex`:
 
 - `Local()` / `Global()` use a fast-path read lock and initialize lazily on first access
-- `WithNamespace()` acquires a write lock to create missing custom namespaces
 - `Clone()`, `MarshalJSON()`, and `MarshalYAML()` snapshot namespace references under lock
 - Inner `StateBag` instances (`SyncStateBag`) protect their own contents independently
 
@@ -370,8 +366,7 @@ State is explicitly passed and managed:
 Workflow (heap-allocated)
 ├── State: NamespacedStateBag (shared reference)
 │   ├── Local: StateBag (lazy-allocated)
-│   ├── Global: StateBag (heap-allocated)
-│   └── Custom: map[string]StateBag (heap-allocated)
+│   └── Global: StateBag (heap-allocated)
 ├── Steps: []Step (slice of interfaces)
 └── lastExecutionStates: map[string]NamespacedStateBag
     └── [step-id]: NamespacedStateBag (cloned snapshots)
@@ -478,8 +473,7 @@ report := automa.SuccessReport(step,
 
 1. **Use namespaced state wisely**
    - Local for step-private data
-   - Global for shared configuration
-   - Custom for domain-specific isolation
+   - Global for shared configuration (use distinct keys to avoid clobbering)
 
 2. **Enable state preservation for critical workflows**
    - Ensures deterministic rollback

--- a/docs/spec/core-spec.md
+++ b/docs/spec/core-spec.md
@@ -15,17 +15,13 @@ Conformance keywords (**MUST**, **SHOULD**, **MAY**, …) are interpreted per
 
 This spec is **derived from** the Go reference implementation but is written to
 be correct in its own right. Where it intentionally departed from the original
-Go behavior, the decision is called out inline as either:
+Go behavior, the decision is called out inline:
 
 > **✓ Spec decision (Go conforms as of #NN).** … adopted by the reference
 > implementation.
 
-or, for the one decision not yet implemented:
-
-> **⚠ Spec decision (differs from current Go implementation).** … The Go
-> implementation is to be adapted to match this spec.
-
-A consolidated list of such decisions, and their adaptation status, is in §11.
+A consolidated list of such decisions is in §11; the Go reference implementation
+now conforms to all of them.
 
 ---
 
@@ -292,59 +288,45 @@ When `execution_mode` is `rollback` and step `i` fails:
 
 ### 7.2 Namespaces
 
-A **namespaced state bag** partitions state into:
+A **namespaced state bag** partitions state into exactly two namespaces:
 
 | Namespace | Visibility |
 |-----------|-----------|
 | **Local** | Private to one step. Never visible to any other step. |
-| **Global** | The default shared room: shared across all steps in a workflow. Writes by one step are visible to subsequent steps. |
-| **Custom (named)** | A **named shared room**: shared across all steps in the workflow under an explicit name, created on first access. A sibling of Global, not a child of it. Isolated from Local and from *other* named rooms, but **not** isolated between steps. |
+| **Global** | Shared across all steps in a workflow. Writes by one step are visible to subsequent steps. |
 
-#### 7.2.1 Custom namespaces are shared, named rooms
+- These two are the whole model: **Local** for step-private scratch, **Global**
+  for intentional cross-step sharing. There is no third, named partition.
+- **Global does not prevent collisions.** Multiple steps writing the same key in
+  Global overwrite each other. Authors SHOULD use distinct keys to publish data
+  for a later step, and MAY deliberately overwrite when a set of cooperating steps
+  intentionally shares a mutable value (e.g. a counter or status). The engine does
+  not arbitrate keys.
 
-- Global and the custom namespaces together form the workflow's **shared state
-  space**. Global is the default unnamed room; `WithNamespace(name)` is a named
-  room. Both are shared across all steps in the workflow.
-- A step that writes to `WithNamespace("database-primary")` publishes data that
-  any later step reading the same named room observes. This is the intended use:
-  a reusable step instance publishes under a distinct name (e.g.
-  `"database-primary"` vs `"database-replica"`) so a consuming step can read the
-  right instance's data without the flat-Global key collisions that would
-  otherwise occur.
-- **Collisions within a named room are by design, not prevented.** Multiple steps
-  writing the same key in the same named room overwrite each other, exactly as in
-  Global. Authors SHOULD use a key convention (e.g. a prefix) to avoid accidental
-  collisions, and MAY deliberately overwrite to let a set of cooperating steps
-  reuse values written by another step. The engine does not arbitrate.
-- Named rooms are isolated **from each other** and from Local; they are not
-  isolated **between steps** (that is the whole point — they are shared).
+> **✓ Spec decision (Go conforms as of #NN).** An earlier revision specified a
+> third "custom named room" namespace (`WithNamespace`). It was removed: a named
+> room provided nothing that Global with a distinct key does not — it did not
+> prevent overwrites *within* the room, so authors needed unique keys either way —
+> and it added a third cross-language concept for no capability gain. Local +
+> Global is the minimal, unambiguous model. (Removes the former decision D8 and
+> resolves review issue #83 by removal.)
 
 ### 7.3 State injection (per step)
 
 Before a step's Prepare, the engine MUST attach a namespaced state bag built as
-follows. "Shared state space" means **Global plus all named rooms** (§7.2.1):
+follows:
 
-- **Ordinary step:** fresh empty **Local**; the *same shared* state space as the
-  workflow's — both Global and the named rooms are shared by reference, so writes
-  to either are visible to later steps.
+- **Ordinary step:** fresh empty **Local**; the workflow's **Global** bag shared
+  by reference, so writes are visible to later steps.
 - **Sub-workflow step:** fresh empty **Local**; a *deep clone* of the workflow's
-  entire shared state space — both Global and every named room are cloned, so the
-  sub-workflow inherits the parent's shared state but its mutations (to Global or
-  any named room) MUST NOT propagate back to the parent (isolation, per §6).
-
-> **Resolved (was an open question).** Custom namespaces are workflow-scoped
-> shared named rooms, propagated to every step's injected bag by reference and
-> deep-cloned for sub-workflows alongside Global. This realizes the
-> `"database-primary"` use case the model was designed for. The previous
-> step-private behavior (review issue #83) is to be changed; the Go
-> implementation MUST be adapted (§11, D8) — tracked in #116.
+  **Global** bag, so the sub-workflow inherits the parent's Global state at entry
+  but its mutations MUST NOT propagate back to the parent (isolation, per §6).
 
 ### 7.4 Execution-time snapshots
 
 - After each step is processed (whether it succeeded or failed), the engine
   SHOULD capture a **deep-cloned snapshot** of that step's state (Local + Global
-  + custom namespaces at that moment), keyed by step ID, for use during
-  compensation (§5.3).
+  at that moment), keyed by step ID, for use during compensation (§5.3).
 - Snapshot capture MAY be disabled as an optimization. When disabled,
   compensation receives the current workflow (global) state instead of a
   per-step snapshot, and per-step Local namespaces are not available during
@@ -450,8 +432,9 @@ a cross-language contract.
 
 **Resolved (folded into the spec):**
 
-1. **Custom namespace propagation (§7.2.1, §7.3).** *Resolved:* workflow-scoped
-   shared named rooms, deep-cloned for sub-workflows. (D8.)
+1. **Custom namespaces (§7.2).** *Resolved:* removed. The state model is Local +
+   Global only; a named partition added no capability over a distinct Global key.
+   (Resolves review issue #83 by removal.)
 2. **Numeric precision boundaries (§7.5).** *Resolved:* document the 2^53
    boundary; recommend string-typed numerics for values beyond it; authors using
    JSON numbers accept the risk.
@@ -485,12 +468,9 @@ implementation is (or is being) adapted to match.
 | D5 | Compensation MUST skip non-executed (`skipped`/`pending`) steps. | 5.3 | #84 |
 | D6 | Nested workflows **inherit** the parent's modes (parent overrides); fix the contradicting builder doc comment. | 6.1 | #82 |
 | D7 | Report enums (`action`, `status`) MUST fail on unknown values on decode, like `mode`. | 8.1 | #94 |
+| D8 | *(withdrawn)* An earlier revision specified custom namespaces as workflow-scoped shared named rooms. The feature was **removed** instead (§7.2): Local + Global is the whole model. | 7.2 | removed |
 
-**Still pending — Go adaptation not yet done:**
-
-| # | Decision | §  |
-|---|----------|----|
-| D8 | Custom namespaces become **workflow-scoped shared named rooms** (propagated by reference to steps, deep-cloned for sub-workflows), replacing the current step-private behavior. The Go engine currently builds per-step state as `NewNamespacedStateBag(nil, global)`, so custom namespaces remain step-private; this MUST be adapted before v1 freeze (tracked in #116). | 7.2.1, 7.3 |
+All spec decisions are now reflected in the Go reference implementation.
 
 ## 12. Conformance
 
@@ -504,4 +484,4 @@ implementation is (or is being) adapted to match.
     implementation MUST load and re-serialize equivalently (§7.5, §8).
 - The **Go** implementation is the first conformant implementation and a
   reference, not the definition. A divergence between Go behavior and this spec
-  is a Go bug (or a §11 item pending adaptation), not a spec amendment.
+  is a Go bug, not a spec amendment.

--- a/docs/spec/durability-spec.md
+++ b/docs/spec/durability-spec.md
@@ -95,8 +95,8 @@ none of the three.
     "phase": "forward",                //   string; workflow phase (§4.1)
     "index": 1                         //   integer; index into this node's steps
   },
-  "shared": { /* namespaced bag */ },  // object; this workflow's shared state space:
-                                        //   Global + all named rooms (§ core 7.2.1).
+  "shared": { /* namespaced bag */ },  // object; this workflow's shared state:
+                                        //   the Global namespace (§ core 7.2).
                                         //   Excludes per-step Local (captured per step).
   "steps": [                           // array; one entry per step, in topology order
     {
@@ -125,8 +125,7 @@ Field requirements:
   **OPTIONAL** and MAY be omitted when not yet produced (e.g. a `pending` step).
   `snapshot`, when present, is the leaf-step state captured for compensation.
 - `shared` MAY be an empty object but the key MUST be present on a workflow node.
-  It captures the workflow's shared state space (Global + all named rooms, per
-  core spec §7.2.1).
+  It captures the workflow's shared state — the Global namespace (core spec §7.2).
 - The serialization of `shared`, `snapshot`, and `report` is governed by their
   own (existing) language-neutral schemas (namespaced state bag, report tree).
   This spec treats them as opaque nested objects and constrains only their
@@ -386,7 +385,7 @@ F3. run the step's execute  (THE SIDE EFFECT happens here)
 F4. steps[i].state   = "completed" | "failed"
     steps[i].snapshot = <execution-time state>          (when completed, for rollback)
     steps[i].report   = <step report>
-    shared            = <current shared state space: Global + named rooms>
+    shared            = <current shared state: Global>
                                                PERSIST   ← commit point, AFTER side effect
 F5. on failure with execution_mode = RollbackOnError:
     cursor = {phase:"compensating", index:i};  PERSIST
@@ -436,7 +435,7 @@ A resume:
 
 1. Loads the journal (§6.2).
 2. Validates topology and modes against the supplied definition (§6.2).
-3. Rehydrates `shared` (Global + named rooms) onto the workflow.
+3. Rehydrates `shared` (Global) onto the workflow.
 4. Dispatches on `cursor.phase` (§6.3, §6.4, §6.5), descending recursively into
    workflow steps (§3.8): a workflow step is resumed by dispatching on its own
    node's `cursor.phase` against its own `steps`.

--- a/state_namespaced.go
+++ b/state_namespaced.go
@@ -8,26 +8,27 @@ import (
 )
 
 // SyncNamespacedStateBag is a thread-safe implementation of NamespacedStateBag
-// that partitions state into three kinds of namespace:
+// that partitions state into two kinds of namespace:
 //
 //   - Local — private to a single step; each step receives its own local bag
 //     so writes in one step cannot accidentally overwrite another step's data.
 //   - Global — shared across all steps in a workflow; mutations are visible to
 //     every subsequent step that reads from the same global bag.
-//   - Custom — an arbitrary set of named bags (e.g. "database-1", "cache"),
-//     useful when a reusable step implementation needs a stable, collision-free
-//     namespace regardless of how many instances are running.
+//
+// These two are the whole model: Local for step-private scratch, Global for
+// cross-step sharing. A step that wants to publish data for a later step writes
+// to Global under a key it chooses; the engine does not arbitrate keys, so
+// authors SHOULD use distinct keys to avoid clobbering each other.
 //
 // Concurrency model:
-//   - n.mu (sync.RWMutex) protects the three pointer fields (local, global,
-//     custom map) and the custom map itself.
+//   - n.mu (sync.RWMutex) protects the two pointer fields (local, global).
 //   - Read operations on the pointers (Local, Global) use a fast-path RLock
 //     and upgrade to a write lock only when lazy initialization is needed.
-//   - Write operations (WithNamespace, Merge, UnmarshalJSON, UnmarshalYAML,
-//     MarshalJSON, MarshalYAML) acquire the write lock for the duration.
-//   - The individual StateBag instances (local, global, custom entries) are
-//     themselves thread-safe SyncStateBag values; their own internal lock
-//     serialises Set/Get/Delete calls.
+//   - Write operations (Merge, UnmarshalJSON, UnmarshalYAML, MarshalJSON,
+//     MarshalYAML) acquire the write lock for the duration.
+//   - The individual StateBag instances (local, global) are themselves
+//     thread-safe SyncStateBag values; their own internal lock serialises
+//     Set/Get/Delete calls.
 //
 // Zero value: a zero-value SyncNamespacedStateBag is safe to use without
 // explicit construction. All fields are lazily initialized on first access via
@@ -38,15 +39,12 @@ import (
 type SyncNamespacedStateBag struct {
 	local  StateBag
 	global StateBag
-	custom map[string]StateBag
-	mu     sync.RWMutex // protects local, global, and the custom map
+	mu     sync.RWMutex // protects local and global
 }
 
 // NewNamespacedStateBag constructs a SyncNamespacedStateBag with explicit
 // initial local and global bags. Either argument may be nil, in which case an
-// empty *SyncStateBag is substituted. The custom namespace map is always
-// initialized to an empty map so that WithNamespace can write without a nil-map
-// panic.
+// empty *SyncStateBag is substituted.
 //
 // Example:
 //
@@ -65,7 +63,6 @@ func NewNamespacedStateBag(local, global StateBag) *SyncNamespacedStateBag {
 	return &SyncNamespacedStateBag{
 		local:  local,
 		global: global,
-		custom: make(map[string]StateBag),
 	}
 }
 
@@ -78,9 +75,6 @@ func (n *SyncNamespacedStateBag) initLocked() {
 	}
 	if n.global == nil {
 		n.global = &SyncStateBag{}
-	}
-	if n.custom == nil {
-		n.custom = make(map[string]StateBag)
 	}
 }
 
@@ -134,45 +128,15 @@ func (n *SyncNamespacedStateBag) Global() StateBag {
 	return g
 }
 
-// WithNamespace returns the StateBag for the named custom namespace, creating
-// it on demand if it does not already exist.
-//
-// Custom namespaces are useful for step implementations that are instantiated
-// multiple times in the same workflow (e.g. "setup-bind-mount-for-app1" and
-// "setup-bind-mount-for-app2"). By writing to WithNamespace(name) each
-// instance gets an isolated bag without the caller needing to worry about key
-// collisions with other instances.
-//
-// The returned bag is stable: repeated calls with the same name always return
-// the same underlying StateBag pointer.
-//
-// Thread-safety: the write lock is always acquired to guarantee atomic
-// check-then-create semantics.
-func (n *SyncNamespacedStateBag) WithNamespace(name string) StateBag {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	n.initLocked()
-
-	bag, exists := n.custom[name]
-	if !exists {
-		bag = &SyncStateBag{}
-		n.custom[name] = bag
-	}
-
-	return bag
-}
-
 // Clone returns a fully independent deep copy of the SyncNamespacedStateBag,
-// including all three namespace kinds.
+// including both namespace kinds.
 //
 // Clone strategy:
-//  1. A write lock is acquired to snapshot the field pointers and the custom
-//     map (so the set of namespace names cannot change mid-clone).
+//  1. A write lock is acquired to snapshot the field pointers.
 //  2. The lock is released before cloning individual bags to avoid holding n's
 //     write lock while the inner SyncStateBag Clone() calls acquire their own
 //     locks, which would otherwise risk lock ordering issues.
-//  3. Local, global, and each custom bag are deep-copied in sequence via their
-//     own Clone() methods.
+//  3. Local and global are deep-copied via their own Clone() methods.
 //
 // The returned NamespacedStateBag shares no memory with the original: mutations
 // to the clone do not affect the original, and vice versa.
@@ -188,10 +152,6 @@ func (n *SyncNamespacedStateBag) Clone() (NamespacedStateBag, error) {
 	n.initLocked()
 	local := n.local
 	global := n.global
-	customCopy := make(map[string]StateBag, len(n.custom))
-	for name, bag := range n.custom {
-		customCopy[name] = bag
-	}
 	n.mu.Unlock()
 
 	// Clone each bag outside the lock — Clone() acquires inner locks.
@@ -205,19 +165,9 @@ func (n *SyncNamespacedStateBag) Clone() (NamespacedStateBag, error) {
 		return nil, err
 	}
 
-	clonedCustom := make(map[string]StateBag, len(customCopy))
-	for name, bag := range customCopy {
-		clonedBag, err := bag.Clone()
-		if err != nil {
-			return nil, err
-		}
-		clonedCustom[name] = clonedBag
-	}
-
 	return &SyncNamespacedStateBag{
 		local:  localClone,
 		global: globalClone,
-		custom: clonedCustom,
 	}, nil
 }
 
@@ -228,15 +178,9 @@ func (n *SyncNamespacedStateBag) Clone() (NamespacedStateBag, error) {
 //   - Local: other's local keys are merged into n's local bag (other wins on
 //     key conflicts).
 //   - Global: other's global keys are merged into n's global bag.
-//   - Custom: for each custom namespace in other —
-//   - If the same namespace already exists in n, the two bags are merged
-//     (other wins on key conflicts).
-//   - If the namespace is new to n, other's bag is deep-cloned and added so
-//     that n and other do not share the same StateBag pointer.
 //
 // Type constraint: other must be a *SyncNamespacedStateBag. If a different
-// implementation is passed, an error is returned immediately so that callers
-// are not surprised by silently dropped custom namespaces.
+// implementation is passed, an error is returned immediately.
 //
 // Deadlock prevention: other's field snapshots are read before n's write lock
 // is acquired, following the same snapshot-before-lock pattern used by
@@ -244,7 +188,7 @@ func (n *SyncNamespacedStateBag) Clone() (NamespacedStateBag, error) {
 //
 // Returns (n, nil) on success.
 // Returns (n, nil) unchanged when other is nil.
-// Returns (nil, error) on type mismatch or inner merge/clone failure.
+// Returns (nil, error) on type mismatch or inner merge failure.
 func (n *SyncNamespacedStateBag) Merge(other NamespacedStateBag) (NamespacedStateBag, error) {
 	if other == nil {
 		return n, nil
@@ -261,13 +205,6 @@ func (n *SyncNamespacedStateBag) Merge(other NamespacedStateBag) (NamespacedStat
 	// Local() and Global() handle their own lazy initialization.
 	otherLocal := otherSync.Local()
 	otherGlobal := otherSync.Global()
-
-	otherSync.mu.RLock()
-	otherCustom := make(map[string]StateBag, len(otherSync.custom))
-	for name, bag := range otherSync.custom {
-		otherCustom[name] = bag
-	}
-	otherSync.mu.RUnlock()
 
 	// Now lock n and perform merges
 	n.mu.Lock()
@@ -288,23 +225,6 @@ func (n *SyncNamespacedStateBag) Merge(other NamespacedStateBag) (NamespacedStat
 	}
 	n.global = mergedGlobal
 
-	// Merge custom namespaces
-	for name, otherBag := range otherCustom {
-		if existingBag, exists := n.custom[name]; exists {
-			merged, err := existingBag.Merge(otherBag)
-			if err != nil {
-				return nil, err
-			}
-			n.custom[name] = merged
-		} else {
-			clonedBag, err := otherBag.Clone()
-			if err != nil {
-				return nil, err
-			}
-			n.custom[name] = clonedBag
-		}
-	}
-
 	return n, nil
 }
 
@@ -313,18 +233,16 @@ func (n *SyncNamespacedStateBag) Merge(other NamespacedStateBag) (NamespacedStat
 // map[string]interface{} (keys are the string form of Key, values are
 // whatever encoding/json or gopkg.in/yaml.v3 produces for the stored value).
 type namespacedSnapshot struct {
-	Local  map[string]interface{}            `json:"local" yaml:"local"`
-	Global map[string]interface{}            `json:"global" yaml:"global"`
-	Custom map[string]map[string]interface{} `json:"custom" yaml:"custom"`
+	Local  map[string]interface{} `json:"local" yaml:"local"`
+	Global map[string]interface{} `json:"global" yaml:"global"`
 }
 
-// MarshalJSON implements json.Marshaler. It serializes all three namespace
-// kinds into the namespacedSnapshot wire format:
+// MarshalJSON implements json.Marshaler. It serializes both namespace kinds
+// into the namespacedSnapshot wire format:
 //
 //	{
 //	  "local":  { "key": value, … },
-//	  "global": { "key": value, … },
-//	  "custom": { "ns-name": { "key": value, … }, … }
+//	  "global": { "key": value, … }
 //	}
 //
 // A nil receiver marshals as JSON null.
@@ -343,20 +261,12 @@ func (n *SyncNamespacedStateBag) MarshalJSON() ([]byte, error) {
 	n.initLocked()
 	local := n.local
 	global := n.global
-	customCopy := make(map[string]StateBag, len(n.custom))
-	for name, bag := range n.custom {
-		customCopy[name] = bag
-	}
 	n.mu.Unlock()
 
 	// Build snapshot outside the lock — StateBagToStringMap acquires inner locks.
 	snapshot := namespacedSnapshot{
 		Local:  StateBagToStringMap(local),
 		Global: StateBagToStringMap(global),
-		Custom: make(map[string]map[string]interface{}, len(customCopy)),
-	}
-	for name, bag := range customCopy {
-		snapshot.Custom[name] = StateBagToStringMap(bag)
 	}
 
 	return json.Marshal(snapshot)
@@ -392,34 +302,22 @@ func (n *SyncNamespacedStateBag) UnmarshalJSON(data []byte) error {
 	for k, v := range snapshot.Global {
 		global.Set(Key(k), v)
 	}
-	custom := make(map[string]StateBag)
-	for name, mp := range snapshot.Custom {
-		b := &SyncStateBag{}
-		for k, v := range mp {
-			b.Set(Key(k), v)
-		}
-		custom[name] = b
-	}
 
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	n.local = local
 	n.global = global
-	n.custom = custom
 	return nil
 }
 
 // MarshalYAML implements yaml.Marshaler. It returns a namespacedSnapshot
-// struct that the YAML encoder serializes into the same three-section layout
+// struct that the YAML encoder serializes into the same two-section layout
 // as MarshalJSON:
 //
 //	local:
 //	  key: value
 //	global:
 //	  key: value
-//	custom:
-//	  ns-name:
-//	    key: value
 //
 // A nil receiver returns (nil, nil), which the encoder renders as YAML null.
 //
@@ -434,20 +332,12 @@ func (n *SyncNamespacedStateBag) MarshalYAML() (interface{}, error) {
 	n.initLocked()
 	local := n.local
 	global := n.global
-	customCopy := make(map[string]StateBag, len(n.custom))
-	for name, bag := range n.custom {
-		customCopy[name] = bag
-	}
 	n.mu.Unlock()
 
 	// Build snapshot outside the lock — StateBagToStringMap acquires inner locks.
 	snapshot := namespacedSnapshot{
 		Local:  StateBagToStringMap(local),
 		Global: StateBagToStringMap(global),
-		Custom: make(map[string]map[string]interface{}, len(customCopy)),
-	}
-	for name, bag := range customCopy {
-		snapshot.Custom[name] = StateBagToStringMap(bag)
 	}
 
 	return snapshot, nil
@@ -481,19 +371,10 @@ func (n *SyncNamespacedStateBag) UnmarshalYAML(node *yaml.Node) error {
 	for k, v := range snapshot.Global {
 		global.Set(Key(k), v)
 	}
-	custom := make(map[string]StateBag)
-	for name, mp := range snapshot.Custom {
-		b := &SyncStateBag{}
-		for k, v := range mp {
-			b.Set(Key(k), v)
-		}
-		custom[name] = b
-	}
 
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	n.local = local
 	n.global = global
-	n.custom = custom
 	return nil
 }

--- a/state_namespaced_concurrency_test.go
+++ b/state_namespaced_concurrency_test.go
@@ -74,76 +74,6 @@ func TestSyncNamespacedStateBag_Concurrent_Global(t *testing.T) {
 	assert.True(t, ok)
 }
 
-// TestSyncNamespacedStateBag_Concurrent_WithNamespace verifies thread-safe access to custom namespaces
-func TestSyncNamespacedStateBag_Concurrent_WithNamespace(t *testing.T) {
-	ns := NewNamespacedStateBag(nil, nil)
-	const goroutines = 100
-	const operations = 100
-
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-
-	for i := 0; i < goroutines; i++ {
-		go func(id int) {
-			defer wg.Done()
-			for j := 0; j < operations; j++ {
-				// Concurrent access to same custom namespace
-				custom := ns.WithNamespace("shared-ns")
-				custom.Set(Key("custom-key"), id)
-
-				// Concurrent reads
-				_, ok := custom.Get(Key("custom-key"))
-				assert.True(t, ok)
-			}
-		}(i)
-	}
-
-	wg.Wait()
-
-	// Verify custom namespace exists and is accessible
-	custom := ns.WithNamespace("shared-ns")
-	assert.NotNil(t, custom)
-	_, ok := custom.Get(Key("custom-key"))
-	assert.True(t, ok)
-}
-
-// TestSyncNamespacedStateBag_Concurrent_MultipleNamespaces verifies thread-safe creation of multiple custom namespaces
-func TestSyncNamespacedStateBag_Concurrent_MultipleNamespaces(t *testing.T) {
-	ns := NewNamespacedStateBag(nil, nil)
-	const goroutines = 50
-	const namespacesPerGoroutine = 10
-
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-
-	for i := 0; i < goroutines; i++ {
-		go func(id int) {
-			defer wg.Done()
-			for j := 0; j < namespacesPerGoroutine; j++ {
-				// Create unique namespace per goroutine
-				nsName := Key("ns-" + string(rune(id)) + "-" + string(rune(j)))
-				custom := ns.WithNamespace(string(nsName))
-				custom.Set(Key("data"), id)
-
-				// Verify data
-				val, ok := custom.Get(Key("data"))
-				assert.True(t, ok)
-				assert.Equal(t, id, val)
-			}
-		}(i)
-	}
-
-	wg.Wait()
-
-	// Verify all namespaces were created
-	// We expect goroutines * namespacesPerGoroutine unique namespaces
-	ns.mu.RLock()
-	customCount := len(ns.custom)
-	ns.mu.RUnlock()
-
-	assert.Equal(t, goroutines*namespacesPerGoroutine, customCount)
-}
-
 // TestSyncNamespacedStateBag_Concurrent_Clone verifies thread-safe cloning
 func TestSyncNamespacedStateBag_Concurrent_Clone(t *testing.T) {
 	ns := NewNamespacedStateBag(nil, nil)
@@ -151,7 +81,6 @@ func TestSyncNamespacedStateBag_Concurrent_Clone(t *testing.T) {
 	// Populate with data
 	ns.Local().Set("local-key", "local-value")
 	ns.Global().Set("global-key", "global-value")
-	ns.WithNamespace("custom").Set("custom-key", "custom-value")
 
 	const goroutines = 100
 
@@ -175,9 +104,6 @@ func TestSyncNamespacedStateBag_Concurrent_Clone(t *testing.T) {
 			globalStr, gok := cloned.Global().String("global-key")
 			assert.True(t, gok)
 			assert.Equal(t, "global-value", globalStr)
-			customStr, cok := cloned.WithNamespace("custom").String("custom-key")
-			assert.True(t, cok)
-			assert.Equal(t, "custom-value", customStr)
 		}(i)
 	}
 
@@ -240,7 +166,7 @@ func TestSyncNamespacedStateBag_Concurrent_MixedOperations(t *testing.T) {
 	const operations = 50
 
 	var wg sync.WaitGroup
-	wg.Add(goroutines * 5) // 5 different operation types
+	wg.Add(goroutines * 4) // 4 different operation types
 
 	// Concurrent Local() access
 	for i := 0; i < goroutines; i++ {
@@ -260,17 +186,6 @@ func TestSyncNamespacedStateBag_Concurrent_MixedOperations(t *testing.T) {
 			for j := 0; j < operations; j++ {
 				ns.Global().Set(Key("global"), id)
 				ns.Global().Get(Key("global"))
-			}
-		}(i)
-	}
-
-	// Concurrent WithNamespace() access
-	for i := 0; i < goroutines; i++ {
-		go func(id int) {
-			defer wg.Done()
-			for j := 0; j < operations; j++ {
-				ns.WithNamespace("custom").Set(Key("custom"), id)
-				ns.WithNamespace("custom").Get(Key("custom"))
 			}
 		}(i)
 	}
@@ -302,7 +217,6 @@ func TestSyncNamespacedStateBag_Concurrent_MixedOperations(t *testing.T) {
 	// Verify state is still accessible after concurrent operations
 	assert.NotNil(t, ns.Local())
 	assert.NotNil(t, ns.Global())
-	assert.NotNil(t, ns.WithNamespace("custom"))
 }
 
 // TestSyncNamespacedStateBag_Concurrent_LocalLazyInit verifies thread-safe lazy initialization of Local()
@@ -352,7 +266,6 @@ func TestSyncNamespacedStateBag_Concurrent_MergeMultipleSources(t *testing.T) {
 			source := NewNamespacedStateBag(nil, nil)
 			source.Local().Set(Key("source-"+string(rune(id))), id)
 			source.Global().Set(Key("global-"+string(rune(id))), id)
-			source.WithNamespace("custom").Set(Key("custom-"+string(rune(id))), id)
 
 			_, err := target.Merge(source)
 			require.NoError(t, err)

--- a/state_namespaced_marshalling_test.go
+++ b/state_namespaced_marshalling_test.go
@@ -14,7 +14,6 @@ func TestSyncNamespacedStateBag_JSONRoundTrip(t *testing.T) {
 	n := NewNamespacedStateBag(nil, nil)
 	n.Global().Set("g", "gv")
 	n.Local().Set("l", "lv")
-	n.WithNamespace("ns").Set("k", "v")
 
 	b, err := json.Marshal(n)
 	require.NoError(t, err)
@@ -29,16 +28,12 @@ func TestSyncNamespacedStateBag_JSONRoundTrip(t *testing.T) {
 	lv, ok := n2.Local().String("l")
 	assert.True(t, ok)
 	assert.Equal(t, "lv", lv)
-	kv, ok := n2.WithNamespace("ns").String("k")
-	assert.True(t, ok)
-	assert.Equal(t, "v", kv)
 }
 
 func TestSyncNamespacedStateBag_YAMLRoundTrip(t *testing.T) {
 	n := NewNamespacedStateBag(nil, nil)
 	n.Global().Set("g", "gv")
 	n.Local().Set("l", "lv")
-	n.WithNamespace("ns").Set("k", "v")
 
 	b, err := yaml.Marshal(n)
 	require.NoError(t, err)
@@ -53,7 +48,4 @@ func TestSyncNamespacedStateBag_YAMLRoundTrip(t *testing.T) {
 	lv, ok := n2.Local().String("l")
 	assert.True(t, ok)
 	assert.Equal(t, "lv", lv)
-	kv, ok := n2.WithNamespace("ns").String("k")
-	assert.True(t, ok)
-	assert.Equal(t, "v", kv)
 }

--- a/state_namespaced_test.go
+++ b/state_namespaced_test.go
@@ -35,28 +35,12 @@ func TestNamespacedStateBag_BasicOperations(t *testing.T) {
 		assert.False(t, ok, "global should not see local-only keys")
 	})
 
-	t.Run("custom namespace isolation", func(t *testing.T) {
-		ns := NewNamespacedStateBag(nil, nil)
-
-		ns.WithNamespace("ns1").Set("key", "value1")
-		ns.WithNamespace("ns2").Set("key", "value2")
-
-		val1, ok1 := ns.WithNamespace("ns1").String("key")
-		val2, ok2 := ns.WithNamespace("ns2").String("key")
-
-		assert.True(t, ok1)
-		assert.True(t, ok2)
-		assert.Equal(t, "value1", val1)
-		assert.Equal(t, "value2", val2)
-	})
-
 	t.Run("clone creates independent copy", func(t *testing.T) {
 		original := NewNamespacedStateBag(nil, nil)
 
-		// Set values in all namespaces
+		// Set values in both namespaces
 		original.Local().Set("local-key", "local-value")
 		original.Global().Set("global-key", "global-value")
-		original.WithNamespace("custom").Set("custom-key", "custom-value")
 
 		// Clone the state
 		cloned, err := original.Clone()
@@ -70,14 +54,10 @@ func TestNamespacedStateBag_BasicOperations(t *testing.T) {
 		clonedGlobalStr, ok := cloned.Global().String("global-key")
 		assert.True(t, ok)
 		assert.Equal(t, "global-value", clonedGlobalStr)
-		clonedCustomStr, ok := cloned.WithNamespace("custom").String("custom-key")
-		assert.True(t, ok)
-		assert.Equal(t, "custom-value", clonedCustomStr)
 
 		// Modify original
 		original.Local().Set("local-key", "modified-local")
 		original.Global().Set("global-key", "modified-global")
-		original.WithNamespace("custom").Set("custom-key", "modified-custom")
 
 		// Verify clone is not affected
 		clonedLocalStr2, ok := cloned.Local().String("local-key")
@@ -86,9 +66,6 @@ func TestNamespacedStateBag_BasicOperations(t *testing.T) {
 		clonedGlobalStr2, ok := cloned.Global().String("global-key")
 		assert.True(t, ok)
 		assert.Equal(t, "global-value", clonedGlobalStr2)
-		clonedCustomStr2, ok := cloned.WithNamespace("custom").String("custom-key")
-		assert.True(t, ok)
-		assert.Equal(t, "custom-value", clonedCustomStr2)
 
 		// Modify clone
 		cloned.Local().Set("new-key", "new-value")
@@ -244,64 +221,14 @@ func TestNamespacedStateBag_Merge(t *testing.T) {
 		assert.Equal(t, "enabled", newSettingVal)
 	})
 
-	t.Run("merge custom namespaces - add new", func(t *testing.T) {
-		ns1 := NewNamespacedStateBag(nil, nil)
-		ns1.WithNamespace("ns1").Set("key", "value1")
-
-		ns2 := NewNamespacedStateBag(nil, nil)
-		ns2.WithNamespace("ns2").Set("key", "value2")
-
-		result, err := ns1.Merge(ns2)
-		require.NoError(t, err)
-		require.Same(t, ns1, result)
-
-		// Verify both custom namespaces exist
-		ns1Val, ok := ns1.WithNamespace("ns1").String("key")
-		assert.True(t, ok)
-		assert.Equal(t, "value1", ns1Val)
-		ns2Val, ok := ns1.WithNamespace("ns2").String("key")
-		assert.True(t, ok)
-		assert.Equal(t, "value2", ns2Val)
-	})
-
-	t.Run("merge custom namespaces - merge existing", func(t *testing.T) {
-		ns1 := NewNamespacedStateBag(nil, nil)
-		ns1.WithNamespace("shared").Set("key1", "value1")
-		ns1.WithNamespace("shared").Set("shared-key", "original")
-
-		ns2 := NewNamespacedStateBag(nil, nil)
-		ns2.WithNamespace("shared").Set("key2", "value2")
-		ns2.WithNamespace("shared").Set("shared-key", "merged")
-
-		result, err := ns1.Merge(ns2)
-		require.NoError(t, err)
-		require.Same(t, ns1, result)
-
-		// Verify custom namespace has merged values
-		sharedNs := ns1.WithNamespace("shared")
-		v1, ok := sharedNs.String("key1")
-		assert.True(t, ok)
-		assert.Equal(t, "value1", v1)
-		v2, ok := sharedNs.String("key2")
-		assert.True(t, ok)
-		assert.Equal(t, "value2", v2)
-		sv, ok := sharedNs.String("shared-key")
-		assert.True(t, ok)
-		assert.Equal(t, "merged", sv)
-	})
-
-	t.Run("merge all namespaces together", func(t *testing.T) {
+	t.Run("merge local and global together", func(t *testing.T) {
 		ns1 := NewNamespacedStateBag(nil, nil)
 		ns1.Local().Set("local1", "l1")
 		ns1.Global().Set("global1", "g1")
-		ns1.WithNamespace("custom1").Set("c1", "v1")
-		ns1.WithNamespace("shared").Set("s1", "original")
 
 		ns2 := NewNamespacedStateBag(nil, nil)
 		ns2.Local().Set("local2", "l2")
 		ns2.Global().Set("global2", "g2")
-		ns2.WithNamespace("custom2").Set("c2", "v2")
-		ns2.WithNamespace("shared").Set("s2", "merged")
 
 		result, err := ns1.Merge(ns2)
 		require.NoError(t, err)
@@ -322,20 +249,6 @@ func TestNamespacedStateBag_Merge(t *testing.T) {
 		g2, ok := ns1.Global().String("global2")
 		assert.True(t, ok)
 		assert.Equal(t, "g2", g2)
-
-		// Verify custom namespaces
-		c1, ok := ns1.WithNamespace("custom1").String("c1")
-		assert.True(t, ok)
-		assert.Equal(t, "v1", c1)
-		c2, ok := ns1.WithNamespace("custom2").String("c2")
-		assert.True(t, ok)
-		assert.Equal(t, "v2", c2)
-		s1, ok := ns1.WithNamespace("shared").String("s1")
-		assert.True(t, ok)
-		assert.Equal(t, "original", s1)
-		s2, ok := ns1.WithNamespace("shared").String("s2")
-		assert.True(t, ok)
-		assert.Equal(t, "merged", s2)
 	})
 
 	t.Run("merge with nil returns self", func(t *testing.T) {
@@ -367,23 +280,6 @@ func TestNamespacedStateBag_Merge(t *testing.T) {
 		ns2Val, ok := ns2.Local().String("key")
 		assert.True(t, ok)
 		assert.Equal(t, "value2", ns2Val)
-	})
-
-	t.Run("merge custom namespaces are cloned not referenced", func(t *testing.T) {
-		ns1 := NewNamespacedStateBag(nil, nil)
-
-		ns2 := NewNamespacedStateBag(nil, nil)
-		ns2.WithNamespace("custom").Set("key", "original")
-
-		result, err := ns1.Merge(ns2)
-		require.NoError(t, err)
-		require.Same(t, ns1, result)
-
-		ns2.WithNamespace("custom").Set("key", "modified")
-
-		ns1CustomVal, ok := ns1.WithNamespace("custom").String("key")
-		assert.True(t, ok)
-		assert.Equal(t, "original", ns1CustomVal)
 	})
 }
 
@@ -487,64 +383,6 @@ func TestNamespacedStateBag_RealWorldScenario_BindMount(t *testing.T) {
 		assert.Equal(t, "/mnt/app1", bindMount1.Target)
 		assert.Equal(t, "/var/sandbox/app2", bindMount2.Source)
 		assert.Equal(t, "/mnt/app2", bindMount2.Target)
-	})
-}
-
-func TestNamespacedStateBag_CustomNamespacePerStep(t *testing.T) {
-	t.Run("steps use custom namespaces for isolation", func(t *testing.T) {
-		wb := NewWorkflowBuilder().WithId("custom-namespace-workflow")
-
-		type Config struct {
-			Host string
-			Port int
-		}
-
-		var config1, config2 Config
-
-		// Step 1 uses custom namespace "database-1"
-		step1 := NewStepBuilder().WithId("setup-db1").
-			WithExecute(func(ctx context.Context, stp Step) *Report {
-				cfg := Config{Host: "db1.example.com", Port: 5432}
-				stp.State().WithNamespace("database-1").Set("config", cfg)
-				return SuccessReport(stp)
-			}).
-			WithRollback(func(ctx context.Context, stp Step) *Report {
-				if val, ok := stp.State().WithNamespace("database-1").Get("config"); ok {
-					config1 = val.(Config)
-				}
-				return SuccessReport(stp)
-			})
-
-		// Step 2 uses custom namespace "database-2"
-		step2 := NewStepBuilder().WithId("setup-db2").
-			WithExecute(func(ctx context.Context, stp Step) *Report {
-				cfg := Config{Host: "db2.example.com", Port: 3306}
-				stp.State().WithNamespace("database-2").Set("config", cfg)
-				return SuccessReport(stp)
-			}).
-			WithRollback(func(ctx context.Context, stp Step) *Report {
-				if val, ok := stp.State().WithNamespace("database-2").Get("config"); ok {
-					config2 = val.(Config)
-				}
-				return SuccessReport(stp)
-			})
-
-		wb.Steps(step1, step2)
-		wf, err := wb.Build()
-		require.NoError(t, err)
-
-		// Execute and rollback
-		executeReport := wf.Execute(context.Background())
-		assert.True(t, executeReport.IsSuccess())
-
-		rollbackReport := wf.Rollback(context.Background())
-		assert.True(t, rollbackReport.IsSuccess())
-
-		// Verify each step accessed its own namespace
-		assert.Equal(t, "db1.example.com", config1.Host)
-		assert.Equal(t, 5432, config1.Port)
-		assert.Equal(t, "db2.example.com", config2.Host)
-		assert.Equal(t, 3306, config2.Port)
 	})
 }
 
@@ -668,36 +506,6 @@ func TestNamespacedStateBag_LocalVsGlobalClearSemantics(t *testing.T) {
 		report := wf.Execute(context.Background())
 		assert.True(t, report.IsSuccess())
 	})
-
-	t.Run("custom namespace independent from local and global", func(t *testing.T) {
-		wb := NewWorkflowBuilder().WithId("custom-independent-workflow")
-
-		step := NewStepBuilder().WithId("test-step").
-			WithExecute(func(ctx context.Context, stp Step) *Report {
-				// Set same key in all three namespace types
-				stp.State().Local().Set("KEY1", "Local-Value")
-				stp.State().Global().Set("KEY1", "Global-Value")
-				stp.State().WithNamespace("custom").Set("KEY1", "Custom-Value")
-
-				// Verify they're all independent
-				localValue, _ := stp.State().Local().String("KEY1")
-				globalValue, _ := stp.State().Global().String("KEY1")
-				customValue, _ := stp.State().WithNamespace("custom").String("KEY1")
-
-				assert.Equal(t, "Local-Value", localValue)
-				assert.Equal(t, "Global-Value", globalValue)
-				assert.Equal(t, "Custom-Value", customValue)
-
-				return SuccessReport(stp)
-			})
-
-		wb.Steps(step)
-		wf, err := wb.Build()
-		require.NoError(t, err)
-
-		report := wf.Execute(context.Background())
-		assert.True(t, report.IsSuccess())
-	})
 }
 
 func TestNamespacedStateBag_RollbackStateIsolation(t *testing.T) {
@@ -747,7 +555,6 @@ type mockNamespacedStateBag struct{}
 
 func (m *mockNamespacedStateBag) Local() StateBag                    { return &SyncStateBag{} }
 func (m *mockNamespacedStateBag) Global() StateBag                   { return &SyncStateBag{} }
-func (m *mockNamespacedStateBag) WithNamespace(_ string) StateBag    { return &SyncStateBag{} }
 func (m *mockNamespacedStateBag) Clone() (NamespacedStateBag, error) { return m, nil }
 func (m *mockNamespacedStateBag) Merge(_ NamespacedStateBag) (NamespacedStateBag, error) {
 	return m, nil
@@ -778,21 +585,11 @@ func TestSyncNamespacedStateBag_ZeroValueUsable(t *testing.T) {
 		assert.Equal(t, "global-value", globalVal)
 	})
 
-	t.Run("with namespace creates custom namespace on zero value", func(t *testing.T) {
-		var ns SyncNamespacedStateBag
-
-		ns.WithNamespace("step1").Set("key", "value")
-		nsVal, ok := ns.WithNamespace("step1").String("key")
-		assert.True(t, ok)
-		assert.Equal(t, "value", nsVal)
-	})
-
 	t.Run("merge works on zero value receiver", func(t *testing.T) {
 		var ns SyncNamespacedStateBag
 		other := NewNamespacedStateBag(nil, nil)
 		other.Local().Set("local-key", "local-value")
 		other.Global().Set("global-key", "global-value")
-		other.WithNamespace("custom").Set("key", "custom-value")
 
 		merged, err := ns.Merge(other)
 		require.NoError(t, err)
@@ -804,16 +601,12 @@ func TestSyncNamespacedStateBag_ZeroValueUsable(t *testing.T) {
 		globalVal, ok := ns.Global().String("global-key")
 		assert.True(t, ok)
 		assert.Equal(t, "global-value", globalVal)
-		customVal, ok := ns.WithNamespace("custom").String("key")
-		assert.True(t, ok)
-		assert.Equal(t, "custom-value", customVal)
 	})
 
 	t.Run("clone works on zero value receiver", func(t *testing.T) {
 		var ns SyncNamespacedStateBag
 		ns.Local().Set("local-key", "local-value")
 		ns.Global().Set("global-key", "global-value")
-		ns.WithNamespace("custom").Set("key", "custom-value")
 
 		cloned, err := ns.Clone()
 		require.NoError(t, err)
@@ -825,8 +618,5 @@ func TestSyncNamespacedStateBag_ZeroValueUsable(t *testing.T) {
 		globalVal, ok := cloned.Global().String("global-key")
 		assert.True(t, ok)
 		assert.Equal(t, "global-value", globalVal)
-		customVal, ok := cloned.WithNamespace("custom").String("key")
-		assert.True(t, ok)
-		assert.Equal(t, "custom-value", customVal)
 	})
 }

--- a/step_builder.go
+++ b/step_builder.go
@@ -224,7 +224,7 @@ func (s *StepBuilder) BuildAndCopy() (Step, error) {
 	s.Step.onFailure = finishedStep.onFailure
 	s.Step.enableAsyncCallbacks = finishedStep.enableAsyncCallbacks
 
-	// Clone the NamespacedStateBag (clones local, global, and custom namespaces)
+	// Clone the NamespacedStateBag (clones local and global namespaces)
 	var err error
 	if finishedStep.state != nil {
 		s.Step.state, err = finishedStep.state.Clone()

--- a/workflow.go
+++ b/workflow.go
@@ -64,7 +64,7 @@ type workflow struct {
 	//
 	// When true (default):
 	//   - State is cloned and stored for each step after execution
-	//   - Rollback steps receive their execution-time state snapshots (local + global + custom namespaces)
+	//   - Rollback steps receive their execution-time state snapshots (local + global namespaces)
 	//   - Higher memory usage due to deep state cloning
 	//
 	// When false:
@@ -483,7 +483,7 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		}
 
 		// Capture state snapshot after step processing (successful or failed)
-		// Clone() creates an immutable snapshot by deep-cloning all namespaces (local, global, custom).
+		// Clone() creates an immutable snapshot by deep-cloning all namespaces (local, global).
 		// This ensures later steps cannot mutate earlier snapshots, enabling deterministic rollback.
 		// State preservation can be disabled via preserveStatesForRollback to reduce memory overhead.
 		if w.preserveStatesForRollback {


### PR DESCRIPTION
## Description

This pull request removes support for custom/named namespaces from the state management model, simplifying the design to just two partitions: `Local` (step-private) and `Global` (shared across all steps). The code, documentation, and specification are all updated to reflect this change, eliminating the `WithNamespace` method and references to custom namespaces. This makes the state model clearer and reduces complexity, aligning the implementation and spec.

These changes ensure that both the implementation and documentation are consistent and easier to understand, with only `Local` and `Global` state partitions.

### Related Issues

- Resolves #83 by removal. 
- Closes #116 (D8) as won't-do.

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
