### PR TITLE
feat: conformance fixtures harness

### DIFF
--- a/conformance_test.go
+++ b/conformance_test.go
@@ -1,0 +1,309 @@
+package automa_test
+
+// Conformance harness. Loads the language-neutral fixtures under
+// docs/spec/conformance/ and asserts the Go reference implementation produces
+// the behavior the spec fixtures describe. Every conformant implementation
+// (Go first, then other languages) MUST pass the same fixtures unchanged.
+//
+// See docs/spec/conformance/README.md for the fixture format and conventions.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	conformanceBehaviorDir      = "docs/spec/conformance/behavior"
+	conformanceSerializationDir = "docs/spec/conformance/serialization"
+)
+
+// ---------------------------------------------------------------------------
+// Behavior fixtures
+// ---------------------------------------------------------------------------
+
+type behaviorFixture struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	SpecRefs    []string        `json:"specRefs"`
+	Workflow    fixtureWorkflow `json:"workflow"`
+	Expect      behaviorExpect  `json:"expect"`
+}
+
+type fixtureWorkflow struct {
+	ID            string        `json:"id"`
+	ExecutionMode string        `json:"executionMode"`
+	RollbackMode  string        `json:"rollbackMode"`
+	Steps         []fixtureStep `json:"steps"`
+}
+
+type fixtureStep struct {
+	ID string `json:"id"`
+
+	// Leaf-step declared outcomes.
+	Prepare  string `json:"prepare"`  // "" (ok) | failed
+	Execute  string `json:"execute"`  // success | failed | skipped
+	Rollback string `json:"rollback"` // success | failed (default: success)
+
+	// When Steps is non-empty this step is a sub-workflow; Execute/Rollback are
+	// ignored and these fields configure the nested workflow.
+	ExecutionMode string        `json:"executionMode"`
+	RollbackMode  string        `json:"rollbackMode"`
+	Steps         []fixtureStep `json:"steps"`
+}
+
+func (s fixtureStep) isWorkflow() bool { return len(s.Steps) > 0 }
+
+type behaviorExpect struct {
+	WorkflowStatus string                  `json:"workflowStatus"`
+	ExecutionOrder []string                `json:"executionOrder"`
+	RollbackOrder  []string                `json:"rollbackOrder"`
+	Steps          map[string]expectedStep `json:"steps"`
+}
+
+type expectedStep struct {
+	Status         string `json:"status"`
+	Action         string `json:"action"`
+	RollbackStatus string `json:"rollbackStatus"`
+}
+
+// recorder captures the order in which leaf steps run Execute and Rollback.
+// Execution is strictly sequential (core-spec §4.1) so a plain slice is safe.
+type recorder struct {
+	execOrder     []string
+	rollbackOrder []string
+}
+
+func parseMode(t *testing.T, s string) automa.TypeMode {
+	t.Helper()
+	switch s {
+	case "continue":
+		return automa.ContinueOnError
+	case "stop":
+		return automa.StopOnError
+	case "rollback":
+		return automa.RollbackOnError
+	default:
+		t.Fatalf("unknown mode %q in fixture", s)
+		return 0
+	}
+}
+
+func buildFixtureStep(t *testing.T, rec *recorder, fs fixtureStep) automa.Builder {
+	t.Helper()
+
+	if fs.isWorkflow() {
+		wb := automa.NewWorkflowBuilder().WithId(fs.ID)
+		if fs.ExecutionMode != "" {
+			wb.WithExecutionMode(parseMode(t, fs.ExecutionMode))
+		}
+		if fs.RollbackMode != "" {
+			wb.WithRollbackMode(parseMode(t, fs.RollbackMode))
+		}
+		subs := make([]automa.Builder, 0, len(fs.Steps))
+		for _, child := range fs.Steps {
+			subs = append(subs, buildFixtureStep(t, rec, child))
+		}
+		wb.Steps(subs...)
+		return wb
+	}
+
+	id := fs.ID
+	prepOutcome := fs.Prepare
+	execOutcome := fs.Execute
+	rbOutcome := fs.Rollback
+
+	sb := automa.NewStepBuilder().WithId(id)
+	if prepOutcome == "failed" {
+		sb.WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			return nil, errors.New("fixture: declared prepare failure")
+		})
+	}
+	return sb.
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			rec.execOrder = append(rec.execOrder, id)
+			switch execOutcome {
+			case "failed":
+				return automa.FailureReport(stp, automa.WithError(errors.New("fixture: declared failure")))
+			case "skipped":
+				return automa.SkippedReport(stp)
+			default:
+				return automa.SuccessReport(stp)
+			}
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			rec.rollbackOrder = append(rec.rollbackOrder, id)
+			if rbOutcome == "failed" {
+				return automa.FailureReport(stp, automa.WithError(errors.New("fixture: declared rollback failure")))
+			}
+			return automa.SuccessReport(stp)
+		})
+}
+
+// collectStepReports indexes every step report in the tree by step ID.
+func collectStepReports(r *automa.Report, out map[string]*automa.Report) {
+	for _, sr := range r.StepReports {
+		if sr == nil {
+			continue
+		}
+		out[sr.Id] = sr
+		collectStepReports(sr, out)
+	}
+}
+
+func runBehaviorFixture(t *testing.T, fx behaviorFixture) {
+	rec := &recorder{}
+
+	wb := automa.NewWorkflowBuilder().WithId(fx.Workflow.ID)
+	if fx.Workflow.ExecutionMode != "" {
+		wb.WithExecutionMode(parseMode(t, fx.Workflow.ExecutionMode))
+	}
+	if fx.Workflow.RollbackMode != "" {
+		wb.WithRollbackMode(parseMode(t, fx.Workflow.RollbackMode))
+	}
+	subs := make([]automa.Builder, 0, len(fx.Workflow.Steps))
+	for _, s := range fx.Workflow.Steps {
+		subs = append(subs, buildFixtureStep(t, rec, s))
+	}
+	wb.Steps(subs...)
+
+	report := automa.RunWorkflow(context.Background(), wb)
+	require.NotNil(t, report, "RunWorkflow returned nil report")
+
+	// Workflow-level status.
+	assert.Equal(t, fx.Expect.WorkflowStatus, report.Status.String(), "workflow status")
+
+	// Execution order (leaf steps that actually ran Execute, in order).
+	assert.Equal(t, fx.Expect.ExecutionOrder, normalizeOrder(rec.execOrder), "execution order")
+
+	// Rollback order, when the fixture declares one.
+	if fx.Expect.RollbackOrder != nil {
+		assert.Equal(t, fx.Expect.RollbackOrder, normalizeOrder(rec.rollbackOrder), "rollback order")
+	}
+
+	// Per-step report expectations.
+	if len(fx.Expect.Steps) > 0 {
+		index := map[string]*automa.Report{}
+		collectStepReports(report, index)
+		for id, want := range fx.Expect.Steps {
+			got, ok := index[id]
+			if !assert.Truef(t, ok, "expected a report for step %q", id) {
+				continue
+			}
+			if want.Status != "" {
+				assert.Equalf(t, want.Status, got.Status.String(), "step %q status", id)
+			}
+			if want.Action != "" {
+				assert.Equalf(t, want.Action, got.Action.String(), "step %q action", id)
+			}
+			if want.RollbackStatus != "" {
+				if assert.NotNilf(t, got.Rollback, "step %q expected a rollback report", id) {
+					assert.Equalf(t, want.RollbackStatus, got.Rollback.Status.String(), "step %q rollback status", id)
+				}
+			}
+		}
+	}
+}
+
+// normalizeOrder returns a non-nil empty slice for an empty recording so it
+// compares equal to a fixture's explicit [] rather than requiring null.
+func normalizeOrder(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+func TestConformance_Behavior(t *testing.T) {
+	fixtures := loadFixtures(t, conformanceBehaviorDir)
+	for path, data := range fixtures {
+		var fx behaviorFixture
+		require.NoErrorf(t, json.Unmarshal(data, &fx), "decode %s", path)
+		name := fx.Name
+		if name == "" {
+			name = filepath.Base(path)
+		}
+		t.Run(name, func(t *testing.T) {
+			runBehaviorFixture(t, fx)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Serialization fixtures
+// ---------------------------------------------------------------------------
+
+type serializationFixture struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	SpecRefs    []string        `json:"specRefs"`
+	Kind        string          `json:"kind"` // statebag
+	JSON        json.RawMessage `json:"json"`
+}
+
+func TestConformance_Serialization(t *testing.T) {
+	fixtures := loadFixtures(t, conformanceSerializationDir)
+	for path, data := range fixtures {
+		var fx serializationFixture
+		require.NoErrorf(t, json.Unmarshal(data, &fx), "decode %s", path)
+		name := fx.Name
+		if name == "" {
+			name = filepath.Base(path)
+		}
+		t.Run(name, func(t *testing.T) {
+			switch fx.Kind {
+			case "statebag":
+				var bag automa.SyncNamespacedStateBag
+				require.NoError(t, json.Unmarshal(fx.JSON, &bag), "load state bag")
+				out, err := json.Marshal(&bag)
+				require.NoError(t, err, "re-serialize state bag")
+				assertJSONEqual(t, fx.JSON, out)
+			default:
+				t.Fatalf("unknown serialization fixture kind %q", fx.Kind)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// loadFixtures reads every *.json file in dir and returns path -> contents.
+// It fails the test if the directory is missing or contains no fixtures, so a
+// mis-placed fixture directory cannot silently pass conformance.
+func loadFixtures(t *testing.T, dir string) map[string][]byte {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoErrorf(t, err, "read fixture dir %s", dir)
+
+	out := map[string][]byte{}
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		p := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(p)
+		require.NoErrorf(t, err, "read fixture %s", p)
+		out[p] = data
+	}
+	require.NotEmptyf(t, out, "no fixtures found in %s", dir)
+	return out
+}
+
+// assertJSONEqual compares two JSON documents structurally (key order and
+// insignificant whitespace are ignored).
+func assertJSONEqual(t *testing.T, want, got []byte) {
+	t.Helper()
+	var wantV, gotV interface{}
+	require.NoError(t, json.Unmarshal(want, &wantV), "decode expected JSON")
+	require.NoError(t, json.Unmarshal(got, &gotV), "decode produced JSON")
+	assert.Equal(t, wantV, gotV, "JSON round-trip mismatch\nexpected: %s\nproduced: %s", want, got)
+}

--- a/conformance_test.go
+++ b/conformance_test.go
@@ -82,6 +82,18 @@ type recorder struct {
 	rollbackOrder []string
 }
 
+// assertAllowed fails the test when a fixture declares an outcome outside the
+// permitted set, so a malformed fixture cannot silently pass.
+func assertAllowed(t *testing.T, stepID, field, value string, allowed ...string) {
+	t.Helper()
+	for _, a := range allowed {
+		if value == a {
+			return
+		}
+	}
+	t.Fatalf("fixture step %q: unknown %s outcome %q (allowed: %v)", stepID, field, value, allowed)
+}
+
 func parseMode(t *testing.T, s string) automa.TypeMode {
 	t.Helper()
 	switch s {
@@ -121,10 +133,17 @@ func buildFixtureStep(t *testing.T, rec *recorder, fs fixtureStep) automa.Builde
 	execOutcome := fs.Execute
 	rbOutcome := fs.Rollback
 
+	// Reject unknown declared outcomes up front. Fixtures are authoritative, so a
+	// typo must fail the suite rather than silently fall through to a default.
+	assertAllowed(t, id, "prepare", prepOutcome, "", "failed")
+	assertAllowed(t, id, "execute", execOutcome, "success", "failed", "skipped", "none")
+	assertAllowed(t, id, "rollback", rbOutcome, "", "success", "failed")
+
 	sb := automa.NewStepBuilder().WithId(id)
 	if prepOutcome == "failed" {
 		sb.WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
-			return nil, errors.New("fixture: declared prepare failure")
+			// Honor the context contract: return the incoming ctx, not nil, on error.
+			return ctx, errors.New("fixture: declared prepare failure")
 		})
 	}
 

--- a/conformance_test.go
+++ b/conformance_test.go
@@ -49,7 +49,7 @@ type fixtureStep struct {
 
 	// Leaf-step declared outcomes.
 	Prepare  string `json:"prepare"`  // "" (ok) | failed
-	Execute  string `json:"execute"`  // success | failed | skipped
+	Execute  string `json:"execute"`  // success | failed | skipped | none (omit Execute → invalid step)
 	Rollback string `json:"rollback"` // success | failed (default: success)
 
 	// When Steps is non-empty this step is a sub-workflow; Execute/Rollback are
@@ -63,6 +63,7 @@ func (s fixtureStep) isWorkflow() bool { return len(s.Steps) > 0 }
 
 type behaviorExpect struct {
 	WorkflowStatus string                  `json:"workflowStatus"`
+	WorkflowAction string                  `json:"workflowAction"` // optional; e.g. "prepare" for a build/validation failure
 	ExecutionOrder []string                `json:"executionOrder"`
 	RollbackOrder  []string                `json:"rollbackOrder"`
 	Steps          map[string]expectedStep `json:"steps"`
@@ -126,6 +127,13 @@ func buildFixtureStep(t *testing.T, rec *recorder, fs fixtureStep) automa.Builde
 			return nil, errors.New("fixture: declared prepare failure")
 		})
 	}
+
+	// "none" omits Execute entirely, producing an invalid step (core-spec §3.2.1)
+	// so the fixture can assert build/validation behavior.
+	if execOutcome == "none" {
+		return sb
+	}
+
 	return sb.
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			rec.execOrder = append(rec.execOrder, id)
@@ -179,6 +187,11 @@ func runBehaviorFixture(t *testing.T, fx behaviorFixture) {
 
 	// Workflow-level status.
 	assert.Equal(t, fx.Expect.WorkflowStatus, report.Status.String(), "workflow status")
+
+	// Workflow-level action, when the fixture asserts one (e.g. build failure).
+	if fx.Expect.WorkflowAction != "" {
+		assert.Equal(t, fx.Expect.WorkflowAction, report.Action.String(), "workflow action")
+	}
 
 	// Execution order (leaf steps that actually ran Execute, in order).
 	assert.Equal(t, fx.Expect.ExecutionOrder, normalizeOrder(rec.execOrder), "execution order")
@@ -264,6 +277,12 @@ func TestConformance_Serialization(t *testing.T) {
 				require.NoError(t, json.Unmarshal(fx.JSON, &bag), "load state bag")
 				out, err := json.Marshal(&bag)
 				require.NoError(t, err, "re-serialize state bag")
+				assertJSONEqual(t, fx.JSON, out)
+			case "report":
+				var rep automa.Report
+				require.NoError(t, json.Unmarshal(fx.JSON, &rep), "load report")
+				out, err := json.Marshal(&rep)
+				require.NoError(t, err, "re-serialize report")
 				assertJSONEqual(t, fx.JSON, out)
 			default:
 				t.Fatalf("unknown serialization fixture kind %q", fx.Kind)

--- a/docs/spec/conformance/README.md
+++ b/docs/spec/conformance/README.md
@@ -92,13 +92,15 @@ matter).
 }
 ```
 
-- `kind` is currently `statebag` (the namespaced state bag: `local` + `global`,
-  core-spec §7.2). Both namespace keys are always present, even when empty.
+- `kind` is one of:
+  - `statebag` — the namespaced state bag (`local` + `global`, core-spec §7.2).
+    Both namespace keys are always present, even when empty.
+  - `report` — a report tree (core-spec §8): step and workflow reports, nested
+    `steps`, an inline `rollback` sub-report, RFC 3339 millisecond timestamps,
+    and error-as-string.
 - **Numeric precision (§7.5):** JSON has one number type; a round-trip through
   floating point is exact only up to 2^53. Values beyond that MUST be stored as
   strings to survive losslessly. Fixtures encode both the safe-integer case and
   the string-encoded large-ID case.
-
-Report round-trip fixtures (`kind: report`) are pending a small addition to the
-Go `Report` type (it currently marshals but does not unmarshal); tracked as the
-next step of #95.
+- **Timestamps (§8):** serialize as RFC 3339 with a timezone designator;
+  trailing-zero fractional seconds are trimmed (e.g. `...00.5Z`, not `...00.500Z`).

--- a/docs/spec/conformance/README.md
+++ b/docs/spec/conformance/README.md
@@ -1,0 +1,104 @@
+# Conformance fixtures
+
+Language-neutral fixtures that define correct automa behavior. Every conformant
+implementation (Go first, then Kotlin/Python/Rust/…) MUST pass **these same
+fixtures, unchanged**. They are the source of truth for cross-language
+agreement; the prose specs ([core](../core-spec.md), [durability](../durability-spec.md))
+are the rationale.
+
+> **Rule:** adding or changing a specified behavior REQUIRES adding or updating a
+> fixture here. A spec change without a fixture change is incomplete.
+
+Fixtures are plain JSON with no language dependency. The Go reference harness
+lives in [`conformance_test.go`](../../../conformance_test.go) and runs every
+fixture under `go test`.
+
+## Layout
+
+```
+docs/spec/conformance/
+  behavior/        # workflow execution outcomes (core-spec §4–§6, §8)
+  serialization/   # load → re-serialize round-trips (core-spec §7.5, §8)
+  journal/         # durability journal + resume (durability-spec §8) — TODO with #86
+```
+
+## Behavior fixtures (`behavior/*.json`)
+
+A workflow definition whose steps have **declared outcomes**, plus the expected
+observable result. The harness builds the workflow, runs it with no real side
+effects, and asserts the execution/rollback order and the report tree.
+
+```json
+{
+  "name": "stop_on_error_halts",
+  "description": "StopOnError stops at the first failure and runs no rollback.",
+  "specRefs": ["§5.1"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "stop",          // stop | continue | rollback
+    "rollbackMode": "continue",       // continue | stop
+    "steps": [
+      { "id": "s1", "execute": "success" },
+      { "id": "s2", "execute": "failed" },
+      { "id": "s3", "execute": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",        // success | failed | skipped
+    "executionOrder": ["s1", "s2"],    // leaf steps that ran Execute, in order
+    "rollbackOrder": [],               // leaf steps that ran Rollback, in order
+    "steps": {                          // per-step report assertions (subset ok)
+      "s1": { "status": "success", "action": "execute" },
+      "s2": { "status": "failed",  "action": "execute" }
+    }
+  }
+}
+```
+
+Step fields:
+
+- **Leaf step:** `execute` is `success` | `failed` | `skipped`. `rollback` is
+  `success` | `failed` (default `success`). `prepare` is `""` (ok) | `failed`;
+  a failed Prepare means the step never Executes.
+- **Sub-workflow step:** provide a non-empty `steps` array (and optionally its
+  own `executionMode` / `rollbackMode`); `prepare`/`execute`/`rollback` are then
+  ignored. A workflow is a step (core-spec §6), so nesting is recursive.
+
+Expectations:
+
+- `executionOrder` / `rollbackOrder` list **leaf** step IDs in the order their
+  Execute / Rollback ran (a sub-workflow contributes its leaves, flattened).
+- `steps[id]` asserts a subset of that step's report: `status`, `action`, and
+  `rollbackStatus` (the status of the step's rollback sub-report). Omitted keys
+  are not asserted. Steps absent from the map are not asserted, so fixtures need
+  not enumerate steps that never produced a report.
+
+## Serialization fixtures (`serialization/*.json`)
+
+A canonical JSON document that every implementation MUST load and re-serialize
+to an equivalent document (structural equality; key order and whitespace do not
+matter).
+
+```json
+{
+  "name": "statebag_numeric_boundary",
+  "description": "Safe integers round-trip; larger IDs use strings (core-spec §7.5).",
+  "specRefs": ["§7.5"],
+  "kind": "statebag",
+  "json": {
+    "local":  {},
+    "global": { "safeInt": 9007199254740992, "bigId": "9007199254740993" }
+  }
+}
+```
+
+- `kind` is currently `statebag` (the namespaced state bag: `local` + `global`,
+  core-spec §7.2). Both namespace keys are always present, even when empty.
+- **Numeric precision (§7.5):** JSON has one number type; a round-trip through
+  floating point is exact only up to 2^53. Values beyond that MUST be stored as
+  strings to survive losslessly. Fixtures encode both the safe-integer case and
+  the string-encoded large-ID case.
+
+Report round-trip fixtures (`kind: report`) are pending a small addition to the
+Go `Report` type (it currently marshals but does not unmarshal); tracked as the
+next step of #95.

--- a/docs/spec/conformance/README.md
+++ b/docs/spec/conformance/README.md
@@ -99,8 +99,10 @@ matter).
     `steps`, an inline `rollback` sub-report, RFC 3339 millisecond timestamps,
     and error-as-string.
 - **Numeric precision (§7.5):** JSON has one number type; a round-trip through
-  floating point is exact only up to 2^53. Values beyond that MUST be stored as
-  strings to survive losslessly. Fixtures encode both the safe-integer case and
-  the string-encoded large-ID case.
+  IEEE-754 double is exact only for integers with magnitude ≤ 2^53−1 (the max
+  *safe* integer — the largest with a unique double representation). 2^53 itself
+  is representable, but 2^53+1 is not, so values beyond the safe range MUST be
+  stored as strings to survive losslessly. Fixtures encode the safe-integer case,
+  the 2^53 boundary, and the string-encoded unsafe-ID case.
 - **Timestamps (§8):** serialize as RFC 3339 with a timezone designator;
   trailing-zero fractional seconds are trimmed (e.g. `...00.5Z`, not `...00.500Z`).

--- a/docs/spec/conformance/behavior/continue_on_error_runs_all.json
+++ b/docs/spec/conformance/behavior/continue_on_error_runs_all.json
@@ -1,0 +1,25 @@
+{
+  "name": "continue_on_error_runs_all",
+  "description": "ContinueOnError runs every step regardless of failures; the workflow still reports failed.",
+  "specRefs": ["§5.1"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "continue",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "s1", "execute": "success" },
+      { "id": "s2", "execute": "failed" },
+      { "id": "s3", "execute": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["s1", "s2", "s3"],
+    "rollbackOrder": [],
+    "steps": {
+      "s1": { "status": "success", "action": "execute" },
+      "s2": { "status": "failed", "action": "execute" },
+      "s3": { "status": "success", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/deeply_nested_composition.json
+++ b/docs/spec/conformance/behavior/deeply_nested_composition.json
@@ -1,0 +1,39 @@
+{
+  "name": "deeply_nested_composition",
+  "description": "Composability is recursive: a workflow nested inside a workflow inside a workflow executes its leaves in flattened topology order (§6).",
+  "specRefs": ["§6"],
+  "workflow": {
+    "id": "L1",
+    "executionMode": "stop",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "s1", "execute": "success" },
+      {
+        "id": "L2",
+        "steps": [
+          { "id": "x", "execute": "success" },
+          {
+            "id": "L3",
+            "steps": [
+              { "id": "y", "execute": "success" },
+              { "id": "z", "execute": "success" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "success",
+    "executionOrder": ["s1", "x", "y", "z"],
+    "rollbackOrder": [],
+    "steps": {
+      "s1": { "status": "success", "action": "execute" },
+      "L2": { "status": "success", "action": "execute" },
+      "x": { "status": "success", "action": "execute" },
+      "L3": { "status": "success", "action": "execute" },
+      "y": { "status": "success", "action": "execute" },
+      "z": { "status": "success", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/nested_workflow_composes.json
+++ b/docs/spec/conformance/behavior/nested_workflow_composes.json
@@ -1,0 +1,33 @@
+{
+  "name": "nested_workflow_composes",
+  "description": "A workflow is a step: a sub-workflow's leaf steps execute in place, and the sub-workflow reports as a workflow step.",
+  "specRefs": ["§6", "§6.1"],
+  "workflow": {
+    "id": "parent",
+    "executionMode": "stop",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "s1", "execute": "success" },
+      {
+        "id": "sub",
+        "steps": [
+          { "id": "a", "execute": "success" },
+          { "id": "b", "execute": "success" }
+        ]
+      },
+      { "id": "s3", "execute": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "success",
+    "executionOrder": ["s1", "a", "b", "s3"],
+    "rollbackOrder": [],
+    "steps": {
+      "s1": { "status": "success", "action": "execute" },
+      "sub": { "status": "success", "action": "execute" },
+      "a": { "status": "success", "action": "execute" },
+      "b": { "status": "success", "action": "execute" },
+      "s3": { "status": "success", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/nested_workflow_inherits_modes.json
+++ b/docs/spec/conformance/behavior/nested_workflow_inherits_modes.json
@@ -1,0 +1,31 @@
+{
+  "name": "nested_workflow_inherits_modes",
+  "description": "A sub-workflow with no explicit modes inherits the parent's (D6). Here the parent is ContinueOnError, so the sub also continues past its own failing step instead of stopping.",
+  "specRefs": ["§6.1"],
+  "workflow": {
+    "id": "parent",
+    "executionMode": "continue",
+    "rollbackMode": "continue",
+    "steps": [
+      {
+        "id": "sub",
+        "steps": [
+          { "id": "a", "execute": "failed" },
+          { "id": "b", "execute": "success" }
+        ]
+      },
+      { "id": "tail", "execute": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["a", "b", "tail"],
+    "rollbackOrder": [],
+    "steps": {
+      "sub": { "status": "failed", "action": "execute" },
+      "a": { "status": "failed", "action": "execute" },
+      "b": { "status": "success", "action": "execute" },
+      "tail": { "status": "success", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/nested_workflow_rollback_propagation.json
+++ b/docs/spec/conformance/behavior/nested_workflow_rollback_propagation.json
@@ -1,0 +1,31 @@
+{
+  "name": "nested_workflow_rollback_propagation",
+  "description": "Under RollbackOnError, when a later sibling fails the engine compensates a previously-succeeded sub-workflow by rolling back its leaf steps in reverse order (a workflow is a step, §6).",
+  "specRefs": ["§6", "§5.1", "§5.3"],
+  "workflow": {
+    "id": "parent",
+    "executionMode": "rollback",
+    "rollbackMode": "continue",
+    "steps": [
+      {
+        "id": "sub",
+        "steps": [
+          { "id": "a", "execute": "success" },
+          { "id": "b", "execute": "success" }
+        ]
+      },
+      { "id": "s2", "execute": "failed" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["a", "b", "s2"],
+    "rollbackOrder": ["s2", "b", "a"],
+    "steps": {
+      "sub": { "status": "success", "action": "execute", "rollbackStatus": "success" },
+      "s2": { "status": "failed", "action": "execute", "rollbackStatus": "success" },
+      "a": { "status": "success", "action": "execute" },
+      "b": { "status": "success", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/rollback_mode_continue_compensates_all.json
+++ b/docs/spec/conformance/behavior/rollback_mode_continue_compensates_all.json
@@ -1,0 +1,25 @@
+{
+  "name": "rollback_mode_continue_compensates_all",
+  "description": "With rollbackMode=continue, a failing rollback does not stop compensation: earlier steps are still compensated.",
+  "specRefs": ["§5.2"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "rollback",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "s1", "execute": "success", "rollback": "success" },
+      { "id": "s2", "execute": "success", "rollback": "failed" },
+      { "id": "s3", "execute": "failed", "rollback": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["s1", "s2", "s3"],
+    "rollbackOrder": ["s3", "s2", "s1"],
+    "steps": {
+      "s3": { "status": "failed", "action": "execute", "rollbackStatus": "success" },
+      "s2": { "status": "success", "action": "execute", "rollbackStatus": "failed" },
+      "s1": { "status": "success", "action": "execute", "rollbackStatus": "success" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/rollback_mode_stop_halts_compensation.json
+++ b/docs/spec/conformance/behavior/rollback_mode_stop_halts_compensation.json
@@ -1,0 +1,25 @@
+{
+  "name": "rollback_mode_stop_halts_compensation",
+  "description": "With rollbackMode=stop, a failing rollback halts compensation: earlier steps are not compensated.",
+  "specRefs": ["§5.2"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "rollback",
+    "rollbackMode": "stop",
+    "steps": [
+      { "id": "s1", "execute": "success", "rollback": "success" },
+      { "id": "s2", "execute": "success", "rollback": "failed" },
+      { "id": "s3", "execute": "failed", "rollback": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["s1", "s2", "s3"],
+    "rollbackOrder": ["s3", "s2"],
+    "steps": {
+      "s3": { "status": "failed", "action": "execute", "rollbackStatus": "success" },
+      "s2": { "status": "success", "action": "execute", "rollbackStatus": "failed" },
+      "s1": { "status": "success", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/rollback_on_error_compensates.json
+++ b/docs/spec/conformance/behavior/rollback_on_error_compensates.json
@@ -1,0 +1,25 @@
+{
+  "name": "rollback_on_error_compensates",
+  "description": "RollbackOnError compensates the failed step and all previously executed steps, in reverse order.",
+  "specRefs": ["§5.1", "§5.3"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "rollback",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "s1", "execute": "success" },
+      { "id": "s2", "execute": "success" },
+      { "id": "s3", "execute": "failed" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["s1", "s2", "s3"],
+    "rollbackOrder": ["s3", "s2", "s1"],
+    "steps": {
+      "s1": { "status": "success", "action": "execute", "rollbackStatus": "success" },
+      "s2": { "status": "success", "action": "execute", "rollbackStatus": "success" },
+      "s3": { "status": "failed", "action": "execute", "rollbackStatus": "success" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/rollback_skips_non_executed_prepare_failure.json
+++ b/docs/spec/conformance/behavior/rollback_skips_non_executed_prepare_failure.json
@@ -1,0 +1,23 @@
+{
+  "name": "rollback_skips_non_executed_prepare_failure",
+  "description": "A step whose Prepare fails reports action=prepare and is skipped during compensation (never executed); previously executed steps are still rolled back.",
+  "specRefs": ["§4.3", "§5.3"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "rollback",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "s1", "execute": "success" },
+      { "id": "s2", "prepare": "failed", "execute": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["s1"],
+    "rollbackOrder": ["s1"],
+    "steps": {
+      "s1": { "status": "success", "action": "execute", "rollbackStatus": "success" },
+      "s2": { "status": "failed", "action": "prepare", "rollbackStatus": "skipped" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/skipped_step_is_not_failure.json
+++ b/docs/spec/conformance/behavior/skipped_step_is_not_failure.json
@@ -1,0 +1,23 @@
+{
+  "name": "skipped_step_is_not_failure",
+  "description": "A step that skips (decides no work is needed) is not a failure; the workflow continues and succeeds.",
+  "specRefs": ["§3.4"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "stop",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "s1", "execute": "skipped" },
+      { "id": "s2", "execute": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "success",
+    "executionOrder": ["s1", "s2"],
+    "rollbackOrder": [],
+    "steps": {
+      "s1": { "status": "skipped", "action": "execute" },
+      "s2": { "status": "success", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/stop_on_error_halts.json
+++ b/docs/spec/conformance/behavior/stop_on_error_halts.json
@@ -1,0 +1,24 @@
+{
+  "name": "stop_on_error_halts",
+  "description": "StopOnError halts at the first failing step and performs no rollback; later steps never run.",
+  "specRefs": ["§5.1", "§4.3"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "stop",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "s1", "execute": "success" },
+      { "id": "s2", "execute": "failed" },
+      { "id": "s3", "execute": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["s1", "s2"],
+    "rollbackOrder": [],
+    "steps": {
+      "s1": { "status": "success", "action": "execute" },
+      "s2": { "status": "failed", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/validation_duplicate_step_id.json
+++ b/docs/spec/conformance/behavior/validation_duplicate_step_id.json
@@ -1,0 +1,20 @@
+{
+  "name": "validation_duplicate_step_id",
+  "description": "Duplicate step IDs within a workflow are rejected at build time; the workflow reports a prepare-phase failure with no steps run (core-spec §3.1).",
+  "specRefs": ["§3.1", "§4.2"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "stop",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "dup", "execute": "success" },
+      { "id": "dup", "execute": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "workflowAction": "prepare",
+    "executionOrder": [],
+    "rollbackOrder": []
+  }
+}

--- a/docs/spec/conformance/behavior/validation_empty_step_id.json
+++ b/docs/spec/conformance/behavior/validation_empty_step_id.json
@@ -1,0 +1,19 @@
+{
+  "name": "validation_empty_step_id",
+  "description": "A step with an empty ID is rejected at build time; the workflow reports a prepare-phase failure with no steps run (core-spec §3.1).",
+  "specRefs": ["§3.1", "§4.2"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "stop",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "", "execute": "success" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "workflowAction": "prepare",
+    "executionOrder": [],
+    "rollbackOrder": []
+  }
+}

--- a/docs/spec/conformance/behavior/validation_step_without_execute.json
+++ b/docs/spec/conformance/behavior/validation_step_without_execute.json
@@ -1,0 +1,19 @@
+{
+  "name": "validation_step_without_execute",
+  "description": "A step that defines no Execute is invalid; the workflow fails to build and reports a prepare-phase failure with no steps run (core-spec §3.2.1).",
+  "specRefs": ["§3.2.1", "§4.2"],
+  "workflow": {
+    "id": "wf",
+    "executionMode": "stop",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "s1", "execute": "none" }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "workflowAction": "prepare",
+    "executionOrder": [],
+    "rollbackOrder": []
+  }
+}

--- a/docs/spec/conformance/serialization/report_workflow_with_rollback.json
+++ b/docs/spec/conformance/serialization/report_workflow_with_rollback.json
@@ -1,0 +1,43 @@
+{
+  "name": "report_workflow_with_rollback",
+  "description": "A workflow report tree round-trips: nested step reports, an inline rollback sub-report, RFC 3339 millisecond timestamps (§8), and error-as-string.",
+  "specRefs": ["§8", "§8.1"],
+  "kind": "report",
+  "json": {
+    "id": "wf",
+    "isWorkflow": true,
+    "action": "execute",
+    "status": "failed",
+    "startTime": "2026-06-17T10:30:00.123Z",
+    "endTime": "2026-06-17T10:30:01.789Z",
+    "error": "workflow \"wf\" completed with 1 step failures: [s2]",
+    "executionMode": "rollback",
+    "rollbackMode": "continue",
+    "steps": [
+      {
+        "id": "s1",
+        "isWorkflow": false,
+        "action": "execute",
+        "status": "success",
+        "startTime": "2026-06-17T10:30:00.123Z",
+        "endTime": "2026-06-17T10:30:00.456Z",
+        "rollback": {
+          "isWorkflow": false,
+          "action": "rollback",
+          "status": "success",
+          "startTime": "2026-06-17T10:30:01.234Z",
+          "endTime": "2026-06-17T10:30:01.345Z"
+        }
+      },
+      {
+        "id": "s2",
+        "isWorkflow": false,
+        "action": "execute",
+        "status": "failed",
+        "startTime": "2026-06-17T10:30:00.456Z",
+        "endTime": "2026-06-17T10:30:00.678Z",
+        "error": "step \"s2\" failed"
+      }
+    ]
+  }
+}

--- a/docs/spec/conformance/serialization/statebag_local_global.json
+++ b/docs/spec/conformance/serialization/statebag_local_global.json
@@ -1,0 +1,10 @@
+{
+  "name": "statebag_local_global",
+  "description": "A namespaced state bag with both Local and Global entries round-trips unchanged.",
+  "specRefs": ["§7.2", "§7.5"],
+  "kind": "statebag",
+  "json": {
+    "local": { "bindMount": "/mnt/app1" },
+    "global": { "env": "production", "replicas": 3 }
+  }
+}

--- a/docs/spec/conformance/serialization/statebag_null_and_empty.json
+++ b/docs/spec/conformance/serialization/statebag_null_and_empty.json
@@ -1,0 +1,10 @@
+{
+  "name": "statebag_null_and_empty",
+  "description": "A null value is storable and distinct from an absent key; an empty namespace serializes as an empty object (core-spec §7.5).",
+  "specRefs": ["§7.5"],
+  "kind": "statebag",
+  "json": {
+    "local": { "explicitNull": null },
+    "global": {}
+  }
+}

--- a/docs/spec/conformance/serialization/statebag_numeric_boundary.json
+++ b/docs/spec/conformance/serialization/statebag_numeric_boundary.json
@@ -1,14 +1,15 @@
 {
   "name": "statebag_numeric_boundary",
-  "description": "Integers within the 2^53 safe range round-trip as numbers; larger IDs are stored as strings to survive losslessly (core-spec §7.5).",
+  "description": "Integers within the IEEE-754 safe range round-trip as JSON numbers; values beyond it are stored as strings to survive losslessly (core-spec §7.5). maxSafeInteger is 2^53-1 (the largest integer with a unique double representation); largestExactInteger is 2^53 (still representable); 2^53+1 is not representable and MUST be a string.",
   "specRefs": ["§7.5"],
   "kind": "statebag",
   "json": {
     "local": {},
     "global": {
       "count": 42,
-      "maxSafeInteger": 9007199254740992,
-      "largeIdAsString": "9007199254740993"
+      "maxSafeInteger": 9007199254740991,
+      "largestExactInteger": 9007199254740992,
+      "unsafeIdAsString": "9007199254740993"
     }
   }
 }

--- a/docs/spec/conformance/serialization/statebag_numeric_boundary.json
+++ b/docs/spec/conformance/serialization/statebag_numeric_boundary.json
@@ -1,0 +1,14 @@
+{
+  "name": "statebag_numeric_boundary",
+  "description": "Integers within the 2^53 safe range round-trip as numbers; larger IDs are stored as strings to survive losslessly (core-spec §7.5).",
+  "specRefs": ["§7.5"],
+  "kind": "statebag",
+  "json": {
+    "local": {},
+    "global": {
+      "count": 42,
+      "maxSafeInteger": 9007199254740992,
+      "largeIdAsString": "9007199254740993"
+    }
+  }
+}

--- a/docs/spec/core-spec.md
+++ b/docs/spec/core-spec.md
@@ -469,6 +469,7 @@ implementation is (or is being) adapted to match.
 | D6 | Nested workflows **inherit** the parent's modes (parent overrides); fix the contradicting builder doc comment. | 6.1 | #82 |
 | D7 | Report enums (`action`, `status`) MUST fail on unknown values on decode, like `mode`. | 8.1 | #94 |
 | D8 | *(withdrawn)* An earlier revision specified custom namespaces as workflow-scoped shared named rooms. The feature was **removed** instead (§7.2): Local + Global is the whole model. | 7.2 | removed |
+| D9 | Duplicate step IDs **MUST** be rejected at build time; the original Go builder silently dropped them (first-wins). | 3.1 | #120 |
 
 All spec decisions are now reflected in the Go reference implementation.
 

--- a/docs/spec/core-spec.md
+++ b/docs/spec/core-spec.md
@@ -346,8 +346,9 @@ normative:
   Implementations MUST provide **coercing typed accessors** (integer, float,
   bool, string) that recover the intended type from the round-tripped value.
 - **Numeric precision policy (normative).** JSON has a single number type, and a
-  round-trip through floating point can represent integers exactly only up to
-  2^53. Values beyond that range (e.g. large 64-bit IDs) CANNOT be guaranteed to
+  round-trip through floating point represents integers with a unique value only
+  up to 2^53−1 (the max *safe* integer; 2^53 is representable but 2^53+1 is not).
+  Values beyond the safe range (e.g. large 64-bit IDs) CANNOT be guaranteed to
   survive a round-trip as numbers across languages.
   - For values that must round-trip losslessly and exceed the safe integer
     range, authors SHOULD store them as **strings** (e.g. a 64-bit ID as

--- a/report.go
+++ b/report.go
@@ -2,7 +2,10 @@ package automa
 
 import (
 	"encoding/json"
+	"errors"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Report describes the outcome of a single step or an entire workflow
@@ -514,6 +517,43 @@ func (r *Report) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// UnmarshalJSON implements json.Unmarshaler. It loads the marshalReport wire
+// format (the same layout MarshalJSON produces) back into the Report,
+// reconstructing the Error field from its string form. Nested StepReports and
+// Rollback decode recursively. The recovered Error is a plain error carrying the
+// serialized message; the original error type is not preserved (errors are
+// serialized as strings, per §8).
+func (r *Report) UnmarshalJSON(data []byte) error {
+	var m marshalReport
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	r.applyMarshalReport(m)
+	return nil
+}
+
+// applyMarshalReport copies a decoded marshalReport into the receiver, shared by
+// UnmarshalJSON and UnmarshalYAML.
+func (r *Report) applyMarshalReport(m marshalReport) {
+	r.Id = m.Id
+	r.IsWorkflow = m.IsWorkflow
+	r.Action = m.Action
+	r.Status = m.Status
+	r.StartTime = m.StartTime
+	r.EndTime = m.EndTime
+	r.Detail = m.Detail
+	if m.Error != "" {
+		r.Error = errors.New(m.Error)
+	} else {
+		r.Error = nil
+	}
+	r.Metadata = m.Metadata
+	r.StepReports = m.StepReports
+	r.Rollback = m.Rollback
+	r.ExecutionMode = m.ExecutionMode
+	r.RollbackMode = m.RollbackMode
+}
+
 // MarshalYAML implements yaml.Marshaler. It serializes the Report into a YAML
 // mapping using the marshalReport wire format. The Error field is serialized
 // as its Error() string (or omitted when nil). Field names follow the yaml
@@ -537,4 +577,17 @@ func (r *Report) MarshalYAML() (interface{}, error) {
 		m.Error = r.Error.Error()
 	}
 	return m, nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler. It loads the marshalReport wire
+// format from a YAML mapping node back into the Report, mirroring UnmarshalJSON
+// (Error is reconstructed from its string form; nested reports decode
+// recursively).
+func (r *Report) UnmarshalYAML(node *yaml.Node) error {
+	var m marshalReport
+	if err := node.Decode(&m); err != nil {
+		return err
+	}
+	r.applyMarshalReport(m)
+	return nil
 }

--- a/report_test.go
+++ b/report_test.go
@@ -295,5 +295,11 @@ func TestReport_UnmarshalYAML_RoundTrip(t *testing.T) {
 
 	secondPass, err := yaml.Marshal(&loaded)
 	assert.NoError(t, err)
-	assert.Equal(t, string(firstPass), string(secondPass))
+
+	// Compare structurally, not as raw text: YAML has no guaranteed stable
+	// textual form across versions/formatting.
+	var firstV, secondV interface{}
+	assert.NoError(t, yaml.Unmarshal(firstPass, &firstV))
+	assert.NoError(t, yaml.Unmarshal(secondPass, &secondV))
+	assert.Equal(t, firstV, secondV)
 }

--- a/report_test.go
+++ b/report_test.go
@@ -217,3 +217,83 @@ func TestReport_Clone_PreservesModes(t *testing.T) {
 	assert.Equal(t, r.ExecutionMode, clone.ExecutionMode)
 	assert.Equal(t, r.RollbackMode, clone.RollbackMode)
 }
+
+// TestReport_UnmarshalJSON_RoundTrip verifies a report tree survives a
+// marshal → unmarshal → marshal cycle unchanged, including nested step reports,
+// an inline rollback sub-report, timestamps, and error-as-string.
+func TestReport_UnmarshalJSON_RoundTrip(t *testing.T) {
+	start := time.Date(2026, 6, 17, 10, 30, 0, 123000000, time.UTC)
+	end := time.Date(2026, 6, 17, 10, 30, 1, 456000000, time.UTC)
+
+	original := &Report{
+		Id:            "wf",
+		IsWorkflow:    true,
+		Action:        ActionExecute,
+		Status:        StatusFailed,
+		StartTime:     start,
+		EndTime:       end,
+		Error:         errors.New("boom"),
+		ExecutionMode: RollbackOnError,
+		RollbackMode:  ContinueOnError,
+		StepReports: []*Report{
+			{
+				Id:        "s1",
+				Action:    ActionExecute,
+				Status:    StatusSuccess,
+				StartTime: start,
+				EndTime:   end,
+				Rollback: &Report{
+					Action:    ActionRollback,
+					Status:    StatusSuccess,
+					StartTime: start,
+					EndTime:   end,
+				},
+			},
+		},
+	}
+
+	firstPass, err := json.Marshal(original)
+	assert.NoError(t, err)
+
+	var loaded Report
+	assert.NoError(t, json.Unmarshal(firstPass, &loaded))
+
+	// Error is reconstructed from its string form.
+	assert.Equal(t, "boom", loaded.Error.Error())
+	assert.Equal(t, ActionExecute, loaded.Action)
+	assert.Equal(t, StatusFailed, loaded.Status)
+	assert.True(t, loaded.StartTime.Equal(start))
+	if assert.Len(t, loaded.StepReports, 1) {
+		assert.Equal(t, "s1", loaded.StepReports[0].Id)
+		assert.NotNil(t, loaded.StepReports[0].Rollback)
+	}
+
+	secondPass, err := json.Marshal(&loaded)
+	assert.NoError(t, err)
+	assert.JSONEq(t, string(firstPass), string(secondPass))
+}
+
+// TestReport_UnmarshalYAML_RoundTrip verifies the YAML unmarshaler mirrors the
+// JSON one.
+func TestReport_UnmarshalYAML_RoundTrip(t *testing.T) {
+	original := &Report{
+		Id:        "s1",
+		Action:    ActionExecute,
+		Status:    StatusFailed,
+		StartTime: time.Date(2026, 6, 17, 10, 30, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 6, 17, 10, 30, 1, 0, time.UTC),
+		Error:     errors.New("kaboom"),
+	}
+
+	firstPass, err := yaml.Marshal(original)
+	assert.NoError(t, err)
+
+	var loaded Report
+	assert.NoError(t, yaml.Unmarshal(firstPass, &loaded))
+	assert.Equal(t, "kaboom", loaded.Error.Error())
+	assert.Equal(t, StatusFailed, loaded.Status)
+
+	secondPass, err := yaml.Marshal(&loaded)
+	assert.NoError(t, err)
+	assert.Equal(t, string(firstPass), string(secondPass))
+}

--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -43,6 +43,12 @@ type WorkflowBuilder struct {
 	// stepBuilders is a map of step ID → Builder, populated by Steps and
 	// NamedSteps. Build iterates stepSequence and looks up each Builder here.
 	stepBuilders map[string]Builder
+
+	// idErrs accumulates step-ID errors detected while adding steps (e.g. a
+	// duplicate ID). Steps/NamedSteps cannot return an error via the fluent API,
+	// so the error is recorded here and surfaced by Validate/Build. Per core-spec
+	// §3.1 a duplicate step ID is a build-time failure, not a silent drop.
+	idErrs []error
 }
 
 // Id returns the workflow ID that has been configured so far.
@@ -105,8 +111,10 @@ func (wb *WorkflowBuilder) Build() (Step, error) {
 }
 
 // Steps registers one or more [Builder] instances in the order they are
-// provided. Each builder is keyed by its ID; if a builder with the same ID has
-// already been registered, the duplicate is silently ignored (first-wins).
+// provided. Each builder is keyed by its ID. Registering a second builder with
+// an ID that already exists is a build-time error (core-spec §3.1): the first
+// builder is kept and the workflow's [Validate]/[Build] subsequently fails with
+// a duplicate-ID error.
 //
 // Steps can be called multiple times to append to the step sequence:
 //
@@ -114,6 +122,11 @@ func (wb *WorkflowBuilder) Build() (Step, error) {
 func (wb *WorkflowBuilder) Steps(steps ...Builder) *WorkflowBuilder {
 	for _, step := range steps {
 		if _, exists := wb.stepBuilders[step.Id()]; exists {
+			// core-spec §3.1: duplicate step IDs are rejected at build time.
+			// Record the error (the fluent API cannot return one) and keep the
+			// first builder; Validate/Build surfaces the failure.
+			wb.idErrs = append(wb.idErrs, IllegalArgument.New(
+				"duplicate step id %q: step ids must be unique within a workflow", step.Id()))
 			continue
 		}
 		wb.stepBuilders[step.Id()] = step
@@ -123,8 +136,9 @@ func (wb *WorkflowBuilder) Steps(steps ...Builder) *WorkflowBuilder {
 }
 
 // NamedSteps looks up step IDs in the configured [Registry] and registers the
-// matching [Builder] instances. IDs that are not found in the registry or that
-// are already registered are silently skipped. The relative order of the
+// matching [Builder] instances. IDs that are not found in the registry are
+// silently skipped; an ID that is already registered is a build-time error
+// (core-spec §3.1), surfaced by Validate/Build. The relative order of the
 // provided IDs is preserved.
 //
 // NamedSteps is a no-op when no registry has been configured via
@@ -139,6 +153,9 @@ func (wb *WorkflowBuilder) NamedSteps(stepIds ...string) *WorkflowBuilder {
 			continue
 		}
 		if _, exists := wb.stepBuilders[id]; exists {
+			// core-spec §3.1: duplicate step IDs are a build-time failure.
+			wb.idErrs = append(wb.idErrs, IllegalArgument.New(
+				"duplicate step id %q: step ids must be unique within a workflow", id))
 			continue
 		}
 		wb.stepBuilders[id] = builder
@@ -158,6 +175,12 @@ func (wb *WorkflowBuilder) NamedSteps(stepIds ...string) *WorkflowBuilder {
 func (wb *WorkflowBuilder) Validate() error {
 	if wb.workflow.id == "" {
 		return IllegalArgument.New("workflow id cannot be empty")
+	}
+
+	// Surface step-ID errors recorded while adding steps (e.g. duplicate IDs,
+	// core-spec §3.1) before any other validation.
+	if len(wb.idErrs) > 0 {
+		return fmt.Errorf("invalid step ids: %v", wb.idErrs)
 	}
 
 	if len(wb.stepBuilders) == 0 {

--- a/workflow_builder_test.go
+++ b/workflow_builder_test.go
@@ -297,3 +297,36 @@ func TestWorkflowBuilder_InheritModesForNestedWorkflow_OtherModes(t *testing.T) 
 		}
 	}
 }
+
+// TestWorkflowBuilder_DuplicateStepID_Rejected verifies that registering two
+// steps with the same ID is a build-time failure (core-spec §3.1) rather than a
+// silent first-wins drop.
+func TestWorkflowBuilder_DuplicateStepID_Rejected(t *testing.T) {
+	wb := NewWorkflowBuilder().WithId("wf").Steps(
+		NewStepBuilder().WithId("dup").WithExecute(func(ctx context.Context, stp Step) *Report {
+			return SuccessReport(stp)
+		}),
+		NewStepBuilder().WithId("dup").WithExecute(func(ctx context.Context, stp Step) *Report {
+			return SuccessReport(stp)
+		}),
+	)
+
+	err := wb.Validate()
+	assert.Error(t, err, "duplicate step id must fail validation")
+	assert.Contains(t, err.Error(), "duplicate step id")
+
+	_, buildErr := wb.Build()
+	assert.Error(t, buildErr, "duplicate step id must fail Build")
+
+	// RunWorkflow surfaces the build failure as a prepare-phase failure report.
+	report := RunWorkflow(context.Background(), NewWorkflowBuilder().WithId("wf2").Steps(
+		NewStepBuilder().WithId("dup").WithExecute(func(ctx context.Context, stp Step) *Report {
+			return SuccessReport(stp)
+		}),
+		NewStepBuilder().WithId("dup").WithExecute(func(ctx context.Context, stp Step) *Report {
+			return SuccessReport(stp)
+		}),
+	))
+	assert.Equal(t, StatusFailed, report.Status)
+	assert.Equal(t, ActionPrepare, report.Action)
+}


### PR DESCRIPTION
## Description

This pull request introduces a comprehensive conformance test suite and a set of language-neutral JSON fixtures to define and verify correct `automa` workflow behavior. The suite ensures that all implementations (starting with Go) conform to the specification by running shared fixtures that cover workflow execution, rollback behavior, and serialization. The included fixtures are now the single source of truth for cross-language correctness.

The most important changes are:

**1. Conformance test harness and shared fixtures**
- Added `conformance_test.go`, which implements a test harness that loads and runs all JSON fixtures under `docs/spec/conformance/`, verifying both workflow execution behavior and serialization round-trips. This enforces that the Go reference implementation and all future language ports must pass the same tests.
- Introduced a clear rule in `docs/spec/conformance/README.md` that any spec change must be accompanied by fixture changes, making fixtures the authoritative contract for conformance.

**2. Behavior fixture coverage**
- Added a suite of workflow behavior fixtures (in `docs/spec/conformance/behavior/*.json`) that cover all major execution and rollback modes, including:
  - ContinueOnError and StopOnError execution (`continue_on_error_runs_all.json`, `stop_on_error_halts.json`) [[1]](diffhunk://#diff-8b365e24eca5b092155c640e521359daeb478f2ee0dc78b5a7568f1e080cbeeeR1-R25) [[2]](diffhunk://#diff-98f88876293af093e77a639022b3619cd49a14ba2b2435268b2bb550d185250fR1-R24)
  - RollbackOnError and rollback compensation strategies (`rollback_on_error_compensates.json`, `rollback_mode_continue_compensates_all.json`, `rollback_mode_stop_halts_compensation.json`) [[1]](diffhunk://#diff-9f8ec14ccfd7bcbe6c0f64e8b01e6bbd476a84bb6fe027a250f523fa3fdf8f59R1-R25) [[2]](diffhunk://#diff-719472d50598b8f95a77fc3f4342c7bf083cbf795fceff0bf832330d499851ddR1-R25) [[3]](diffhunk://#diff-3b0200911e4cf0741b00d23d3a085f6f171de51523bd7dc6b75cec92afb3c11bR1-R25)
  - Nested workflows and step skipping/validation edge cases (`nested_workflow_composes.json`, `skipped_step_is_not_failure.json`, `validation_step_without_execute.json`, `rollback_skips_non_executed_prepare_failure.json`) [[1]](diffhunk://#diff-1c3af3a086bd587cff2447aa4c5e179e103a16b4e1437cfd7362d1fb9028bd8bR1-R33) [[2]](diffhunk://#diff-8b811c202a68861f838eef4f3a73d751fea06652e8012d4976fd83c56e6e67ccR1-R23) [[3]](diffhunk://#diff-44fbda13beb1bd7ae3e228f134a6b62661489712de08941d3cf35822625f3d97R1-R19) [[4]](diffhunk://#diff-7308df1774d140b50758afd7820fa7395b3af63f808e35ca9716c4f34977be73R1-R23)

**3. Serialization round-trip fixtures**
- Added serialization fixtures (described in the README) to ensure that state bags and reports can be loaded and re-serialized without loss, including numeric precision and timestamp formatting.

These changes lay the groundwork for robust, cross-language conformance testing and make it easy to validate that all implementations behave identically in every specified scenario.

### Related Issues

* Closes #95 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
