### PR TITLE
fix: handle nested double compensation

### DIFF
--- a/docs/spec/conformance/behavior/deeply_nested_failed_leaf_compensated_once.json
+++ b/docs/spec/conformance/behavior/deeply_nested_failed_leaf_compensated_once.json
@@ -1,0 +1,33 @@
+{
+  "name": "deeply_nested_failed_leaf_compensated_once",
+  "description": "A leaf failure three levels deep is compensated exactly once, at the level closest to the failure — not once per enclosing workflow. Each parent's compensation of an already-self-compensated child is a no-op (D10, §6). Depth guard for #122.",
+  "specRefs": ["§5.3", "§6", "D10"],
+  "workflow": {
+    "id": "parent",
+    "executionMode": "rollback",
+    "rollbackMode": "continue",
+    "steps": [
+      {
+        "id": "sub1",
+        "steps": [
+          {
+            "id": "sub2",
+            "steps": [
+              { "id": "leaf_a", "execute": "success" },
+              { "id": "leaf_b", "execute": "failed" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["leaf_a", "leaf_b"],
+    "rollbackOrder": ["leaf_b", "leaf_a"],
+    "steps": {
+      "leaf_a": { "status": "success", "action": "execute" },
+      "leaf_b": { "status": "failed", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/deeply_nested_inherits_modes.json
+++ b/docs/spec/conformance/behavior/deeply_nested_inherits_modes.json
@@ -1,0 +1,32 @@
+{
+  "name": "deeply_nested_inherits_modes",
+  "description": "Mode inheritance reaches every depth, not just direct children (§6.1, D6). The root is ContinueOnError; a grandchild sub-workflow must also run ContinueOnError, so a failure in its first leaf does NOT halt it — the second leaf still executes. Before #123 the grandchild kept the default StopOnError and stopped after the first failure.",
+  "specRefs": ["§6.1", "D6"],
+  "workflow": {
+    "id": "parent",
+    "executionMode": "continue",
+    "steps": [
+      {
+        "id": "sub1",
+        "steps": [
+          {
+            "id": "sub2",
+            "steps": [
+              { "id": "x", "execute": "failed" },
+              { "id": "y", "execute": "success" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["x", "y"],
+    "rollbackOrder": [],
+    "steps": {
+      "x": { "status": "failed", "action": "execute" },
+      "y": { "status": "success", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/conformance/behavior/nested_workflow_failed_sub_compensated_once.json
+++ b/docs/spec/conformance/behavior/nested_workflow_failed_sub_compensated_once.json
@@ -1,0 +1,30 @@
+{
+  "name": "nested_workflow_failed_sub_compensated_once",
+  "description": "Under RollbackOnError, a sub-workflow that fails internally self-compensates its executed steps exactly once; the parent MUST NOT re-compensate them, but MUST still compensate its own other executed steps (D10, §5.3.5, §6). Regression guard for the double-compensation bug in #122.",
+  "specRefs": ["§5.3", "§6", "D10"],
+  "workflow": {
+    "id": "parent",
+    "executionMode": "rollback",
+    "rollbackMode": "continue",
+    "steps": [
+      { "id": "s1", "execute": "success" },
+      {
+        "id": "sub",
+        "steps": [
+          { "id": "a", "execute": "success" },
+          { "id": "b", "execute": "failed" }
+        ]
+      }
+    ]
+  },
+  "expect": {
+    "workflowStatus": "failed",
+    "executionOrder": ["s1", "a", "b"],
+    "rollbackOrder": ["b", "a", "s1"],
+    "steps": {
+      "s1": { "status": "success", "action": "execute" },
+      "a": { "status": "success", "action": "execute" },
+      "b": { "status": "failed", "action": "execute" }
+    }
+  }
+}

--- a/docs/spec/core-spec.md
+++ b/docs/spec/core-spec.md
@@ -236,6 +236,21 @@ When `execution_mode` is `rollback` and step `i` fails:
 
 4. Each compensation produces a rollback report; these are attached under the
    corresponding step's report (§8.2).
+5. **Compensate at most once.** Each executed step is compensated **at most once**
+   per rollback of a given workflow run. An implementation MUST track per-step
+   compensation state and MUST NOT invoke a step's Rollback again once that step
+   has been compensated. This is enforced by the engine at the orchestration
+   level; the "Rollback MUST be idempotent" contract (§3) is a backstop for
+   distinct invocations (e.g. durability resume, §5.4), not a licence to
+   double-compensate within a single run. For sub-workflow steps this rule has a
+   specific consequence spelled out in §6 (nested compensation) and D10.
+
+   > This tracking (and all per-step rollback bookkeeping: execution-time state
+   > snapshots, the executed-step set, and rollback reports) is keyed by **step
+   > ID**. It is therefore correct only because step IDs are **unique within a
+   > workflow and non-empty** (§3.1 / D9). Relaxing D9 would silently corrupt
+   > compensation — two same-ID steps in one workflow would share a snapshot and
+   > a compensated-once flag. D10 depends on D9.
 
 ### 5.4 Manual rollback
 
@@ -272,10 +287,24 @@ When `execution_mode` is `rollback` and step `i` fails:
   > (parent overrides) is correct per this spec; the misleading doc comment was
   > corrected to match in #82.
 
-- **Nested compensation.** When a parent compensates a child-workflow step, the
-  child workflow's own compensation logic runs (it rolls back its own steps in
-  reverse). How the nested rollback report is represented under the parent is
-  defined in §8.2.
+- **Nested compensation.** A sub-workflow compensates its **own** steps (§5.3).
+  When a parent's compensation pass reaches a child-workflow step, it drives the
+  child's compensation only for steps the child has **not already compensated**,
+  so each executed step is compensated exactly once (§5.3.5, D10):
+  - A child that **succeeded** never self-compensated. When a *later sibling*
+    fails, the parent's rollback pass MUST compensate the child (rolling back the
+    child's leaf steps in reverse). See `nested_workflow_rollback_propagation`.
+  - A child that **failed** under the inherited `rollback` mode has already
+    self-compensated its executed steps by the time it returns. The parent MUST
+    NOT compensate those steps again — the parent's compensation of that child
+    step is a no-op. Because compensation happens at the level closest to the
+    failure, this holds at any nesting depth: a leaf failure deep in the tree is
+    compensated once, not once per enclosing level. See
+    `nested_workflow_failed_sub_compensated_once` and
+    `deeply_nested_failed_leaf_compensated_once`.
+
+  The parent still compensates its **own** other executed steps normally. How a
+  nested rollback report is represented under the parent is defined in §8.2.
 
 ## 7. State model
 
@@ -447,6 +476,11 @@ a cross-language contract.
 5. **Sub-workflow rollback report shape (§8.2).** *Resolved:* a compensated child
    workflow's rollback report nests **inline** under the parent step's `rollback`
    field, recursively — a child's rollback is itself a workflow-shaped report.
+6. **Double-compensation of nested steps (§5.3, §6).** *Resolved:* an executed
+   step is compensated at most once per run (D10). A failed sub-workflow
+   self-compensates; the parent MUST NOT compensate it again. The engine
+   previously re-compensated nested steps once per enclosing level. (Resolves
+   #122.)
 
 **Still open:**
 
@@ -471,6 +505,7 @@ implementation is (or is being) adapted to match.
 | D7 | Report enums (`action`, `status`) MUST fail on unknown values on decode, like `mode`. | 8.1 | #94 |
 | D8 | *(withdrawn)* An earlier revision specified custom namespaces as workflow-scoped shared named rooms. The feature was **removed** instead (§7.2): Local + Global is the whole model. | 7.2 | removed |
 | D9 | Duplicate step IDs **MUST** be rejected at build time; the original Go builder silently dropped them (first-wins). | 3.1 | #120 |
+| D10 | An executed step is compensated **at most once** per run. A parent MUST NOT re-compensate a sub-workflow that already self-compensated (a failed child under the inherited `rollback` mode); the parent still compensates its own other steps. Enforced via per-step compensation tracking keyed by step ID, so **D10 depends on D9** (unique, non-empty IDs). The engine originally double-compensated nested steps once per enclosing level. | 5.3, 6 | #122 |
 
 All spec decisions are now reflected in the Go reference implementation.
 

--- a/docs/spec/core-spec.md
+++ b/docs/spec/core-spec.md
@@ -273,8 +273,9 @@ When `execution_mode` is `rollback` and step `i` fails:
 #### 6.1 Mode inheritance
 
 - A nested workflow **inherits its parent's** execution mode and rollback mode:
-  during assembly, the parent's modes are propagated to its child workflows, so
-  the entire tree executes under one consistent error-handling policy.
+  during assembly, the parent's modes are propagated to its child workflows **at
+  every depth** (cascaded root→leaf), so the entire tree executes under one
+  consistent error-handling policy.
 - This is a deliberate uniformity guarantee: an operator configuring a top-level
   workflow as `rollback` gets rollback semantics throughout the tree without
   having to set the mode on every nested workflow.
@@ -282,10 +283,22 @@ When `execution_mode` is `rollback` and step `i` fails:
   advisory: they MAY be set for documentation or for standalone execution of that
   workflow, but when it runs as a child its parent's modes apply.
 
-  > **✓ Spec decision (Go conforms as of #82).** The Go `WorkflowBuilder` doc
-  > comment previously contradicted the actual overwrite behavior. The behavior
-  > (parent overrides) is correct per this spec; the misleading doc comment was
-  > corrected to match in #82.
+  > **Future direction (#124, non-normative).** A proposal exists to let a child
+  > *tighten* the error-handling policy but never *loosen* it (effective mode =
+  > the stricter of parent and child, on the order `continue < stop < rollback`),
+  > so a reusable sub-workflow can guarantee its own atomicity without weakening
+  > the operator's runtime decision. If inheritance is ever relaxed it MUST only
+  > permit tightening, never loosening. Not adopted for v1; parent-overrides is
+  > the whole model here.
+
+  > **✓ Spec decision (Go conforms as of #82, #123).** The Go `WorkflowBuilder`
+  > doc comment previously contradicted the actual overwrite behavior; the
+  > behavior (parent overrides) is correct per this spec and the doc comment was
+  > corrected in #82. That fix only reached **direct** children, though: a child
+  > was built (stamping its own default modes onto its grandchildren) before the
+  > parent could override it, so nesting deeper than one level did not inherit.
+  > #123 replaced the per-child stamp with a root→leaf cascade so inheritance
+  > holds at every depth (see `deeply_nested_inherits_modes`).
 
 - **Nested compensation.** A sub-workflow compensates its **own** steps (§5.3).
   When a parent's compensation pass reaches a child-workflow step, it drives the
@@ -501,7 +514,7 @@ implementation is (or is being) adapted to match.
 | D3 | Step **Prepare** failure reports action `prepare`, not `execute`. | 4.3 | #92 |
 | D4 | `rollback_mode` restricted to `{ continue, stop }`; reject `rollback`. | 5.2 | #93 |
 | D5 | Compensation MUST skip non-executed (`skipped`/`pending`) steps. | 5.3 | #84 |
-| D6 | Nested workflows **inherit** the parent's modes (parent overrides); fix the contradicting builder doc comment. | 6.1 | #82 |
+| D6 | Nested workflows **inherit** the parent's modes (parent overrides) **at every depth**; fix the contradicting builder doc comment. | 6.1 | #82, #123 |
 | D7 | Report enums (`action`, `status`) MUST fail on unknown values on decode, like `mode`. | 8.1 | #94 |
 | D8 | *(withdrawn)* An earlier revision specified custom namespaces as workflow-scoped shared named rooms. The feature was **removed** instead (§7.2): Local + Global is the whole model. | 7.2 | removed |
 | D9 | Duplicate step IDs **MUST** be rejected at build time; the original Go builder silently dropped them (first-wins). | 3.1 | #120 |

--- a/workflow.go
+++ b/workflow.go
@@ -58,6 +58,20 @@ type workflow struct {
 	// are excluded so rollbackFrom can skip compensating them (spec D5 / §5.3).
 	lastExecutedStepIDs map[string]struct{}
 
+	// compensatedStepIDs tracks step IDs already compensated during this run so a
+	// step's Rollback is invoked at most once (spec §5.3.5 / D10). A sub-workflow
+	// that self-compensates on internal failure (during its own Execute) records
+	// its steps here; when the parent later drives this sub-workflow's Rollback,
+	// rollbackFrom finds them already compensated and skips them instead of
+	// double-compensating. The set is per instance (workflows are single-use), so
+	// a manual Rollback after an automatic one is likewise a no-op for steps the
+	// automatic pass already handled.
+	//
+	// Like lastExecutionStates and lastExecutedStepIDs, this is keyed by step ID
+	// and so relies on IDs being unique within the workflow and non-empty (D9);
+	// duplicate/empty IDs are rejected at build time (workflow_builder.go).
+	compensatedStepIDs map[string]struct{}
+
 	// preserveStatesForRollback controls whether state snapshots are cloned and preserved
 	// after each step execution. When true (default), enables deterministic rollback but
 	// increases memory usage. When false, skips state cloning to reduce overhead.
@@ -160,6 +174,12 @@ func (w *workflow) rollbackFrom(ctx context.Context, index int, states map[strin
 	stepReports := map[string]*Report{}
 	startTime := time.Now()
 
+	// Guard against instances built outside newDefaultWorkflow (writing to a nil
+	// map panics); the compensate-once set (D10) must always be usable.
+	if w.compensatedStepIDs == nil {
+		w.compensatedStepIDs = make(map[string]struct{})
+	}
+
 	for i := index; i >= 0; i-- {
 		step := w.steps[i]
 
@@ -167,6 +187,20 @@ func (w *workflow) rollbackFrom(ctx context.Context, index int, states map[strin
 		// nil is treated as empty: no execution context means nothing to compensate.
 		if _, ran := executedIDs[step.Id()]; !ran {
 			w.log().Debug("skipping rollback for non-executed step", "workflowId", w.id, "stepId", step.Id(), "index", i)
+			stepReports[step.Id()] = SkippedReport(step,
+				WithWorkflow(w),
+				WithActionType(ActionRollback),
+				WithStartTime(startTime),
+			)
+			continue
+		}
+
+		// Compensate at most once (spec §5.3.5 / D10). A step already compensated
+		// in this run (e.g. a sub-workflow that self-compensated during its own
+		// Execute, then had its Rollback driven again by the parent) MUST NOT have
+		// its Rollback re-invoked. Record it as skipped and move on.
+		if _, done := w.compensatedStepIDs[step.Id()]; done {
+			w.log().Debug("skipping already-compensated step", "workflowId", w.id, "stepId", step.Id(), "index", i)
 			stepReports[step.Id()] = SkippedReport(step,
 				WithWorkflow(w),
 				WithActionType(ActionRollback),
@@ -215,6 +249,12 @@ func (w *workflow) rollbackFrom(ctx context.Context, index int, states map[strin
 		}
 
 		stepReports[step.Id()] = rollbackReport
+
+		// Mark compensated so a subsequent pass over the same instance (e.g. the
+		// parent driving this sub-workflow's Rollback after self-compensation, or
+		// a manual Rollback after an automatic one) does not compensate it again
+		// (spec §5.3.5 / D10).
+		w.compensatedStepIDs[step.Id()] = struct{}{}
 
 		if rollbackReport.IsFailed() {
 			w.log().Warn("step rollback failed",
@@ -711,6 +751,8 @@ func newDefaultWorkflow() *workflow {
 		// Empty (not nil) so Rollback() called before Execute() compensates nothing.
 		// nil would bypass the D5 filter; a non-nil empty map correctly skips all steps.
 		lastExecutedStepIDs: make(map[string]struct{}),
+		// Tracks steps compensated this run so each is rolled back at most once (D10).
+		compensatedStepIDs: make(map[string]struct{}),
 	}
 }
 

--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -60,13 +60,13 @@ func (wb *WorkflowBuilder) Id() string {
 // Build validates the builder, constructs all registered steps in order,
 // wires them into the workflow, and returns the finished [Step] (a *workflow).
 //
-// Nested workflow propagation: if any registered step produces a *workflow
-// (i.e. is itself a sub-workflow), its executionMode and rollbackMode are
-// always overwritten with the parent's modes so that all nested workflows
-// follow the same error-handling and rollback strategy as the enclosing
-// workflow. This is a deliberate uniformity guarantee (core-spec §6.1, decision
-// D6): a child cannot override its parent's modes. Any modes set on a nested
-// builder apply only when it is built and run as a top-level workflow.
+// Nested workflow propagation: every sub-workflow anywhere in the tree has its
+// executionMode and rollbackMode overwritten with its parent's, cascaded
+// root→leaf by [propagateModes], so all nested workflows (at any depth) follow
+// the same error-handling and rollback strategy as the enclosing workflow. This
+// is a deliberate uniformity guarantee (core-spec §6.1, decision D6): a child
+// cannot override its parent's modes. Any modes set on a nested builder apply
+// only when it is built and run as a top-level workflow.
 //
 // After Build returns the internal workflow is reset to a fresh default so the
 // builder can be reused.
@@ -90,24 +90,42 @@ func (wb *WorkflowBuilder) Build() (Step, error) {
 		}
 
 		if step != nil {
-			// If the step itself is a workflow, propagate the parent workflow's
-			// execution and rollback modes so that nested workflows behave
-			// consistently and follow the same error handling and rollback
-			// strategy as the enclosing workflow.
-			if wfStep, ok := step.(*workflow); ok {
-				wfStep.executionMode = wb.workflow.executionMode
-				wfStep.rollbackMode = wb.workflow.rollbackMode
-			}
-
 			steps = append(steps, step)
 		}
 	}
 
 	wb.workflow.steps = steps
+
+	// Propagate modes top-down over the whole subtree (core-spec §6.1, D6). A
+	// per-child stamp here would only reach direct children: a child is built
+	// (and stamps its own then-default modes onto its grandchildren) before this
+	// parent could override it, so grandchildren never inherited. Cascading
+	// root→leaf from the outermost Build — which the caller always invokes — sets
+	// each level from its parent's already-corrected value, so the whole tree ends
+	// up under one policy. (#122/#123)
+	propagateModes(wb.workflow)
+
 	finished := wb.workflow
 	wb.workflow = newDefaultWorkflow()
 
 	return finished, nil
+}
+
+// propagateModes overwrites every nested sub-workflow's execution and rollback
+// modes with its parent's, descending root→leaf so the update cascades: by the
+// time a grandchild is visited its parent's modes are already the inherited
+// ones. This is the deliberate uniformity guarantee of core-spec §6.1 / D6 — a
+// child cannot override its parent's modes when run as part of the tree.
+func propagateModes(w *workflow) {
+	for _, step := range w.steps {
+		child, ok := step.(*workflow)
+		if !ok {
+			continue
+		}
+		child.executionMode = w.executionMode
+		child.rollbackMode = w.rollbackMode
+		propagateModes(child)
+	}
 }
 
 // Steps registers one or more [Builder] instances in the order they are


### PR DESCRIPTION
## Description
This pull request addresses two major areas of workflow engine correctness: (1) ensuring that compensation (rollback) for executed steps is performed at most once per workflow run, even in deeply nested workflows, and (2) guaranteeing that execution and rollback modes are properly inherited at every depth of workflow nesting. These changes fix long-standing issues with double-compensation of nested steps and incomplete mode inheritance, and are accompanied by new conformance tests and detailed specification updates.

**Compensation correctness and prevention of double-compensation:**

- The workflow engine now tracks which steps have already been compensated during a run using the new `compensatedStepIDs` map in the `workflow` struct. Before compensating a step, the engine checks this map to ensure a step's rollback is invoked at most once per run, preventing double-compensation of nested steps [[1]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR61-R74) [[2]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR177-R182) [[3]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR198-R211) [[4]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR253-R258) [[5]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR754-R755).
- The specification is updated to clarify that each executed step must be compensated at most once per run, and that this is enforced by tracking per-step compensation keyed by unique step IDs [[1]](diffhunk://#diff-4b3d5e20b1fb9772c579c47a7aca38242fed80c4d535aa6e53b9941d29a440b1R239-R253) [[2]](diffhunk://#diff-4b3d5e20b1fb9772c579c47a7aca38242fed80c4d535aa6e53b9941d29a440b1R492-R496) [[3]](diffhunk://#diff-4b3d5e20b1fb9772c579c47a7aca38242fed80c4d535aa6e53b9941d29a440b1L470-R521).

**Deep, uniform mode inheritance:**

- Mode inheritance is now cascaded root-to-leaf throughout the entire workflow tree, ensuring that all nested workflows (at any depth) inherit the parent's execution and rollback modes. This is implemented by the new `propagateModes` function, called during workflow construction, and replaces the previous approach that only updated direct children [[1]](diffhunk://#diff-e7c112cda9bd742190f9330772f29be4afcc18e33049f3dc0c47553f22d6d0e0L63-R69) [[2]](diffhunk://#diff-e7c112cda9bd742190f9330772f29be4afcc18e33049f3dc0c47553f22d6d0e0L93-R130).
- The specification and builder documentation are updated to reflect that mode inheritance applies at all depths, not just to direct children [[1]](diffhunk://#diff-4b3d5e20b1fb9772c579c47a7aca38242fed80c4d535aa6e53b9941d29a440b1L261-R320) [[2]](diffhunk://#diff-e7c112cda9bd742190f9330772f29be4afcc18e33049f3dc0c47553f22d6d0e0L63-R69).

**Conformance and regression tests:**

- Added new conformance tests to ensure correct behavior for:
  - Deeply nested failed leaf compensation
  - Deeply nested mode inheritance
  - Nested workflow failed sub-compensation

These changes fix bugs where nested steps could be compensated multiple times and where mode inheritance did not reach beyond the first level of nesting, and they bring the implementation and specification into alignment.

### Related Issues

* Closes #122 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
