### PR TITLE
feat: implement durability and resumable workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The name `automa` is derived from the word `automate`.
 - Compensating actions for non-reversible steps
 - Step-level execution reporting (with JSON/YAML marshalling support)
 - Extensible step interface
+- Opt-in crash recovery: a durable journal plus resume (forward or compensating)
 
 ## Getting Started
 
@@ -22,6 +23,54 @@ go get -u github.com/automa-saga/automa
 ```
 
 See an [example](https://github.com/automa-saga/automa/blob/master/examples) in the examples directory. 
+
+## Durability (crash recovery)
+
+Automa can make a workflow survive a process crash, restart, or power loss and
+then continue where it stopped — resuming the remaining steps or completing an
+interrupted rollback — with no external infrastructure (the state is a single
+local journal file). It is **opt-in**: without it, workflows behave exactly as
+before and write nothing to disk.
+
+Make a workflow durable by giving it a journal path and running it through
+`ResumeWorkflow`, which starts fresh when there is no journal yet and resumes
+when there is:
+
+```go
+wb := automa.NewWorkflowBuilder().
+    WithId("setup").
+    WithExecutionMode(automa.RollbackOnError).
+    WithJournal("/var/lib/myapp/setup.journal"). // opt in
+    Steps(/* ... */)
+
+// First run starts fresh and journals; a later run with the same path resumes.
+report := automa.ResumeWorkflow(context.Background(), wb, "/var/lib/myapp/setup.journal")
+```
+
+See the runnable [`examples/resumable_setup`](examples/resumable_setup) (crash it
+mid-workflow, re-run it, watch it resume), the design rationale in
+[`docs/durability.md`](docs/durability.md), and the normative
+[durability spec](docs/spec/durability-spec.md).
+
+### Step-author contract
+
+Durability shifts a small, well-defined set of obligations onto the step author
+(durability spec §7). The engine cannot enforce these — they are your
+responsibility, and resume correctness depends on them:
+
+1. **Steps must be idempotent.** A step recorded `started` but not `completed`
+   before a crash is re-executed on resume (its side effect's completion is
+   unknown). Running it twice must equal running it once — check "does this
+   already exist?" and adopt the existing resource rather than creating a second.
+2. **Compensations must be idempotent.** A rollback may be retried across a crash
+   during the compensating phase.
+3. **Resume-relevant data must live in the state bag.** Anything a step needs to
+   resume or compensate (resource IDs, handles, prior outputs) must be written to
+   `State().Global()` or the step's namespace — not held in closures or struct
+   fields, which do not survive the process.
+4. **Topology must be reconstructible.** The same ordered step IDs and modes must
+   be produced by your code at resume time; if steps are derived from runtime
+   data, persist that data so the topology is deterministic across restarts.
 
 ## Logging
 

--- a/conformance_test.go
+++ b/conformance_test.go
@@ -316,17 +316,37 @@ func TestConformance_Serialization(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 type journalFixture struct {
-	Name        string          `json:"name"`
-	Description string          `json:"description"`
-	SpecRefs    []string        `json:"specRefs"`
-	Kind        string          `json:"kind"` // roundtrip
-	Journal     json.RawMessage `json:"journal"`
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	SpecRefs    []string            `json:"specRefs"`
+	Kind        string              `json:"kind"` // roundtrip | resume
+	Journal     json.RawMessage     `json:"journal"`
+	Expect      journalResumeExpect `json:"expect"` // resume fixtures only
+}
+
+// journalResumeExpect is the classification a conformant resume MUST produce for
+// a "resume" fixture (durability-spec §8.1): which leaf steps re-run forward,
+// which compensate, and the resulting workflow status. Steps in the topology
+// absent from reExecute are skipped (already completed).
+type journalResumeExpect struct {
+	ReExecute      []string `json:"reExecute"`
+	Compensate     []string `json:"compensate"`
+	WorkflowStatus string   `json:"workflowStatus"`
+}
+
+// resumeRec records which leaf steps run Execute / Rollback during a resume.
+type resumeRec struct {
+	exec     []string
+	rollback []string
 }
 
 // TestConformance_Journal verifies journal fixtures. For "roundtrip" fixtures a
-// conformant implementation MUST load the journal document and re-serialize it
-// to a structurally-equivalent document, proving schema agreement (§3, §8.1).
-// Resume-classification fixtures land with the resume story (#88).
+// conformant implementation MUST load the journal and re-serialize it to a
+// structurally-equivalent document, proving schema agreement (§3, §8.1). For
+// "resume" fixtures it MUST classify the journal — via the real recovery entry
+// point, ResumeWorkflow — into the same set of steps that re-run vs. compensate,
+// proving resume decision agreement (§6). Steps are side-effect-free recorders,
+// so the decision is observed without real side effects.
 func TestConformance_Journal(t *testing.T) {
 	fixtures := loadFixtures(t, conformanceJournalDir)
 	for path, data := range fixtures {
@@ -344,10 +364,55 @@ func TestConformance_Journal(t *testing.T) {
 				out, err := json.Marshal(&j)
 				require.NoError(t, err, "re-serialize journal")
 				assertJSONEqual(t, fx.Journal, out)
+			case "resume":
+				runJournalResumeFixture(t, fx)
 			default:
 				t.Fatalf("unknown journal fixture kind %q", fx.Kind)
 			}
 		})
+	}
+}
+
+// runJournalResumeFixture rebuilds the journal's (flat) topology with
+// side-effect-free recording steps, writes the journal to disk, resumes it with
+// ResumeWorkflow, and asserts the recorded re-run / compensation matches.
+func runJournalResumeFixture(t *testing.T, fx journalFixture) {
+	var jdoc automa.Journal
+	require.NoError(t, json.Unmarshal(fx.Journal, &jdoc), "load journal")
+
+	rec := &resumeRec{}
+	wb := automa.NewWorkflowBuilder().WithId(jdoc.WorkflowID).
+		WithExecutionMode(jdoc.ExecutionMode).
+		WithRollbackMode(jdoc.RollbackMode)
+	builders := make([]automa.Builder, 0, len(jdoc.Steps))
+	for _, s := range jdoc.Steps {
+		require.Falsef(t, s.IsWorkflow(), "resume fixtures are flat; step %q is a sub-workflow", s.ID)
+		id := s.ID
+		builders = append(builders,
+			automa.NewStepBuilder().WithId(id).
+				WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+					rec.exec = append(rec.exec, id)
+					return automa.SuccessReport(stp)
+				}).
+				WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+					rec.rollback = append(rec.rollback, id)
+					return automa.SuccessReport(stp)
+				}))
+	}
+	wb.Steps(builders...)
+
+	path := filepath.Join(t.TempDir(), "fixture.journal")
+	require.NoError(t, os.WriteFile(path, fx.Journal, 0o600), "write journal fixture")
+
+	report := automa.ResumeWorkflow(context.Background(), wb, path)
+	require.NotNil(t, report)
+
+	assert.Equal(t, normalizeOrder(fx.Expect.ReExecute), normalizeOrder(rec.exec),
+		"steps that re-run forward on resume")
+	assert.Equal(t, normalizeOrder(fx.Expect.Compensate), normalizeOrder(rec.rollback),
+		"steps that compensate on resume")
+	if fx.Expect.WorkflowStatus != "" {
+		assert.Equal(t, fx.Expect.WorkflowStatus, report.Status.String(), "resumed workflow status")
 	}
 }
 

--- a/conformance_test.go
+++ b/conformance_test.go
@@ -23,6 +23,7 @@ import (
 const (
 	conformanceBehaviorDir      = "docs/spec/conformance/behavior"
 	conformanceSerializationDir = "docs/spec/conformance/serialization"
+	conformanceJournalDir       = "docs/spec/conformance/journal"
 )
 
 // ---------------------------------------------------------------------------
@@ -305,6 +306,46 @@ func TestConformance_Serialization(t *testing.T) {
 				assertJSONEqual(t, fx.JSON, out)
 			default:
 				t.Fatalf("unknown serialization fixture kind %q", fx.Kind)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Journal fixtures (durability-spec §8.1)
+// ---------------------------------------------------------------------------
+
+type journalFixture struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	SpecRefs    []string        `json:"specRefs"`
+	Kind        string          `json:"kind"` // roundtrip
+	Journal     json.RawMessage `json:"journal"`
+}
+
+// TestConformance_Journal verifies journal fixtures. For "roundtrip" fixtures a
+// conformant implementation MUST load the journal document and re-serialize it
+// to a structurally-equivalent document, proving schema agreement (§3, §8.1).
+// Resume-classification fixtures land with the resume story (#88).
+func TestConformance_Journal(t *testing.T) {
+	fixtures := loadFixtures(t, conformanceJournalDir)
+	for path, data := range fixtures {
+		var fx journalFixture
+		require.NoErrorf(t, json.Unmarshal(data, &fx), "decode %s", path)
+		name := fx.Name
+		if name == "" {
+			name = filepath.Base(path)
+		}
+		t.Run(name, func(t *testing.T) {
+			switch fx.Kind {
+			case "roundtrip":
+				var j automa.Journal
+				require.NoError(t, json.Unmarshal(fx.Journal, &j), "load journal")
+				out, err := json.Marshal(&j)
+				require.NoError(t, err, "re-serialize journal")
+				assertJSONEqual(t, fx.Journal, out)
+			default:
+				t.Fatalf("unknown journal fixture kind %q", fx.Kind)
 			}
 		})
 	}

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -1,6 +1,13 @@
 # Durable Workflows (Design)
 
-> Status: **proposed** — design under review, not yet implemented.
+> Status: **implemented** — shipped in v1; this document is the design rationale.
+> The normative, language-neutral behavior is the
+> [durability spec](spec/durability-spec.md), backed by
+> [conformance fixtures](spec/conformance/journal). The public API is
+> `WithJournal(path)` on the builder plus `ResumeWorkflow(ctx, wb, journalPath)`,
+> demonstrated end-to-end in
+> [examples/resumable_setup](../examples/resumable_setup). Where this document and
+> the spec disagree, the spec governs.
 
 This document describes a design for adding **crash recovery** to automa: the
 ability for a workflow to survive a process crash, restart, or power loss and
@@ -195,7 +202,7 @@ contract below.
 
 ## Recovery / `Resume`
 
-`Resume` is the new public entry point. The caller re-supplies the workflow
+`Resume` is the public recovery entry point. The caller re-supplies the workflow
 definition (the same builder/code); automa rehydrates state onto it and
 continues.
 
@@ -230,6 +237,13 @@ func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string
 A mismatch (the workflow definition changed between crash and resume) is an
 error, not a silent restart — this is the single-process analogue of workflow
 versioning, and it is intentionally strict.
+
+> The names above are illustrative. The shipped code lives in
+> [`resume.go`](../resume.go): `ResumeWorkflow` dispatches on phase, `rehydrateInto`
+> loads the journal onto the rebuilt workflow (recursively, so a nested
+> sub-workflow that was in progress at the crash resumes on its own cursor —
+> durability-spec §3.8/§6.4), a resume-aware `Execute` skips already-`completed`
+> steps, and `resumeCompensation` finishes an interrupted rollback.
 
 ## Worked example: crash and resume
 
@@ -320,14 +334,25 @@ independent features; none are required for crash recovery of sequential sagas.
   `WithJournal(path)` on the builder) and invoking via `ResumeWorkflow`.
 - The journal format carries a `Version` field so the on-disk schema can evolve.
 
-## Open questions
+## Resolved questions
 
-- Storage backend: start with a plain JSON file (snapshot) — should an embedded
-  KV (e.g. BoltDB) be offered as an alternative for many concurrent workflow
-  runs?
-- Journal lifecycle: delete on `PhaseDone`, or retain for audit and let the
-  caller prune?
-- Where should `WithJournal` live on the builder, and how is the path namespaced
-  per run (workflow ID + run ID)?
-- How strictly should `validateTopology` treat additive changes (e.g. new steps
-  appended after the last completed one)?
+These were open during design and are now settled (see durability-spec §10 for
+the normative statements):
+
+- **Storage backend.** v1 is a single JSON snapshot file. The `ResumeWorkflow`
+  API and journal semantics are backend-neutral, so an embedded KV can be added
+  later without breaking the contract.
+- **Journal lifecycle.** Retention is configurable; the default is `retain` (keep
+  the journal for a full audit trail, caller prunes). `delete_on_success` and
+  `delete_on_done` policies drop it on the corresponding terminal outcome.
+- **`WithJournal` / path namespacing.** `WithJournal(path)` on the builder makes
+  a workflow durable. The spec's per-run convention is
+  `<dir>/<workflowID>-<runID>.journal` with a caller-supplied run ID; the current
+  API takes the full file path directly.
+- **Additive topology changes.** `validateTopology` is strict by default: any
+  change to step IDs, order, or modes refuses the resume. An opt-in relaxation
+  for appended steps may be added later.
+
+The only sanctioned extension still deferred is **nested-workflow forward resume
+robustness across schema evolution**; forward and compensating resume of nested
+workflows themselves is implemented (durability-spec §3.8).

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -342,9 +342,10 @@ the normative statements):
 - **Storage backend.** v1 is a single JSON snapshot file. The `ResumeWorkflow`
   API and journal semantics are backend-neutral, so an embedded KV can be added
   later without breaking the contract.
-- **Journal lifecycle.** Retention is configurable; the default is `retain` (keep
-  the journal for a full audit trail, caller prunes). `delete_on_success` and
-  `delete_on_done` policies drop it on the corresponding terminal outcome.
+- **Journal lifecycle.** The journal is always retained after the run reaches a
+  terminal state; automa never deletes it. The caller owns pruning (and so keeps a
+  full audit trail by default). Configurable retention policies (e.g. delete on
+  success) are a possible future addition, not part of the current API.
 - **`WithJournal` / path namespacing.** `WithJournal(path)` on the builder makes
   a workflow durable. The spec's per-run convention is
   `<dir>/<workflowID>-<runID>.journal` with a caller-supplied run ID; the current

--- a/docs/spec/conformance/README.md
+++ b/docs/spec/conformance/README.md
@@ -115,6 +115,12 @@ Durability journal fixtures, governed by the
 - `roundtrip` — a `journal` document that every implementation MUST load and
   re-serialize to a structurally-equivalent document (key order and whitespace
   do not matter), verifying **schema agreement** (durability-spec §3, §8.1).
+- `resume` — a `journal` plus an `expect` block describing how a conformant
+  resume MUST classify it: `reExecute` (leaf steps that run forward on resume),
+  `compensate` (leaf steps whose rollback runs), and `workflowStatus`. Steps in
+  the topology absent from `reExecute` are skipped as already `completed`. This
+  verifies **resume decision agreement** (§6) without real side effects — the Go
+  harness drives the real `ResumeWorkflow` with recording steps.
 
 ```json
 {

--- a/docs/spec/conformance/README.md
+++ b/docs/spec/conformance/README.md
@@ -19,7 +19,7 @@ fixture under `go test`.
 docs/spec/conformance/
   behavior/        # workflow execution outcomes (core-spec §4–§6, §8)
   serialization/   # load → re-serialize round-trips (core-spec §7.5, §8)
-  journal/         # durability journal + resume (durability-spec §8) — TODO with #86
+  journal/         # durability journal round-trips (durability-spec §3, §8)
 ```
 
 ## Behavior fixtures (`behavior/*.json`)
@@ -106,3 +106,48 @@ matter).
   the 2^53 boundary, and the string-encoded unsafe-ID case.
 - **Timestamps (§8):** serialize as RFC 3339 with a timezone designator;
   trailing-zero fractional seconds are trimmed (e.g. `...00.5Z`, not `...00.500Z`).
+
+## Journal fixtures (`journal/*.json`)
+
+Durability journal fixtures, governed by the
+[durability spec](../durability-spec.md). Each has a `kind`:
+
+- `roundtrip` — a `journal` document that every implementation MUST load and
+  re-serialize to a structurally-equivalent document (key order and whitespace
+  do not matter), verifying **schema agreement** (durability-spec §3, §8.1).
+
+```json
+{
+  "name": "journal_flat_forward_in_progress",
+  "description": "A flat run mid-forward …",
+  "specRefs": ["§3.3", "§3.4", "§5"],
+  "kind": "roundtrip",
+  "journal": {
+    "version": 1,
+    "workflow_id": "setup_local_dev",
+    "execution_mode": "rollback",       // TypeMode wire form: stop | continue | rollback
+    "rollback_mode":  "continue",       // TypeMode wire form: stop | continue
+    "cursor": { "phase": "forward", "index": 1 },
+    "shared": { "local": {}, "global": { "region": "us-east-1" } },
+    "steps": [
+      { "id": "create-network", "state": "completed",
+        "snapshot": { "local": {}, "global": {} } },
+      { "id": "create-db",  "state": "started" },
+      { "id": "deploy-app", "state": "pending" }
+    ]
+  }
+}
+```
+
+- **Modes** use automa's existing `TypeMode` JSON encoding — the short lowercase
+  strings `stop` / `continue` / `rollback` — the same form the behavior and
+  report fixtures use. The journal reuses `TypeMode`, not a second wire form.
+- **Workflow-node invariant (§3.3/§3.8):** a node is a workflow **iff** its entry
+  has a `steps` array; whenever `steps` is present, `cursor` and `shared` are too.
+  A leaf step carries none of the three. A workflow step omits the leaf
+  `snapshot`. The structure is recursive to arbitrary depth.
+- **`report` / `snapshot` / `shared`** nest their own existing schemas (report
+  tree, namespaced state bag); journal fixtures constrain only their placement.
+- **Resume-classification fixtures** (a journal plus the expected phase,
+  first-incomplete index, and which steps re-run vs. skip) land with the resume
+  story; they verify the §6 decision logic without running side effects.

--- a/docs/spec/conformance/journal/journal_done_with_report.json
+++ b/docs/spec/conformance/journal/journal_done_with_report.json
@@ -1,0 +1,30 @@
+{
+  "name": "journal_done_with_report",
+  "description": "A terminal run in phase done: every step completed, steps[0] carries both its rollback snapshot and its report tree. This exercises report placement under a step entry; the report's own serialization is covered by the report serialization fixtures (durability-spec §3.3, §4.1, §6.5).",
+  "specRefs": ["§3.3", "§4.1", "§6.5"],
+  "kind": "roundtrip",
+  "journal": {
+    "version": 1,
+    "workflow_id": "migrate",
+    "execution_mode": "stop",
+    "rollback_mode": "continue",
+    "cursor": { "phase": "done", "index": 1 },
+    "shared": { "local": {}, "global": { "migrated": true } },
+    "steps": [
+      {
+        "id": "backup",
+        "state": "completed",
+        "snapshot": { "local": {}, "global": {} },
+        "report": {
+          "id": "backup",
+          "isWorkflow": false,
+          "action": "execute",
+          "status": "success",
+          "startTime": "2026-06-17T10:30:00.123Z",
+          "endTime": "2026-06-17T10:30:00.456Z"
+        }
+      },
+      { "id": "apply", "state": "completed" }
+    ]
+  }
+}

--- a/docs/spec/conformance/journal/journal_flat_compensating.json
+++ b/docs/spec/conformance/journal/journal_flat_compensating.json
@@ -1,0 +1,19 @@
+{
+  "name": "journal_flat_compensating",
+  "description": "A flat run in the compensating phase after steps[2] failed under RollbackOnError: steps[1] is already compensated and the cursor now proceeds downward from steps[0] toward index 0 (durability-spec §4.1, §4.2, §6.4).",
+  "specRefs": ["§4.1", "§4.2", "§6.4"],
+  "kind": "roundtrip",
+  "journal": {
+    "version": 1,
+    "workflow_id": "provision",
+    "execution_mode": "rollback",
+    "rollback_mode": "continue",
+    "cursor": { "phase": "compensating", "index": 0 },
+    "shared": { "local": {}, "global": {} },
+    "steps": [
+      { "id": "a", "state": "completed", "snapshot": { "local": {}, "global": {} } },
+      { "id": "b", "state": "compensated", "snapshot": { "local": {}, "global": {} } },
+      { "id": "c", "state": "failed" }
+    ]
+  }
+}

--- a/docs/spec/conformance/journal/journal_flat_forward_in_progress.json
+++ b/docs/spec/conformance/journal/journal_flat_forward_in_progress.json
@@ -1,0 +1,23 @@
+{
+  "name": "journal_flat_forward_in_progress",
+  "description": "A flat run mid-forward: steps[0] completed (with its rollback snapshot), steps[1] started (write-ahead record written; side-effect outcome unknown), steps[2] still pending. The cursor points at the most recently started step (durability-spec §3.3, §3.4, §5).",
+  "specRefs": ["§3.3", "§3.4", "§5"],
+  "kind": "roundtrip",
+  "journal": {
+    "version": 1,
+    "workflow_id": "setup_local_dev",
+    "execution_mode": "rollback",
+    "rollback_mode": "continue",
+    "cursor": { "phase": "forward", "index": 1 },
+    "shared": { "local": {}, "global": { "region": "us-east-1" } },
+    "steps": [
+      {
+        "id": "create-network",
+        "state": "completed",
+        "snapshot": { "local": { "netId": "net-123" }, "global": { "region": "us-east-1" } }
+      },
+      { "id": "create-db", "state": "started" },
+      { "id": "deploy-app", "state": "pending" }
+    ]
+  }
+}

--- a/docs/spec/conformance/journal/journal_nested_forward.json
+++ b/docs/spec/conformance/journal/journal_nested_forward.json
@@ -1,0 +1,37 @@
+{
+  "name": "journal_nested_forward",
+  "description": "A recursive journal (durability-spec §3.8): the top level is working on workflow step 'db', which is itself working on nested workflow step 'start-postgres'. Each workflow node carries its own cursor/shared/steps; leaf steps carry none of the trio. Not-yet-started workflow steps ('app', 'smoke-test') are leaf-shaped until reached. The live position is the cursor path db → start-postgres → run-container.",
+  "specRefs": ["§3.8", "§3.4"],
+  "kind": "roundtrip",
+  "journal": {
+    "version": 1,
+    "workflow_id": "setup",
+    "execution_mode": "rollback",
+    "rollback_mode": "continue",
+    "cursor": { "phase": "forward", "index": 0 },
+    "shared": { "local": {}, "global": {} },
+    "steps": [
+      {
+        "id": "db",
+        "state": "started",
+        "cursor": { "phase": "forward", "index": 1 },
+        "shared": { "local": {}, "global": {} },
+        "steps": [
+          { "id": "create-volume", "state": "completed" },
+          {
+            "id": "start-postgres",
+            "state": "started",
+            "cursor": { "phase": "forward", "index": 1 },
+            "shared": { "local": {}, "global": {} },
+            "steps": [
+              { "id": "pull-image", "state": "completed" },
+              { "id": "run-container", "state": "started" }
+            ]
+          }
+        ]
+      },
+      { "id": "app", "state": "pending" },
+      { "id": "smoke-test", "state": "pending" }
+    ]
+  }
+}

--- a/docs/spec/conformance/journal/resume_compensating_continues.json
+++ b/docs/spec/conformance/journal/resume_compensating_continues.json
@@ -1,0 +1,24 @@
+{
+  "name": "resume_compensating_continues",
+  "description": "Compensation resume: rollback continues from the cursor downward, skipping already-compensated steps (durability-spec §6.4). b and c are already compensated; only a's rollback runs. No forward execution occurs and the outcome is a failure (the run rolled back).",
+  "specRefs": ["§6.4"],
+  "kind": "resume",
+  "journal": {
+    "version": 1,
+    "workflow_id": "wf",
+    "execution_mode": "rollback",
+    "rollback_mode": "continue",
+    "cursor": { "phase": "compensating", "index": 1 },
+    "shared": { "local": {}, "global": {} },
+    "steps": [
+      { "id": "a", "state": "completed", "snapshot": { "local": {}, "global": {} } },
+      { "id": "b", "state": "compensated", "snapshot": { "local": {}, "global": {} } },
+      { "id": "c", "state": "compensated" }
+    ]
+  },
+  "expect": {
+    "reExecute": [],
+    "compensate": ["a"],
+    "workflowStatus": "failed"
+  }
+}

--- a/docs/spec/conformance/journal/resume_done_is_noop.json
+++ b/docs/spec/conformance/journal/resume_done_is_noop.json
@@ -1,0 +1,23 @@
+{
+  "name": "resume_done_is_noop",
+  "description": "Resuming a terminal (done) journal returns the recorded result and executes/compensates nothing (durability-spec §6.5). All steps completed, so the outcome is success.",
+  "specRefs": ["§6.5"],
+  "kind": "resume",
+  "journal": {
+    "version": 1,
+    "workflow_id": "wf",
+    "execution_mode": "rollback",
+    "rollback_mode": "continue",
+    "cursor": { "phase": "done", "index": 1 },
+    "shared": { "local": {}, "global": {} },
+    "steps": [
+      { "id": "a", "state": "completed" },
+      { "id": "b", "state": "completed" }
+    ]
+  },
+  "expect": {
+    "reExecute": [],
+    "compensate": [],
+    "workflowStatus": "success"
+  }
+}

--- a/docs/spec/conformance/journal/resume_forward_reruns_started.json
+++ b/docs/spec/conformance/journal/resume_forward_reruns_started.json
@@ -1,0 +1,23 @@
+{
+  "name": "resume_forward_reruns_started",
+  "description": "Forward resume with a started-but-not-completed step (the ambiguous case): the completed step (a) is skipped and the started step (b) is re-executed exactly once (durability-spec §6.3). This is the correctness-critical re-run that relies on step idempotency (§7).",
+  "specRefs": ["§6.3", "§7"],
+  "kind": "resume",
+  "journal": {
+    "version": 1,
+    "workflow_id": "wf",
+    "execution_mode": "rollback",
+    "rollback_mode": "continue",
+    "cursor": { "phase": "forward", "index": 1 },
+    "shared": { "local": {}, "global": {} },
+    "steps": [
+      { "id": "a", "state": "completed", "snapshot": { "local": {}, "global": {} } },
+      { "id": "b", "state": "started" }
+    ]
+  },
+  "expect": {
+    "reExecute": ["b"],
+    "compensate": [],
+    "workflowStatus": "success"
+  }
+}

--- a/docs/spec/conformance/journal/resume_forward_skips_completed.json
+++ b/docs/spec/conformance/journal/resume_forward_skips_completed.json
@@ -1,0 +1,23 @@
+{
+  "name": "resume_forward_skips_completed",
+  "description": "Forward resume after a clean commit: the completed step (a) is skipped and the remaining step (b) runs (durability-spec §6.3). First-incomplete index is 1.",
+  "specRefs": ["§6.3"],
+  "kind": "resume",
+  "journal": {
+    "version": 1,
+    "workflow_id": "wf",
+    "execution_mode": "rollback",
+    "rollback_mode": "continue",
+    "cursor": { "phase": "forward", "index": 0 },
+    "shared": { "local": {}, "global": {} },
+    "steps": [
+      { "id": "a", "state": "completed", "snapshot": { "local": {}, "global": {} } },
+      { "id": "b", "state": "pending" }
+    ]
+  },
+  "expect": {
+    "reExecute": ["b"],
+    "compensate": [],
+    "workflowStatus": "success"
+  }
+}

--- a/docs/spec/durability-spec.md
+++ b/docs/spec/durability-spec.md
@@ -87,8 +87,8 @@ none of the three.
   // ── header: stable identity + configuration ──
   "version": 1,                        // integer; schema version (§3.5)
   "workflow_id": "setup_local_dev",    // string; identifies the run's workflow
-  "execution_mode": "RollbackOnError", // string; one of the execution modes (§4.3)
-  "rollback_mode":  "StopOnError",     // string; one of the rollback modes (§4.3)
+  "execution_mode": "rollback",        // string; one of the execution modes (§4.3)
+  "rollback_mode":  "stop",            // string; one of the rollback modes (§4.3)
 
   // ── run state ──
   "cursor": {                          // object; the execution position (§3.4)
@@ -275,8 +275,8 @@ Rules:
 {
   "version": 1,
   "workflow_id": "setup",
-  "execution_mode": "RollbackOnError",
-  "rollback_mode":  "ContinueOnError",
+  "execution_mode": "rollback",
+  "rollback_mode":  "continue",
   "cursor": { "phase": "forward", "index": 0 },   // working on steps[0] = "db"
   "shared": { /* namespaced bag */ },
   "steps": [
@@ -364,13 +364,16 @@ completed ──▶ compensated      (during compensating phase)
 
 The journal records two modes, both as strings:
 
-- `execution_mode` ∈ { `StopOnError`, `ContinueOnError`, `RollbackOnError` }.
-- `rollback_mode` ∈ { `StopOnError`, `ContinueOnError` }.
+- `execution_mode` ∈ { `stop`, `continue`, `rollback` }.
+- `rollback_mode` ∈ { `stop`, `continue` }.
 
-These values MUST be spelled exactly as above (matching automa's existing
-`TypeMode` values). The modes recorded in the journal MUST equal the modes of the
-workflow definition supplied at resume (§6.2 topology validation includes mode
-agreement).
+These values MUST be spelled exactly as above. They are automa's existing
+`TypeMode` JSON encoding — the same short, lowercase strings used by the core
+spec and the report/behavior fixtures (`StopOnError` → `stop`,
+`ContinueOnError` → `continue`, `RollbackOnError` → `rollback`) — because the
+journal reuses `TypeMode` rather than defining a second wire form. The modes
+recorded in the journal MUST equal the modes of the workflow definition supplied
+at resume (§6.2 topology validation includes mode agreement).
 
 ## 5. Persistence ordering
 

--- a/docs/spec/durability-spec.md
+++ b/docs/spec/durability-spec.md
@@ -422,6 +422,17 @@ Requirements:
 - In `compensating` phase, each step's `compensated` record (C3) MUST be durably
   written before proceeding to the next-lower index, so an interrupted rollback
   resumes without repeating already-compensated steps.
+- **PERSIST failure.** The two *write-ahead* PERSISTs, F1 (`started`) and F5
+  (entering `compensating`), guard a side effect that has **not yet run**. If
+  either fails, the implementation MUST NOT run the side effect (F1) or begin
+  compensation (F5): it MUST abort that step (or the rollback) and surface the
+  failure, because running an effect with no durable record would strand it beyond
+  what resume can observe or compensate. The *commit* PERSISTs — F4
+  (`completed`/`failed`), C3 (`compensated`), and D1 (`done`) — record an outcome
+  **after** its side effect has already returned; an implementation MAY tolerate
+  (log and continue) a failure at these points, since a lost commit record only
+  causes resume to re-execute or re-compensate a step, which §7 idempotency already
+  requires to be safe.
 - **Recursion.** When step `i` is itself a workflow, its F3 (execute) is the
   recursive run of that sub-workflow, which performs its own F1–D1 against its
   own node (`steps[i].cursor`/`shared`/`steps`). The parent's F1/F4 still bracket

--- a/docs/spec/durability-spec.md
+++ b/docs/spec/durability-spec.md
@@ -337,11 +337,9 @@ forward ──▶ done
 ### 4.2 Step states
 
 ```
-pending ──▶ started ──▶ completed
-                  │
-                  └────▶ failed
-
-completed ──▶ compensated      (during compensating phase)
+pending ──▶ started ──▶ completed ──┐
+                  │                  ├──▶ compensated   (during compensating phase)
+                  └────▶ failed ─────┘
 ```
 
 | State | Meaning |
@@ -351,6 +349,12 @@ completed ──▶ compensated      (during compensating phase)
 | `completed` | Execute succeeded; commit point recorded. |
 | `failed` | Execute failed. |
 | `compensated` | Rollback for this step completed. |
+
+- Both `completed` and `failed` can transition to `compensated`. When a step
+  fails under `RollbackOnError`, the compensating phase begins **at the failed
+  step** (§5 F5 sets `cursor.index` to it, and the C-phase runs from there down),
+  so the failed step's own rollback runs to clean up any partial work before the
+  earlier `completed` steps are compensated in reverse.
 
 - A step found in `started` but not `completed` after a crash is the **ambiguous
   case**: its side effect's completion is unknown. It MUST be re-executed on

--- a/errors.go
+++ b/errors.go
@@ -11,4 +11,13 @@ var (
 	StepAlreadyExists = IllegalArgument.NewSubtype("step_already_exists", errorx.Duplicate())
 
 	StepExecutionError = ErrNamespace.NewType("step_execution_error")
+
+	// JournalError and its subtypes cover durability journal failures
+	// (durability-spec §3, §6). Each subtype maps to a distinct fail-loudly case:
+	// a journal that cannot be decoded, a schema version this build does not
+	// support, or a topology/mode disagreement with the supplied definition.
+	JournalError              = ErrNamespace.NewType("journal_error")
+	JournalCorrupt            = JournalError.NewSubtype("corrupt")
+	JournalUnsupportedVersion = JournalError.NewSubtype("unsupported_version")
+	JournalTopologyMismatch   = JournalError.NewSubtype("topology_mismatch")
 )

--- a/examples/resumable_setup/README.md
+++ b/examples/resumable_setup/README.md
@@ -1,0 +1,58 @@
+# resumable_setup
+
+A runnable demonstration of automa's crash-recovery durability
+([durability spec](../../docs/spec/durability-spec.md),
+[design](../../docs/durability.md)). The workflow provisions a few marker files
+under a work directory while journaling its progress. Crash it partway through
+and re-run it — it resumes from where it stopped instead of starting over.
+
+## Run it
+
+First run, crashing right after the `write_config` step:
+
+```bash
+go run ./examples/resumable_setup -crash-at=write_config
+```
+
+```
+No journal yet — starting fresh.
+  + create_workdir
+  + write_config
+  ! simulating a crash right after write_config
+exit status 1
+```
+
+Re-run with no crash — it resumes:
+
+```bash
+go run ./examples/resumable_setup
+```
+
+```
+Found an existing journal — resuming.
+  = write_config (already done; skipping side effect)
+  + provision_database
+  + finalize
+
+✔ workflow completed.
+```
+
+`create_workdir` isn't re-run (it was recorded `completed`), `write_config` is
+re-run but is an idempotent no-op (its marker already exists), and the remaining
+steps run to completion. Run it a third time and it's a safe no-op: the journal
+is `done`.
+
+Flags: `-journal <path>` (journal file), `-work <dir>` (provisioned directory),
+`-crash-at <stepID>` (simulate a crash after a step; omit on the resume run).
+
+## How it works
+
+- **One entry point.** [`main.go`](main.go) always calls
+  `automa.ResumeWorkflow(ctx, wb, journalPath)`. A missing journal is a normal
+  fresh start; an existing one is resumed (durability-spec §6.2).
+- **Opt-in journaling.** `ResumeWorkflow` writes the journal at the given path as
+  the workflow runs (write-ahead before each side effect, commit after).
+- **The author contract.** Each step in [`steps.go`](steps.go) is **idempotent**:
+  it checks whether its marker already exists and does nothing if so. That is
+  what makes it safe for resume to re-run a step that was `started` but never
+  confirmed `completed` before the crash (durability-spec §7).

--- a/examples/resumable_setup/main.go
+++ b/examples/resumable_setup/main.go
@@ -1,0 +1,59 @@
+// Command resumable_setup is a runnable demonstration of automa's crash-recovery
+// durability. It provisions a few marker files under a work directory, journaling
+// its progress. Crash it partway through and re-run it: it resumes from where it
+// stopped instead of starting over.
+//
+// Usage:
+//
+//	# First run: crash right after the "write_config" step.
+//	go run ./examples/resumable_setup -crash-at=write_config
+//
+//	# Re-run with no crash: it resumes — completed steps are skipped, the rest run.
+//	go run ./examples/resumable_setup
+//
+// The single call site is ResumeWorkflow: with no journal yet it starts fresh
+// and creates one; with an existing journal it continues from the recorded point.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/automa-saga/automa"
+)
+
+func main() {
+	var journalPath, workDir, crashAt string
+	flag.StringVar(&journalPath, "journal", "/tmp/automa-resumable/setup.journal", "journal file path")
+	flag.StringVar(&workDir, "work", "/tmp/automa-resumable/work", "work directory the steps provision")
+	flag.StringVar(&crashAt, "crash-at", "", "step ID to simulate a crash after (leave empty on the resume run)")
+	flag.Parse()
+
+	if err := os.MkdirAll(filepath.Dir(journalPath), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot create journal directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	wb := buildWorkflow(workDir, crashAt)
+
+	fmt.Printf("Running resumable_setup (journal=%s, work=%s)\n", journalPath, workDir)
+	if _, err := os.Stat(journalPath); err == nil {
+		fmt.Println("Found an existing journal — resuming.")
+	} else {
+		fmt.Println("No journal yet — starting fresh.")
+	}
+
+	// ResumeWorkflow is the single entry point for both the first run and every
+	// resume: a missing journal is a normal start (durability-spec §6.2).
+	report := automa.ResumeWorkflow(context.Background(), wb, journalPath)
+	if report.IsFailed() {
+		fmt.Printf("\n✘ workflow failed: %v\n", report.Error)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\n✔ workflow completed. Journal: %s\n", journalPath)
+	fmt.Println("(Run again and it is a safe no-op: the journal is `done`.)")
+}

--- a/examples/resumable_setup/main_test.go
+++ b/examples/resumable_setup/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/automa-saga/automa"
+)
+
+// TestResumableSetup_CrashThenResume drives the example the way the CLI does:
+// a first run that crashes after write_config, then a resume that completes.
+// It asserts the resume skips the already-completed step and finishes the rest.
+func TestResumableSetup_CrashThenResume(t *testing.T) {
+	workDir := t.TempDir()
+	journalPath := filepath.Join(t.TempDir(), "setup.journal")
+
+	// Simulate the crash as a panic (recovered here) instead of os.Exit, so it
+	// does not kill the test process. Restore the default afterward.
+	original := crashFn
+	t.Cleanup(func() { crashFn = original })
+	crashFn = func() { panic("simulated crash") }
+
+	// First run: crash right after write_config.
+	func() {
+		defer func() { _ = recover() }()
+		wb := buildWorkflow(workDir, stepConfig)
+		_ = automa.ResumeWorkflow(context.Background(), wb, journalPath)
+	}()
+
+	assertExists(t, filepath.Join(workDir, "config.yaml"), "write_config ran its side effect before the crash")
+	assertMissing(t, filepath.Join(workDir, "DONE"), "finalize must not have run before the crash")
+
+	// Second run: no crash → resume to completion.
+	crashFn = func() {}
+	report := automa.ResumeWorkflow(context.Background(), buildWorkflow(workDir, ""), journalPath)
+	if report.IsFailed() {
+		t.Fatalf("resume should succeed, got: %v", report.Error)
+	}
+
+	assertExists(t, filepath.Join(workDir, "DONE"), "resume must run the remaining steps to completion")
+}
+
+func assertExists(t *testing.T, path, why string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s to exist (%s): %v", path, why, err)
+	}
+}
+
+func assertMissing(t *testing.T, path, why string) {
+	t.Helper()
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("expected %s to be absent (%s)", path, why)
+	}
+}

--- a/examples/resumable_setup/steps.go
+++ b/examples/resumable_setup/steps.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/automa-saga/automa"
+)
+
+// Step IDs for the resumable provisioning workflow.
+const (
+	stepWorkdir  = "create_workdir"
+	stepConfig   = "write_config"
+	stepDatabase = "provision_database"
+	stepFinalize = "finalize"
+)
+
+// crashFn simulates a hard process crash (power loss / kill -9). In the CLI it
+// is os.Exit; tests override it so they can observe resume without killing the
+// test process. A hard crash is the interesting case for durability: it stops
+// the process AFTER a step's side effect but before the commit record, leaving
+// the journal with that step `started`.
+var crashFn = func() { os.Exit(1) }
+
+// fileStep returns a step that idempotently creates a marker file under dir.
+//
+// Idempotency is the durability author contract (durability-spec §7): running a
+// step twice must equal running it once. Here that means checking whether the
+// marker already exists and doing nothing if so — which is exactly what makes it
+// safe for resume to re-run a step that was `started` but never confirmed
+// `completed` before a crash.
+//
+// If crashAfter equals this step's ID, the step simulates a crash right after
+// writing its file (before returning), so the journal is left mid-workflow.
+func fileStep(id, dir, filename, crashAfter string) *automa.StepBuilder {
+	target := filepath.Join(dir, filename)
+	return automa.NewStepBuilder().WithId(id).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if _, err := os.Stat(target); err == nil {
+				fmt.Printf("  = %s (already done; skipping side effect)\n", id)
+				return automa.SuccessReport(stp)
+			}
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return automa.FailureReport(stp, automa.WithError(err))
+			}
+			if err := os.WriteFile(target, []byte(id+"\n"), 0o644); err != nil {
+				return automa.FailureReport(stp, automa.WithError(err))
+			}
+			fmt.Printf("  + %s\n", id)
+			if crashAfter == id {
+				fmt.Printf("  ! simulating a crash right after %s\n", id)
+				crashFn()
+			}
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			_ = os.Remove(target)
+			fmt.Printf("  - rolled back %s\n", id)
+			return automa.SuccessReport(stp)
+		})
+}
+
+// buildWorkflow assembles the provisioning workflow. crashAfter names a step to
+// crash after (empty on the resume run).
+func buildWorkflow(dir, crashAfter string) *automa.WorkflowBuilder {
+	return automa.NewWorkflowBuilder().
+		WithId("resumable_setup").
+		WithExecutionMode(automa.RollbackOnError).
+		Steps(
+			fileStep(stepWorkdir, dir, ".workdir", crashAfter),
+			fileStep(stepConfig, dir, "config.yaml", crashAfter),
+			fileStep(stepDatabase, dir, "database.id", crashAfter),
+			fileStep(stepFinalize, dir, "DONE", crashAfter),
+		)
+}

--- a/examples/setup_local/go.mod
+++ b/examples/setup_local/go.mod
@@ -1,6 +1,6 @@
 module github.com/automa-saga/automa/examples/setup_local
 
-go 1.25.0
+go 1.26.5
 
 replace github.com/automa-saga/automa => ../../../automa
 
@@ -17,7 +17,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/term v0.1.0 // indirect
 )

--- a/examples/setup_local/go.sum
+++ b/examples/setup_local/go.sum
@@ -33,6 +33,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=

--- a/journal.go
+++ b/journal.go
@@ -140,6 +140,11 @@ func (j *Journal) validateStructure() error {
 // validateStructure enforces the workflow-node invariant on a step entry and
 // recurses into workflow steps (durability-spec §3.3, §3.8).
 func (s *StepJournal) validateStructure() error {
+	// A null entry in a `steps` array (e.g. `"steps": [null]`) decodes to a nil
+	// element. Treat it as corruption and fail loudly rather than dereferencing it.
+	if s == nil {
+		return JournalCorrupt.New("journal contains a null step entry")
+	}
 	if s.ID == "" {
 		return JournalCorrupt.New("journal step entry has an empty id")
 	}

--- a/journal.go
+++ b/journal.go
@@ -92,7 +92,9 @@ type Journal struct {
 // shape the top level has, minus the header, which it inherits) and omits the
 // leaf snapshot. This is the workflow-node invariant: a node is a workflow iff
 // it has a steps array, in which case cursor and shared are present too; a leaf
-// carries none of the three.
+// carries none of the three. A pending workflow definition step may still be
+// leaf-shaped in a loaded journal because not every writer pre-populates nested
+// workflow state before the step is reached.
 type StepJournal struct {
 	ID    string    `json:"id"`
 	State StepState `json:"state"`
@@ -115,6 +117,59 @@ type StepJournal struct {
 // its entry carries a steps array.
 func (s *StepJournal) IsWorkflow() bool { return s.Steps != nil }
 
+// valid reports whether p is one of the phases this build understands. An
+// unrecognized phase in a loaded journal is corruption: resume dispatches on it
+// (resume.go), and a bad value would silently fall through to forward execution
+// and risk re-running committed steps.
+func (p Phase) valid() bool {
+	switch p {
+	case PhaseForward, PhaseCompensating, PhaseDone:
+		return true
+	}
+	return false
+}
+
+// valid reports whether s is one of the step states this build understands. An
+// unrecognized state in a loaded journal is corruption: rehydrateInto switches
+// on it, and a bad value would silently read as "not executed" and cause resume
+// to skip compensation for a step that actually ran.
+func (s StepState) valid() bool {
+	switch s {
+	case StepPending, StepStarted, StepCompleted, StepFailed, StepCompensated:
+		return true
+	}
+	return false
+}
+
+// validateCursor checks a workflow node's cursor: a known phase, and an index
+// that addresses this node's own steps. The index is used directly to index
+// steps on resume/rollback (rollbackFrom does w.steps[i]), so an out-of-range
+// value from a corrupt journal must be rejected on load rather than panic at
+// resume. Index 0 is the benign default for a node with no steps.
+func validateCursor(id string, c Cursor, nSteps int) error {
+	if !c.Phase.valid() {
+		return JournalCorrupt.New("node %q has an unknown cursor phase %q", id, c.Phase)
+	}
+	if c.Phase == PhaseDone {
+		return nil
+	}
+	if c.Index < 0 || (nSteps == 0 && c.Index != 0) || (nSteps > 0 && c.Index >= nSteps) {
+		return JournalCorrupt.New(
+			"node %q cursor index %d is out of range for %d step(s)", id, c.Index, nSteps)
+	}
+	return nil
+}
+
+// validateStepState checks that a loaded step state is one of the known values.
+// Unknown values are treated as corruption because resume logic uses the state to
+// decide whether a step was executed and/or compensated.
+func validateStepState(id string, state StepState) error {
+	if state.valid() {
+		return nil
+	}
+	return JournalCorrupt.New("journal step %q has an unknown state %q", id, state)
+}
+
 // validateStructure checks the journal against the schema invariants that a
 // well-formed journal MUST satisfy (durability-spec §3.3, §3.5). It is applied
 // on load so a malformed journal fails loudly rather than resuming wrongly.
@@ -128,6 +183,12 @@ func (j *Journal) validateStructure() error {
 	// the struct; steps must be present.
 	if j.Steps == nil {
 		return JournalCorrupt.New("journal has no steps array")
+	}
+	if j.Shared == nil {
+		return JournalCorrupt.New("journal is missing its shared state")
+	}
+	if err := validateCursor(j.WorkflowID, j.Cursor, len(j.Steps)); err != nil {
+		return err
 	}
 	for _, s := range j.Steps {
 		if err := s.validateStructure(); err != nil {
@@ -148,6 +209,9 @@ func (s *StepJournal) validateStructure() error {
 	if s.ID == "" {
 		return JournalCorrupt.New("journal step entry has an empty id")
 	}
+	if err := validateStepState(s.ID, s.State); err != nil {
+		return err
+	}
 	if s.IsWorkflow() {
 		// A workflow step MUST carry cursor and shared, and MUST NOT carry the
 		// leaf snapshot.
@@ -159,6 +223,9 @@ func (s *StepJournal) validateStructure() error {
 		}
 		if s.Snapshot != nil {
 			return JournalCorrupt.New("workflow step %q must not carry a leaf snapshot", s.ID)
+		}
+		if err := validateCursor(s.ID, *s.Cursor, len(s.Steps)); err != nil {
+			return err
 		}
 		for _, child := range s.Steps {
 			if err := child.validateStructure(); err != nil {
@@ -305,6 +372,9 @@ func validateStepsTopology(path string, steps []Step, entries []*StepJournal) er
 				path, i, step.Id(), entry.ID)
 		}
 		child, defIsWorkflow := step.(*workflow)
+		if defIsWorkflow && !entry.IsWorkflow() && entry.State == StepPending {
+			continue
+		}
 		if defIsWorkflow != entry.IsWorkflow() {
 			return JournalTopologyMismatch.New(
 				"step %q: definition is %s but journal records %s",

--- a/journal.go
+++ b/journal.go
@@ -1,0 +1,322 @@
+package automa
+
+// Durability journal (schema v1). This file defines the on-disk journal types
+// and the atomic write/read primitives that the rest of the durability feature
+// builds on. It introduces no user-visible behavior on its own: nothing here is
+// wired into Execute/Rollback yet (that is Durability Story 2).
+//
+// The journal is the persisted, language-neutral record of a run's progress. Its
+// shape and semantics are the normative durability spec, not this code; where
+// they disagree the spec governs. See docs/spec/durability-spec.md and the
+// conformance fixtures under docs/spec/conformance/journal.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// JournalVersion is the journal schema version this implementation reads and
+// writes (durability-spec §3.5). A journal carrying any other version is
+// rejected loudly on load rather than resumed, because silently restarting an
+// unrecognized journal risks re-executing side effects.
+const JournalVersion = 1
+
+// Phase is a workflow node's execution phase as recorded in the journal
+// (durability-spec §4.1). It is serialized as a fixed lowercase string.
+type Phase string
+
+const (
+	// PhaseForward means the node is executing its steps in topology order.
+	PhaseForward Phase = "forward"
+	// PhaseCompensating means the node is rolling back completed steps in
+	// reverse order.
+	PhaseCompensating Phase = "compensating"
+	// PhaseDone is terminal: the node has finished (success, fully compensated,
+	// or terminally failed per its mode).
+	PhaseDone Phase = "done"
+)
+
+// StepState is a step's recorded state as its parent sees it (durability-spec
+// §4.2). It is serialized as a fixed lowercase string.
+type StepState string
+
+const (
+	// StepPending means the step has not started.
+	StepPending StepState = "pending"
+	// StepStarted means the write-ahead record was written; the side effect may
+	// or may not have run. A step found in this state after a crash is the
+	// ambiguous case and is re-executed on resume (durability-spec §6.3).
+	StepStarted StepState = "started"
+	// StepCompleted means Execute succeeded and the commit point was recorded.
+	StepCompleted StepState = "completed"
+	// StepFailed means Execute failed.
+	StepFailed StepState = "failed"
+	// StepCompensated means the step's Rollback completed.
+	StepCompensated StepState = "compensated"
+)
+
+// Cursor is the execution position of one workflow node: its phase plus the
+// index into that node's own steps array (durability-spec §3.4). It never
+// addresses across levels; each workflow node carries its own cursor.
+type Cursor struct {
+	Phase Phase `json:"phase"`
+	Index int   `json:"index"`
+}
+
+// Journal is the top-level record of a run (durability-spec §3.3). Because a
+// workflow is a step, the structure is recursive: a step that is itself a
+// workflow carries its own cursor/shared/steps (see StepJournal and §3.8). The
+// top level is always a workflow, so it always carries the header plus the full
+// run-state trio.
+//
+// On-disk keys are snake_case and fixed by the spec; implementations MUST NOT
+// rename them to match language idioms.
+type Journal struct {
+	// Header — stable identity and configuration.
+	Version       int      `json:"version"`
+	WorkflowID    string   `json:"workflow_id"`
+	ExecutionMode TypeMode `json:"execution_mode"`
+	RollbackMode  TypeMode `json:"rollback_mode"`
+
+	// Run state.
+	Cursor Cursor                  `json:"cursor"`
+	Shared *SyncNamespacedStateBag `json:"shared"`
+	Steps  []*StepJournal          `json:"steps"`
+}
+
+// StepJournal is one entry in a node's steps array (durability-spec §3.3, §3.8).
+//
+// A leaf (ordinary) step carries id, state, and optionally snapshot/report. A
+// workflow step instead carries the run-state trio cursor/shared/steps (the same
+// shape the top level has, minus the header, which it inherits) and omits the
+// leaf snapshot. This is the workflow-node invariant: a node is a workflow iff
+// it has a steps array, in which case cursor and shared are present too; a leaf
+// carries none of the three.
+type StepJournal struct {
+	ID    string    `json:"id"`
+	State StepState `json:"state"`
+
+	// Leaf-step fields. snapshot is the execution-time state captured for
+	// rollback; report is the step's report tree. Both are OPTIONAL and omitted
+	// when not yet produced. A workflow step omits snapshot entirely (§3.8).
+	Snapshot *SyncNamespacedStateBag `json:"snapshot,omitempty"`
+	Report   *Report                 `json:"report,omitempty"`
+
+	// Workflow-step run-state trio, present iff this entry is itself a workflow
+	// (the workflow-node invariant). A leaf step carries none of the three.
+	Cursor *Cursor                 `json:"cursor,omitempty"`
+	Shared *SyncNamespacedStateBag `json:"shared,omitempty"`
+	Steps  []*StepJournal          `json:"steps,omitempty"`
+}
+
+// IsWorkflow reports whether this entry is a workflow node. Per the
+// workflow-node invariant (durability-spec §3.3/§3.8) a node is a workflow iff
+// its entry carries a steps array.
+func (s *StepJournal) IsWorkflow() bool { return s.Steps != nil }
+
+// validateStructure checks the journal against the schema invariants that a
+// well-formed journal MUST satisfy (durability-spec §3.3, §3.5). It is applied
+// on load so a malformed journal fails loudly rather than resuming wrongly.
+func (j *Journal) validateStructure() error {
+	if j.Version != JournalVersion {
+		return JournalUnsupportedVersion.New(
+			"journal version %d is not supported by this build (expected %d)",
+			j.Version, JournalVersion)
+	}
+	// The top level is always a workflow node: cursor and shared are implied by
+	// the struct; steps must be present.
+	if j.Steps == nil {
+		return JournalCorrupt.New("journal has no steps array")
+	}
+	for _, s := range j.Steps {
+		if err := s.validateStructure(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateStructure enforces the workflow-node invariant on a step entry and
+// recurses into workflow steps (durability-spec §3.3, §3.8).
+func (s *StepJournal) validateStructure() error {
+	if s.ID == "" {
+		return JournalCorrupt.New("journal step entry has an empty id")
+	}
+	if s.IsWorkflow() {
+		// A workflow step MUST carry cursor and shared, and MUST NOT carry the
+		// leaf snapshot.
+		if s.Cursor == nil {
+			return JournalCorrupt.New("workflow step %q is missing its cursor", s.ID)
+		}
+		if s.Shared == nil {
+			return JournalCorrupt.New("workflow step %q is missing its shared state", s.ID)
+		}
+		if s.Snapshot != nil {
+			return JournalCorrupt.New("workflow step %q must not carry a leaf snapshot", s.ID)
+		}
+		for _, child := range s.Steps {
+			if err := child.validateStructure(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	// A leaf step MUST carry none of the run-state trio.
+	if s.Cursor != nil || s.Shared != nil {
+		return JournalCorrupt.New("leaf step %q must not carry cursor/shared", s.ID)
+	}
+	return nil
+}
+
+// persist atomically writes the journal to path (durability-spec §3.6). A
+// reader — including a post-crash reader — observes either the complete previous
+// journal or the complete new one, never a torn file. The procedure is:
+// serialize, write to a temp file in the same directory, fsync it before the
+// rename, then atomically rename it over the target. The parent directory is
+// also fsynced so the rename itself survives power loss.
+func (j *Journal) persist(path string) error {
+	data, err := json.MarshalIndent(j, "", "  ")
+	if err != nil {
+		return JournalError.Wrap(err, "marshal journal")
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".journal-*.tmp")
+	if err != nil {
+		return JournalError.Wrap(err, "create temp journal in %s", dir)
+	}
+	tmpName := tmp.Name()
+
+	// Clean up the temp file if we return before a successful rename. After a
+	// successful rename the temp path no longer exists, so the removal is a
+	// harmless no-op whose error is intentionally ignored.
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return JournalError.Wrap(err, "write temp journal")
+	}
+	// Flush data to stable storage before the rename (§3.6 step 3) — REQUIRED to
+	// survive power loss, not merely a process crash.
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return JournalError.Wrap(err, "fsync temp journal")
+	}
+	if err := tmp.Close(); err != nil {
+		return JournalError.Wrap(err, "close temp journal")
+	}
+
+	// Atomic rename over the target (§3.6 step 4).
+	if err := os.Rename(tmpName, path); err != nil {
+		return JournalError.Wrap(err, "rename temp journal over %s", path)
+	}
+	renamed = true
+
+	// fsync the parent directory so the rename is itself durable across power
+	// loss. A directory that cannot be synced (e.g. some non-POSIX targets) is
+	// not fatal to the all-or-nothing guarantee of the rename itself.
+	if d, derr := os.Open(dir); derr == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
+}
+
+// loadJournal reads and decodes a journal from path (durability-spec §6.2).
+//
+// A missing file returns an error satisfying errors.Is(err, os.ErrNotExist);
+// callers implementing resume treat that as a fresh run (§6.2). A file that
+// cannot be decoded, or one carrying an unsupported version, fails loudly: this
+// function never silently discards or restarts a journal, because doing so could
+// re-execute side effects.
+func loadJournal(path string) (*Journal, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Return os errors (including not-exist) unwrapped so callers can use
+		// errors.Is(err, os.ErrNotExist) to detect the fresh-run case.
+		return nil, err
+	}
+
+	var j Journal
+	if err := json.Unmarshal(data, &j); err != nil {
+		return nil, JournalCorrupt.Wrap(err, "decode journal at %s", path)
+	}
+	if err := j.validateStructure(); err != nil {
+		return nil, err
+	}
+	return &j, nil
+}
+
+// validateTopology checks that a workflow definition matches the topology and
+// modes recorded in the journal (durability-spec §6.2). Resume refuses to
+// proceed on any mismatch — differing step IDs or order at any depth, or
+// differing execution/rollback modes. This is the single-process analogue of
+// workflow versioning and is intentionally strict, because rehydrating a journal
+// onto a changed definition could re-run or skip the wrong side effects.
+//
+// Only the top-level modes are compared: a sub-workflow step inherits its
+// enclosing workflow's modes (durability-spec §3.8) and does not record its own.
+func validateTopology(wf *workflow, j *Journal) error {
+	if wf == nil || j == nil {
+		return JournalTopologyMismatch.New("cannot validate a nil workflow or journal")
+	}
+	if wf.Id() != j.WorkflowID {
+		return JournalTopologyMismatch.New(
+			"workflow id %q does not match journal %q", wf.Id(), j.WorkflowID)
+	}
+	if wf.executionMode != j.ExecutionMode {
+		return JournalTopologyMismatch.New(
+			"execution mode %q does not match journal %q",
+			wf.executionMode.String(), j.ExecutionMode.String())
+	}
+	if wf.rollbackMode != j.RollbackMode {
+		return JournalTopologyMismatch.New(
+			"rollback mode %q does not match journal %q",
+			wf.rollbackMode.String(), j.RollbackMode.String())
+	}
+	return validateStepsTopology(wf.Id(), wf.Steps(), j.Steps)
+}
+
+// validateStepsTopology compares an ordered list of definition steps against the
+// journal's step entries at one level, recursing into workflow steps. path names
+// the enclosing workflow for error messages.
+func validateStepsTopology(path string, steps []Step, entries []*StepJournal) error {
+	if len(steps) != len(entries) {
+		return JournalTopologyMismatch.New(
+			"workflow %q defines %d steps but journal records %d",
+			path, len(steps), len(entries))
+	}
+	for i, step := range steps {
+		entry := entries[i]
+		if step.Id() != entry.ID {
+			return JournalTopologyMismatch.New(
+				"workflow %q step %d: definition id %q does not match journal id %q",
+				path, i, step.Id(), entry.ID)
+		}
+		child, defIsWorkflow := step.(*workflow)
+		if defIsWorkflow != entry.IsWorkflow() {
+			return JournalTopologyMismatch.New(
+				"step %q: definition is %s but journal records %s",
+				entry.ID, stepKind(defIsWorkflow), stepKind(entry.IsWorkflow()))
+		}
+		if defIsWorkflow {
+			if err := validateStepsTopology(entry.ID, child.Steps(), entry.Steps); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func stepKind(isWorkflow bool) string {
+	if isWorkflow {
+		return "a workflow step"
+	}
+	return "a leaf step"
+}

--- a/journal_execution_test.go
+++ b/journal_execution_test.go
@@ -1,0 +1,175 @@
+package automa
+
+// Story 2 tests: a workflow with WithJournal produces a correct on-disk journal
+// as it runs. These are internal (package automa) so they can load the journal
+// with loadJournal and inspect the recorded transitions directly.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func journalPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "wf-run1.journal")
+}
+
+// TestJournal_ForwardSuccess checks the forward ordering (§5 F1/F4/D1): the
+// write-ahead marks a step started BEFORE its side effect, the commit marks it
+// completed with a snapshot AFTER, and the run ends terminal (done).
+func TestJournal_ForwardSuccess(t *testing.T) {
+	path := journalPath(t)
+
+	// Step a, mid-execute, MUST see itself started and (later) b sees a completed.
+	execA := func(ctx context.Context, stp Step) *Report {
+		j, err := loadJournal(path)
+		require.NoError(t, err)
+		assert.Equal(t, StepStarted, j.Steps[0].State, "a must be `started` during its own Execute (write-ahead)")
+		assert.Equal(t, StepPending, j.Steps[1].State, "b must still be pending while a runs")
+		return SuccessReport(stp)
+	}
+	execB := func(ctx context.Context, stp Step) *Report {
+		j, err := loadJournal(path)
+		require.NoError(t, err)
+		assert.Equal(t, StepCompleted, j.Steps[0].State, "a must be committed `completed` before b's side effect")
+		assert.Equal(t, StepStarted, j.Steps[1].State, "b must be `started` during its own Execute")
+		return SuccessReport(stp)
+	}
+
+	step, err := NewWorkflowBuilder().WithId("wf").
+		WithExecutionMode(RollbackOnError).
+		WithJournal(path).
+		Steps(
+			NewStepBuilder().WithId("a").WithExecute(execA),
+			NewStepBuilder().WithId("b").WithExecute(execB),
+		).Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+	require.True(t, report.IsSuccess(), "workflow should succeed")
+
+	j, err := loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseDone, j.Cursor.Phase, "terminal run must be `done`")
+	require.Len(t, j.Steps, 2)
+	assert.Equal(t, StepCompleted, j.Steps[0].State)
+	assert.Equal(t, StepCompleted, j.Steps[1].State)
+	assert.NotNil(t, j.Steps[0].Snapshot, "a completed leaf must carry a rollback snapshot")
+	assert.NotNil(t, j.Steps[0].Report, "a completed leaf must carry its report")
+}
+
+// TestJournal_FailureRollback checks that a failure under RollbackOnError flips
+// the phase to compensating (§5 F5) and records each compensated step (§5 C3),
+// including the failed step itself.
+func TestJournal_FailureRollback(t *testing.T) {
+	path := journalPath(t)
+
+	var phaseDuringRollbackOfA Phase
+	rollbackA := func(ctx context.Context, stp Step) *Report {
+		if j, err := loadJournal(path); err == nil {
+			phaseDuringRollbackOfA = j.Cursor.Phase
+		}
+		return SuccessReport(stp)
+	}
+
+	step, err := NewWorkflowBuilder().WithId("wf").
+		WithExecutionMode(RollbackOnError).
+		WithJournal(path).
+		Steps(
+			NewStepBuilder().WithId("a").
+				WithExecute(func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }).
+				WithRollback(rollbackA),
+			NewStepBuilder().WithId("b").
+				WithExecute(func(ctx context.Context, stp Step) *Report {
+					return FailureReport(stp, WithError(StepExecutionError.New("boom")))
+				}),
+		).Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+	require.True(t, report.IsFailed(), "workflow should fail")
+
+	assert.Equal(t, PhaseCompensating, phaseDuringRollbackOfA,
+		"phase must be compensating while a's Rollback runs")
+
+	j, err := loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseDone, j.Cursor.Phase, "run is terminal after rollback")
+	require.Len(t, j.Steps, 2)
+	assert.Equal(t, StepCompensated, j.Steps[0].State, "a (completed) must be compensated")
+	assert.Equal(t, StepCompensated, j.Steps[1].State, "b (failed) must be compensated for cleanup")
+}
+
+// TestJournal_Disabled_WritesNothing verifies WithJournal is opt-in: a workflow
+// built without it writes no file (backward compatibility).
+func TestJournal_Disabled_WritesNothing(t *testing.T) {
+	dir := t.TempDir()
+
+	step, err := NewWorkflowBuilder().WithId("wf").
+		WithExecutionMode(RollbackOnError).
+		Steps(
+			NewStepBuilder().WithId("a").WithExecute(func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }),
+		).Build()
+	require.NoError(t, err)
+
+	require.True(t, step.Execute(context.Background()).IsSuccess())
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "a workflow without WithJournal must write nothing to disk")
+}
+
+// TestJournal_Nested verifies a sub-workflow is journaled inline under its parent
+// step entry, recursively (§3.8): the parent entry is a workflow node carrying
+// its own cursor/shared/steps, each reaching done.
+func TestJournal_Nested(t *testing.T) {
+	path := journalPath(t)
+
+	ok := func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }
+	sub := NewWorkflowBuilder().WithId("sub").
+		Steps(
+			NewStepBuilder().WithId("x").WithExecute(ok),
+			NewStepBuilder().WithId("y").WithExecute(ok),
+		)
+	step, err := NewWorkflowBuilder().WithId("wf").
+		WithExecutionMode(RollbackOnError).
+		WithJournal(path).
+		Steps(
+			NewStepBuilder().WithId("a").WithExecute(ok),
+			sub,
+		).Build()
+	require.NoError(t, err)
+
+	require.True(t, step.Execute(context.Background()).IsSuccess())
+
+	j, err := loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseDone, j.Cursor.Phase)
+	require.Len(t, j.Steps, 2)
+
+	// steps[0] "a" is a leaf.
+	assert.False(t, j.Steps[0].IsWorkflow())
+	assert.Equal(t, StepCompleted, j.Steps[0].State)
+
+	// steps[1] "sub" is a workflow node with its own recursive run-state.
+	subEntry := j.Steps[1]
+	require.True(t, subEntry.IsWorkflow(), "sub must be a workflow node (has steps)")
+	assert.Equal(t, "sub", subEntry.ID)
+	assert.Equal(t, StepCompleted, subEntry.State, "sub step is completed once its node is done")
+	require.NotNil(t, subEntry.Cursor)
+	assert.Equal(t, PhaseDone, subEntry.Cursor.Phase, "sub node reached done")
+	require.NotNil(t, subEntry.Shared)
+	require.Len(t, subEntry.Steps, 2)
+	assert.Equal(t, StepCompleted, subEntry.Steps[0].State)
+	assert.Equal(t, StepCompleted, subEntry.Steps[1].State)
+
+	// The loaded journal must satisfy the schema invariants and match its own
+	// topology when validated against the definition.
+	require.NoError(t, j.validateStructure())
+	require.NoError(t, validateTopology(step.(*workflow), j))
+}

--- a/journal_execution_test.go
+++ b/journal_execution_test.go
@@ -6,7 +6,6 @@ package automa
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -107,22 +106,58 @@ func TestJournal_FailureRollback(t *testing.T) {
 }
 
 // TestJournal_Disabled_WritesNothing verifies WithJournal is opt-in: a workflow
-// built without it writes no file (backward compatibility).
+// built without it has journaling switched off (no persist closure), so every
+// transition is inert and nothing is written to disk (backward compatibility).
 func TestJournal_Disabled_WritesNothing(t *testing.T) {
-	dir := t.TempDir()
-
-	step, err := NewWorkflowBuilder().WithId("wf").
+	built, err := NewWorkflowBuilder().WithId("wf").
 		WithExecutionMode(RollbackOnError).
 		Steps(
 			NewStepBuilder().WithId("a").WithExecute(func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }),
 		).Build()
 	require.NoError(t, err)
 
-	require.True(t, step.Execute(context.Background()).IsSuccess())
+	wf, ok := built.(*workflow)
+	require.True(t, ok)
+	assert.Empty(t, wf.journalPath, "a workflow without WithJournal must have no journal path")
+	assert.Nil(t, wf.journalPersist, "no persist closure should be installed before Execute")
+	assert.False(t, wf.journaling(), "journaling must be disabled without WithJournal")
 
-	entries, err := os.ReadDir(dir)
+	require.True(t, wf.Execute(context.Background()).IsSuccess())
+
+	// After a full run the persist closure must still be nil: nothing was journaled.
+	assert.Nil(t, wf.journalPersist, "journaling must remain disabled through a full run")
+	assert.False(t, wf.journaling(), "journaling must remain disabled through a full run")
+}
+
+// TestJournal_ManualRollbackReachesDone verifies a directly-invoked Rollback of a
+// durable workflow leaves the journal terminal (`done`), not stuck in
+// `compensating`, so a later ResumeWorkflow does not re-enter compensation.
+func TestJournal_ManualRollbackReachesDone(t *testing.T) {
+	path := journalPath(t)
+	ok := func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }
+
+	built, err := NewWorkflowBuilder().WithId("wf").
+		WithExecutionMode(RollbackOnError).
+		WithJournal(path).
+		Steps(
+			NewStepBuilder().WithId("a").WithExecute(ok).WithRollback(ok),
+			NewStepBuilder().WithId("b").WithExecute(ok).WithRollback(ok),
+		).Build()
 	require.NoError(t, err)
-	assert.Empty(t, entries, "a workflow without WithJournal must write nothing to disk")
+	wf := built.(*workflow)
+
+	require.True(t, wf.Execute(context.Background()).IsSuccess())
+	j, err := loadJournal(path)
+	require.NoError(t, err)
+	require.Equal(t, PhaseDone, j.Cursor.Phase, "a successful run must end `done`")
+
+	// Manually roll the durable workflow back.
+	require.True(t, wf.Rollback(context.Background()).IsSuccess())
+
+	j, err = loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseDone, j.Cursor.Phase,
+		"manual rollback must mark the journal terminal (§5 D1), not leave it compensating")
 }
 
 // TestJournal_Nested verifies a sub-workflow is journaled inline under its parent

--- a/journal_execution_test.go
+++ b/journal_execution_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/joomcode/errorx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -172,4 +173,105 @@ func TestJournal_Nested(t *testing.T) {
 	// topology when validated against the definition.
 	require.NoError(t, j.validateStructure())
 	require.NoError(t, validateTopology(step.(*workflow), j))
+}
+
+// TestJournal_NestedStartedSnapshotCarriesParentGlobal is a regression test for
+// the write-ahead ordering of a sub-workflow (durability-spec §3.8): the parent
+// records the child `started` (F1) with the child's cloned Global BEFORE the child
+// runs, so the child node's `shared` snapshot on disk must already carry the
+// parent's Global. The sub-workflow's own WithPrepare runs in exactly that window
+// — after the parent's F1, before the child persists any of its own progress — so
+// it observes the parent's write-ahead snapshot of the child.
+func TestJournal_NestedStartedSnapshotCarriesParentGlobal(t *testing.T) {
+	path := journalPath(t)
+
+	var sawChildStarted bool
+	var sharedAtChildPrepare string
+
+	childPrepare := func(ctx context.Context, stp Step) (context.Context, error) {
+		j, err := loadJournal(path)
+		if err != nil {
+			return ctx, nil
+		}
+		if len(j.Steps) == 2 && j.Steps[1].IsWorkflow() {
+			sawChildStarted = j.Steps[1].State == StepStarted
+			if j.Steps[1].Shared != nil {
+				if v, ok := j.Steps[1].Shared.Global().String(Key("region")); ok {
+					sharedAtChildPrepare = v
+				}
+			}
+		}
+		return ctx, nil
+	}
+
+	seedGlobal := func(ctx context.Context, stp Step) *Report {
+		stp.State().Global().Set(Key("region"), "us-east-1")
+		return SuccessReport(stp)
+	}
+	ok := func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }
+
+	sub := NewWorkflowBuilder().WithId("sub").
+		WithPrepare(childPrepare).
+		Steps(NewStepBuilder().WithId("x").WithExecute(ok))
+
+	step, err := NewWorkflowBuilder().WithId("wf").
+		WithExecutionMode(RollbackOnError).
+		WithJournal(path).
+		Steps(
+			NewStepBuilder().WithId("a").WithExecute(seedGlobal),
+			sub,
+		).Build()
+	require.NoError(t, err)
+
+	require.True(t, step.Execute(context.Background()).IsSuccess())
+
+	assert.True(t, sawChildStarted, "child must be recorded `started` (F1) before it runs any inner step")
+	assert.Equal(t, "us-east-1", sharedAtChildPrepare,
+		"the F1 snapshot of the child node must carry the parent's Global (write-ahead ordering, §3.8)")
+}
+
+// TestJournal_WriteAheadFailureAbortsStep verifies the write-ahead contract
+// (durability-spec §5 F1): if the `started` record cannot be made durable, the
+// step's side effect MUST NOT run and the step fails with a JournalError, rather
+// than executing an effect that a crash could strand with no journal record.
+func TestJournal_WriteAheadFailureAbortsStep(t *testing.T) {
+	// A journal path inside a directory that does not exist makes every persist
+	// fail (the temp file cannot be created), so the write-ahead never becomes
+	// durable.
+	badPath := filepath.Join(t.TempDir(), "no-such-dir", "wf.journal")
+
+	var executed bool
+	step, err := NewWorkflowBuilder().WithId("wf").
+		WithExecutionMode(RollbackOnError).
+		WithJournal(badPath).
+		Steps(
+			NewStepBuilder().WithId("a").WithExecute(func(ctx context.Context, stp Step) *Report {
+				executed = true
+				return SuccessReport(stp)
+			}),
+		).Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+	require.True(t, report.IsFailed(), "run must fail when the write-ahead journal cannot be persisted")
+	assert.False(t, executed, "the side effect MUST NOT run when its write-ahead record is not durable")
+
+	// The failure must carry a JournalError so callers can distinguish a durability
+	// failure from an ordinary step failure.
+	var carriesJournalError func(r *Report) bool
+	carriesJournalError = func(r *Report) bool {
+		if r == nil {
+			return false
+		}
+		if r.Error != nil && errorx.IsOfType(r.Error, JournalError) {
+			return true
+		}
+		for _, c := range r.StepReports {
+			if carriesJournalError(c) {
+				return true
+			}
+		}
+		return false
+	}
+	assert.True(t, carriesJournalError(report), "failure must carry a JournalError")
 }

--- a/journal_resume_test.go
+++ b/journal_resume_test.go
@@ -31,6 +31,21 @@ func TestResume_EmptyJournalPathFailsFast(t *testing.T) {
 	assert.Equal(t, ActionPrepare, report.Action)
 }
 
+func TestRehydrateInto_FailsWhenSharedCloneFails(t *testing.T) {
+	wf := &workflow{
+		id:    "wf",
+		steps: []Step{&defaultStep{id: "a"}},
+	}
+	err := rehydrateInto(wf,
+		Cursor{Phase: PhaseForward, Index: 0},
+		&SyncNamespacedStateBag{global: &cloneErrStateBag{SyncStateBag: &SyncStateBag{}}},
+		[]*StepJournal{{ID: "a", State: StepPending}},
+		func() error { return nil },
+	)
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, JournalCorrupt), "want JournalCorrupt, got %v", err)
+}
+
 // resumeRecorder captures which steps run Execute / Rollback on resume.
 type resumeRecorder struct {
 	exec     []string
@@ -171,6 +186,24 @@ func TestResume_CorruptJournalFailsLoudly(t *testing.T) {
 	require.True(t, report.IsFailed())
 	assert.True(t, errorx.IsOfType(report.Error, JournalCorrupt), "want JournalCorrupt, got %v", report.Error)
 	assert.Empty(t, rec.exec, "nothing must run for a corrupt journal")
+}
+
+// TestResume_UnknownCursorPhaseFailsLoudly: a journal with an unrecognized phase
+// is rejected before any step can re-run.
+func TestResume_UnknownCursorPhaseFailsLoudly(t *testing.T) {
+	path := journalPath(t)
+	craftJournal(t, path, RollbackOnError, ContinueOnError, Phase("garbage"), 0, []*StepJournal{
+		{ID: "a", State: StepCompleted},
+	})
+
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsFailed())
+	assert.True(t, errorx.IsOfType(report.Error, JournalCorrupt), "want JournalCorrupt, got %v", report.Error)
+	assert.Empty(t, rec.exec, "nothing must run for an unknown phase")
 }
 
 // TestResume_MissingJournalRunsFresh: resuming a never-started run is a normal

--- a/journal_resume_test.go
+++ b/journal_resume_test.go
@@ -1,0 +1,238 @@
+package automa
+
+// Story 3 tests: the crash-and-resume scenarios. Each test hand-crafts an
+// on-disk journal representing a specific crash point, then calls ResumeWorkflow
+// with a fresh (identical) definition and asserts exactly which steps run. This
+// is deterministic where a real crash is not.
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resumeRecorder captures which steps run Execute / Rollback on resume.
+type resumeRecorder struct {
+	exec     []string
+	rollback []string
+}
+
+// recStep builds a leaf step that records its Execute and Rollback. execFail
+// makes its Execute return a failure report.
+func recStep(rec *resumeRecorder, id string, execFail bool) *StepBuilder {
+	return NewStepBuilder().WithId(id).
+		WithExecute(func(ctx context.Context, stp Step) *Report {
+			rec.exec = append(rec.exec, id)
+			if execFail {
+				return FailureReport(stp, WithError(StepExecutionError.New("fixture: %s failed", id)))
+			}
+			return SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp Step) *Report {
+			rec.rollback = append(rec.rollback, id)
+			return SuccessReport(stp)
+		})
+}
+
+// craftJournal writes a journal for workflow "wf" with the given modes, cursor,
+// and leaf step entries.
+func craftJournal(t *testing.T, path string, exec, rb TypeMode, phase Phase, idx int, entries []*StepJournal) {
+	t.Helper()
+	j := &Journal{
+		Version:       JournalVersion,
+		WorkflowID:    "wf",
+		ExecutionMode: exec,
+		RollbackMode:  rb,
+		Cursor:        Cursor{Phase: phase, Index: idx},
+		Shared:        &SyncNamespacedStateBag{},
+		Steps:         entries,
+	}
+	require.NoError(t, j.persist(path))
+}
+
+// TestResume_CrashAfterCommit_SkipsCompleted: a crash after a clean commit
+// leaves completed steps that MUST NOT re-run; the remaining steps run.
+func TestResume_CrashAfterCommit_SkipsCompleted(t *testing.T) {
+	path := journalPath(t)
+	craftJournal(t, path, RollbackOnError, ContinueOnError, PhaseForward, 0, []*StepJournal{
+		{ID: "a", State: StepCompleted},
+		{ID: "b", State: StepPending},
+	})
+
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), recStep(rec, "b", false))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsSuccess(), "resumed run should succeed")
+	assert.Equal(t, []string{"b"}, rec.exec, "only b should run; a was already completed")
+
+	j, err := loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseDone, j.Cursor.Phase)
+	assert.Equal(t, StepCompleted, j.Steps[1].State)
+}
+
+// TestResume_StartedStepRerunsOnce: a step recorded `started` but not
+// `completed` (the ambiguous case) re-runs exactly once on resume.
+func TestResume_StartedStepRerunsOnce(t *testing.T) {
+	path := journalPath(t)
+	craftJournal(t, path, RollbackOnError, ContinueOnError, PhaseForward, 1, []*StepJournal{
+		{ID: "a", State: StepCompleted},
+		{ID: "b", State: StepStarted},
+	})
+
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), recStep(rec, "b", false))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsSuccess())
+	assert.Equal(t, []string{"b"}, rec.exec, "b must re-run exactly once; a skipped")
+}
+
+// TestResume_ContinuesCompensation: a crash mid-compensation resumes the
+// rollback from the cursor, skipping already-compensated steps.
+func TestResume_ContinuesCompensation(t *testing.T) {
+	path := journalPath(t)
+	// Forward reached c and failed; c and b already compensated; a remains.
+	craftJournal(t, path, RollbackOnError, ContinueOnError, PhaseCompensating, 1, []*StepJournal{
+		{ID: "a", State: StepCompleted},
+		{ID: "b", State: StepCompensated},
+		{ID: "c", State: StepCompensated},
+	})
+
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), recStep(rec, "b", false), recStep(rec, "c", true))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsFailed(), "a compensated run is a failure outcome")
+	assert.Equal(t, []string{"a"}, rec.rollback, "only a remains to compensate; b and c already were")
+	assert.Empty(t, rec.exec, "no forward execution during compensation resume")
+
+	j, err := loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseDone, j.Cursor.Phase)
+	assert.Equal(t, StepCompensated, j.Steps[0].State)
+}
+
+// TestResume_TopologyMismatchRefused: a definition that no longer matches the
+// journal is refused, and nothing runs.
+func TestResume_TopologyMismatchRefused(t *testing.T) {
+	path := journalPath(t)
+	craftJournal(t, path, RollbackOnError, ContinueOnError, PhaseForward, 0, []*StepJournal{
+		{ID: "a", State: StepCompleted},
+		{ID: "b", State: StepPending},
+	})
+
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), recStep(rec, "different", false))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsFailed())
+	assert.True(t, errorx.IsOfType(report.Error, JournalTopologyMismatch),
+		"want a topology-mismatch error, got %v", report.Error)
+	assert.Empty(t, rec.exec, "nothing must run on a refused resume")
+}
+
+// TestResume_CorruptJournalFailsLoudly: a corrupt journal fails loudly and runs
+// nothing (never silently restarts).
+func TestResume_CorruptJournalFailsLoudly(t *testing.T) {
+	path := journalPath(t)
+	require.NoError(t, os.WriteFile(path, []byte("{ not json"), 0o600))
+
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), recStep(rec, "b", false))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsFailed())
+	assert.True(t, errorx.IsOfType(report.Error, JournalCorrupt), "want JournalCorrupt, got %v", report.Error)
+	assert.Empty(t, rec.exec, "nothing must run for a corrupt journal")
+}
+
+// TestResume_MissingJournalRunsFresh: resuming a never-started run is a normal
+// start and creates the journal.
+func TestResume_MissingJournalRunsFresh(t *testing.T) {
+	path := journalPath(t) // does not exist yet
+
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), recStep(rec, "b", false))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsSuccess())
+	assert.Equal(t, []string{"a", "b"}, rec.exec, "a fresh run executes every step")
+
+	j, err := loadJournal(path)
+	require.NoError(t, err, "a fresh resumed run must create the journal")
+	assert.Equal(t, PhaseDone, j.Cursor.Phase)
+}
+
+// TestResume_DonePhaseReturnsFinalRunsNothing: a terminal journal returns the
+// recorded result and executes/compensates nothing.
+func TestResume_DonePhaseReturnsFinalRunsNothing(t *testing.T) {
+	path := journalPath(t)
+	craftJournal(t, path, RollbackOnError, ContinueOnError, PhaseDone, 1, []*StepJournal{
+		{ID: "a", State: StepCompleted},
+		{ID: "b", State: StepCompleted},
+	})
+
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), recStep(rec, "b", false))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsSuccess(), "a done journal with all steps completed returns success")
+	assert.Empty(t, rec.exec, "a terminal resume runs nothing")
+	assert.Empty(t, rec.rollback)
+}
+
+// TestResume_EndToEnd_CrashThenResume exercises the real S2→S3 integration: a
+// first attempt journals a completed and then crashes mid-b (simulated with a
+// panic, which leaves b `started` because its write-ahead persisted before the
+// side effect). A resume with a healthy b re-runs only b, exactly once.
+func TestResume_EndToEnd_CrashThenResume(t *testing.T) {
+	path := journalPath(t)
+
+	// First attempt: a succeeds, b crashes after its write-ahead record.
+	func() {
+		defer func() { _ = recover() }()
+		wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).WithJournal(path).
+			Steps(
+				recStep(&resumeRecorder{}, "a", false),
+				NewStepBuilder().WithId("b").WithExecute(func(ctx context.Context, stp Step) *Report {
+					panic("simulated crash during b")
+				}),
+			)
+		step, err := wb.Build()
+		require.NoError(t, err)
+		_ = step.Execute(context.Background())
+	}()
+
+	// The engine-written journal captures the crash point: a completed, b started.
+	j, err := loadJournal(path)
+	require.NoError(t, err)
+	require.Equal(t, PhaseForward, j.Cursor.Phase)
+	require.Equal(t, StepCompleted, j.Steps[0].State)
+	require.Equal(t, StepStarted, j.Steps[1].State, "b's write-ahead must have persisted before the crash")
+
+	// Resume with a healthy b.
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), recStep(rec, "b", false))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsSuccess())
+	assert.Equal(t, []string{"b"}, rec.exec, "resume re-runs only b; a stays completed")
+
+	j2, err := loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseDone, j2.Cursor.Phase)
+}

--- a/journal_resume_test.go
+++ b/journal_resume_test.go
@@ -236,3 +236,125 @@ func TestResume_EndToEnd_CrashThenResume(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, PhaseDone, j2.Cursor.Phase)
 }
+
+// TestResume_EndToEnd_NestedForwardCrashThenResume exercises a crash INSIDE a
+// sub-workflow's forward loop. On resume, only the in-progress inner step
+// re-runs (the parent step and the completed inner step are skipped), and the
+// re-run inner step still sees the shared state its earlier sibling wrote —
+// proving the sub-workflow's rehydrated state is preserved, not re-cloned from
+// the parent (durability-spec §3.8/§6).
+func TestResume_EndToEnd_NestedForwardCrashThenResume(t *testing.T) {
+	path := journalPath(t)
+
+	// First attempt: a succeeds; sub.x writes shared state and completes; sub.y
+	// crashes (panic) after its write-ahead.
+	func() {
+		defer func() { _ = recover() }()
+		sub := NewWorkflowBuilder().WithId("sub").
+			Steps(
+				NewStepBuilder().WithId("x").WithExecute(func(ctx context.Context, stp Step) *Report {
+					stp.State().Global().Set(Key("fromX"), "present")
+					return SuccessReport(stp)
+				}),
+				NewStepBuilder().WithId("y").WithExecute(func(ctx context.Context, stp Step) *Report {
+					panic("simulated crash during sub.y")
+				}),
+			)
+		wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).WithJournal(path).
+			Steps(
+				NewStepBuilder().WithId("a").WithExecute(func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }),
+				sub,
+			)
+		step, err := wb.Build()
+		require.NoError(t, err)
+		_ = step.Execute(context.Background())
+	}()
+
+	// The journal captures: a completed; sub started with x completed, y started.
+	j, err := loadJournal(path)
+	require.NoError(t, err)
+	require.Equal(t, PhaseForward, j.Cursor.Phase)
+	require.Equal(t, StepCompleted, j.Steps[0].State)
+	subEntry := j.Steps[1]
+	require.True(t, subEntry.IsWorkflow())
+	require.Equal(t, StepStarted, subEntry.State)
+	require.Equal(t, StepCompleted, subEntry.Steps[0].State, "sub.x committed before the crash")
+	require.Equal(t, StepStarted, subEntry.Steps[1].State, "sub.y's write-ahead persisted before the crash")
+
+	// Resume with a healthy sub.y that reads what sub.x wrote.
+	rec := &resumeRecorder{}
+	var yObservedFromX string
+	subResume := NewWorkflowBuilder().WithId("sub").
+		Steps(
+			recStep(rec, "x", false),
+			NewStepBuilder().WithId("y").WithExecute(func(ctx context.Context, stp Step) *Report {
+				rec.exec = append(rec.exec, "y")
+				if v, ok := stp.State().Global().String(Key("fromX")); ok {
+					yObservedFromX = v
+				}
+				return SuccessReport(stp)
+			}),
+		)
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), subResume)
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsSuccess())
+	assert.Equal(t, []string{"y"}, rec.exec, "resume must re-run only sub.y; a and sub.x are skipped")
+	assert.Equal(t, "present", yObservedFromX,
+		"sub.y must see the shared state sub.x wrote before the crash (rehydrated, not re-cloned from parent)")
+
+	j2, err := loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseDone, j2.Cursor.Phase)
+	assert.Equal(t, StepCompleted, j2.Steps[1].Steps[1].State, "sub.y completed on resume")
+}
+
+// TestResume_NestedCompensationContinues covers a crash while a sub-workflow was
+// compensating itself: on resume the sub-workflow finishes its own rollback
+// (skipping already-compensated inner steps), which then drives the parent's
+// compensation of the earlier sibling — with no step compensated twice (D10).
+func TestResume_NestedCompensationContinues(t *testing.T) {
+	path := journalPath(t)
+
+	// parent: forward, working on sub (index 1); a completed and awaiting rollback.
+	// sub: compensating at index 0; inner q already compensated, p still to go.
+	j := &Journal{
+		Version:       JournalVersion,
+		WorkflowID:    "wf",
+		ExecutionMode: RollbackOnError,
+		RollbackMode:  ContinueOnError,
+		Cursor:        Cursor{Phase: PhaseForward, Index: 1},
+		Shared:        &SyncNamespacedStateBag{},
+		Steps: []*StepJournal{
+			{ID: "a", State: StepCompleted},
+			{
+				ID:     "sub",
+				State:  StepStarted,
+				Cursor: &Cursor{Phase: PhaseCompensating, Index: 0},
+				Shared: &SyncNamespacedStateBag{},
+				Steps: []*StepJournal{
+					{ID: "p", State: StepCompleted},
+					{ID: "q", State: StepCompensated},
+				},
+			},
+		},
+	}
+	require.NoError(t, j.persist(path))
+
+	rec := &resumeRecorder{}
+	subResume := NewWorkflowBuilder().WithId("sub").
+		Steps(recStep(rec, "p", false), recStep(rec, "q", false))
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), subResume)
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsFailed())
+	assert.Empty(t, rec.exec, "no forward execution when resuming into compensation")
+	assert.Equal(t, []string{"p", "a"}, rec.rollback,
+		"sub finishes with p (q already compensated), then the parent compensates a; nothing twice")
+
+	j2, err := loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseDone, j2.Cursor.Phase)
+}

--- a/journal_resume_test.go
+++ b/journal_resume_test.go
@@ -15,6 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestResume_EmptyJournalPathFailsFast verifies ResumeWorkflow rejects an empty
+// path with IllegalArgument/ActionPrepare rather than silently starting a fresh,
+// un-journaled run (loadJournal("") reports os.ErrNotExist).
+func TestResume_EmptyJournalPathFailsFast(t *testing.T) {
+	wb := NewWorkflowBuilder().WithId("wf").
+		WithExecutionMode(RollbackOnError).
+		Steps(NewStepBuilder().WithId("a").
+			WithExecute(func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }))
+
+	report := ResumeWorkflow(context.Background(), wb, "")
+	require.True(t, report.IsFailed(), "empty journalPath must fail")
+	assert.True(t, errorx.IsOfType(report.Error, IllegalArgument),
+		"empty journalPath must fail as IllegalArgument, got %v", report.Error)
+	assert.Equal(t, ActionPrepare, report.Action)
+}
+
 // resumeRecorder captures which steps run Execute / Rollback on resume.
 type resumeRecorder struct {
 	exec     []string

--- a/journal_runtime.go
+++ b/journal_runtime.go
@@ -31,10 +31,12 @@ func (w *workflow) initJournalProgress() {
 	w.jStepReports = make([]*Report, n)
 }
 
-// persistJournal writes the whole root journal atomically. A write failure is
-// logged but does not fail the workflow: the journal is a recovery aid, and
-// aborting a run that is otherwise progressing would trade a recoverable state
-// for an unrecoverable one.
+// persistJournal writes the whole root journal atomically, tolerating failure.
+// It is used at the *commit* points (F4/C3/D1), which record an outcome AFTER a
+// side effect has already run: a lost commit record only means resume re-executes
+// (or re-compensates) a step the idempotency contract (§7) already requires to be
+// safe, so aborting an otherwise-progressing run would trade a recoverable state
+// for an unrecoverable one. A write failure is therefore logged, not returned.
 func (w *workflow) persistJournal() {
 	if w.journalPersist == nil {
 		return
@@ -42,6 +44,19 @@ func (w *workflow) persistJournal() {
 	if err := w.journalPersist(); err != nil {
 		w.log().Warn("failed to persist durability journal", "workflowId", w.id, "error", err)
 	}
+}
+
+// persistJournalCritical writes the journal and returns any error. It is used at
+// the *write-ahead* points (F1 started, F5 enter-compensating), where the spec
+// forbids proceeding unless the record is durable (durability-spec §5): running a
+// side effect — or beginning compensation — without a durable record can strand an
+// effect that resume can neither observe nor compensate. The caller MUST abort the
+// step (or the rollback) when this returns an error.
+func (w *workflow) persistJournalCritical() error {
+	if w.journalPersist == nil {
+		return nil
+	}
+	return w.journalPersist()
 }
 
 // nodeCursor returns this node's cursor, defaulting an unset phase to forward so
@@ -123,15 +138,16 @@ func (w *workflow) stepStateAt(i int) StepState {
 // journalStepStarted records the write-ahead entry for the step at index i:
 // state `started` and the forward cursor, persisted BEFORE the step's side
 // effect runs (§5 F1). An implementation MUST NOT run a side effect before its
-// started record is durable.
-func (w *workflow) journalStepStarted(i int) {
+// started record is durable, so this returns the persist error and the caller
+// MUST NOT execute the step when it is non-nil.
+func (w *workflow) journalStepStarted(i int) error {
 	if !w.journaling() {
-		return
+		return nil
 	}
 	w.jPhase = PhaseForward
 	w.jIndex = i
 	w.jStepStates[i] = StepStarted
-	w.persistJournal()
+	return w.persistJournalCritical()
 }
 
 // journalStepCommitted records the commit entry for the step at index i: its
@@ -153,14 +169,17 @@ func (w *workflow) journalStepCommitted(i int, state StepState, snapshot *SyncNa
 }
 
 // journalEnterCompensating flips this node to the compensating phase with the
-// cursor at index i, persisted before compensation begins (§5 F5).
-func (w *workflow) journalEnterCompensating(i int) {
+// cursor at index i, persisted before compensation begins (§5 F5). This is a
+// write-ahead point: it returns the persist error and the caller MUST NOT begin
+// compensation when it is non-nil, since a crash mid-rollback would leave a
+// journal that still reads as forward and resume would re-run instead of continue.
+func (w *workflow) journalEnterCompensating(i int) error {
 	if !w.journaling() {
-		return
+		return nil
 	}
 	w.jPhase = PhaseCompensating
 	w.jIndex = i
-	w.persistJournal()
+	return w.persistJournalCritical()
 }
 
 // journalStepCompensated records that the step at index i has been compensated,

--- a/journal_runtime.go
+++ b/journal_runtime.go
@@ -1,0 +1,188 @@
+package automa
+
+// Runtime journaling for a running workflow (Durability Story 2). These helpers
+// project a workflow's live progress into the on-disk journal (journal.go) and
+// persist it atomically at the ordering points defined by durability-spec §5.
+//
+// The journal is a *projection*: each workflow instance owns its own progress
+// fields (jPhase/jIndex and the per-step slices); snapshotJournal derives the
+// full recursive tree from them on demand. The only cross-node coupling is the
+// persist closure — the root installs it and every sub-workflow inherits it, so
+// any node's transition rewrites the single shared file atomically (§3.6, §3.8).
+//
+// All of this is inert unless the workflow was made durable with WithJournal:
+// journaling reports false and every transition returns immediately.
+
+// journaling reports whether this workflow instance writes a journal.
+func (w *workflow) journaling() bool { return w.journalPersist != nil }
+
+// initJournalProgress prepares this node's progress fields for a run: forward
+// phase at index 0, with per-step slices sized to the topology (all steps
+// pending). It is called at the start of Execute for every journaling node.
+func (w *workflow) initJournalProgress() {
+	w.jPhase = PhaseForward
+	w.jIndex = 0
+	n := len(w.steps)
+	w.jStepStates = make([]StepState, n)
+	for i := range w.jStepStates {
+		w.jStepStates[i] = StepPending
+	}
+	w.jStepSnapshots = make([]*SyncNamespacedStateBag, n)
+	w.jStepReports = make([]*Report, n)
+}
+
+// persistJournal writes the whole root journal atomically. A write failure is
+// logged but does not fail the workflow: the journal is a recovery aid, and
+// aborting a run that is otherwise progressing would trade a recoverable state
+// for an unrecoverable one.
+func (w *workflow) persistJournal() {
+	if w.journalPersist == nil {
+		return
+	}
+	if err := w.journalPersist(); err != nil {
+		w.log().Warn("failed to persist durability journal", "workflowId", w.id, "error", err)
+	}
+}
+
+// nodeCursor returns this node's cursor, defaulting an unset phase to forward so
+// a not-yet-run node projects sensibly.
+func (w *workflow) nodeCursor() Cursor {
+	phase := w.jPhase
+	if phase == "" {
+		phase = PhaseForward
+	}
+	return Cursor{Phase: phase, Index: w.jIndex}
+}
+
+// sharedSnapshot captures this workflow's shared state — the Global namespace,
+// with an empty Local — for the journal's `shared` field (durability-spec §3.3).
+// A clone failure degrades to an empty bag rather than failing the run.
+func (w *workflow) sharedSnapshot() *SyncNamespacedStateBag {
+	global, err := w.State().Global().Clone()
+	if err != nil {
+		w.log().Warn("failed to clone global state for journal snapshot", "workflowId", w.id, "error", err)
+		global = nil
+	}
+	return NewNamespacedStateBag(nil, global)
+}
+
+// snapshotJournal projects the live workflow tree into a *Journal (the top-level
+// node). It is the writer counterpart of the journal schema (durability-spec
+// §3.3/§3.8) and is recomputed at every persist point.
+func (w *workflow) snapshotJournal() *Journal {
+	return &Journal{
+		Version:       JournalVersion,
+		WorkflowID:    w.id,
+		ExecutionMode: w.executionMode,
+		RollbackMode:  w.rollbackMode,
+		Cursor:        w.nodeCursor(),
+		Shared:        w.sharedSnapshot(),
+		Steps:         w.snapshotSteps(),
+	}
+}
+
+// snapshotSteps projects this node's step entries in topology order. A step that
+// is itself a workflow contributes its own recursive run-state trio
+// (cursor/shared/steps); a leaf contributes its optional snapshot and report.
+// The projection is nil-tolerant so a not-yet-run node reads as all pending.
+func (w *workflow) snapshotSteps() []*StepJournal {
+	out := make([]*StepJournal, len(w.steps))
+	for i, s := range w.steps {
+		e := &StepJournal{ID: s.Id(), State: w.stepStateAt(i)}
+		if child, ok := s.(*workflow); ok {
+			cursor := child.nodeCursor()
+			e.Cursor = &cursor
+			e.Shared = child.sharedSnapshot()
+			e.Steps = child.snapshotSteps()
+		} else {
+			if i < len(w.jStepSnapshots) {
+				e.Snapshot = w.jStepSnapshots[i]
+			}
+			if i < len(w.jStepReports) {
+				e.Report = w.jStepReports[i]
+			}
+		}
+		out[i] = e
+	}
+	return out
+}
+
+// stepStateAt returns the recorded state of the step at index i, defaulting to
+// pending when progress has not been recorded yet.
+func (w *workflow) stepStateAt(i int) StepState {
+	if i < len(w.jStepStates) && w.jStepStates[i] != "" {
+		return w.jStepStates[i]
+	}
+	return StepPending
+}
+
+// ---------------------------------------------------------------------------
+// Transition points (durability-spec §5). Each is a no-op unless journaling.
+// ---------------------------------------------------------------------------
+
+// journalStepStarted records the write-ahead entry for the step at index i:
+// state `started` and the forward cursor, persisted BEFORE the step's side
+// effect runs (§5 F1). An implementation MUST NOT run a side effect before its
+// started record is durable.
+func (w *workflow) journalStepStarted(i int) {
+	if !w.journaling() {
+		return
+	}
+	w.jPhase = PhaseForward
+	w.jIndex = i
+	w.jStepStates[i] = StepStarted
+	w.persistJournal()
+}
+
+// journalStepCommitted records the commit entry for the step at index i: its
+// final state (completed/failed), its rollback snapshot (leaf steps only; pass
+// nil for a workflow step), and its report, persisted AFTER the side effect
+// returns (§5 F4).
+func (w *workflow) journalStepCommitted(i int, state StepState, snapshot *SyncNamespacedStateBag, report *Report) {
+	if !w.journaling() {
+		return
+	}
+	w.jStepStates[i] = state
+	if snapshot != nil {
+		w.jStepSnapshots[i] = snapshot
+	}
+	if report != nil {
+		w.jStepReports[i] = report
+	}
+	w.persistJournal()
+}
+
+// journalEnterCompensating flips this node to the compensating phase with the
+// cursor at index i, persisted before compensation begins (§5 F5).
+func (w *workflow) journalEnterCompensating(i int) {
+	if !w.journaling() {
+		return
+	}
+	w.jPhase = PhaseCompensating
+	w.jIndex = i
+	w.persistJournal()
+}
+
+// journalStepCompensated records that the step at index i has been compensated,
+// with the cursor at i, persisted before compensation proceeds to a lower index
+// (§5 C3) so an interrupted rollback does not repeat it.
+func (w *workflow) journalStepCompensated(i int) {
+	if !w.journaling() {
+		return
+	}
+	if i >= 0 && i < len(w.jStepStates) {
+		w.jStepStates[i] = StepCompensated
+	}
+	w.jIndex = i
+	w.persistJournal()
+}
+
+// journalDone marks this node terminal (§5 D1). The run is finished; no further
+// step transitions occur. Retention/deletion policy is applied by the caller.
+func (w *workflow) journalDone() {
+	if !w.journaling() {
+		return
+	}
+	w.jPhase = PhaseDone
+	w.persistJournal()
+}

--- a/journal_runtime.go
+++ b/journal_runtime.go
@@ -71,44 +71,56 @@ func (w *workflow) nodeCursor() Cursor {
 
 // sharedSnapshot captures this workflow's shared state — the Global namespace,
 // with an empty Local — for the journal's `shared` field (durability-spec §3.3).
-// A clone failure degrades to an empty bag rather than failing the run.
-func (w *workflow) sharedSnapshot() *SyncNamespacedStateBag {
+// Clone failure is fatal to the snapshot so we never persist an empty shared
+// bag in place of real state.
+func (w *workflow) sharedSnapshot() (*SyncNamespacedStateBag, error) {
 	global, err := w.State().Global().Clone()
 	if err != nil {
 		w.log().Warn("failed to clone global state for journal snapshot", "workflowId", w.id, "error", err)
-		global = nil
+		return nil, err
 	}
-	return NewNamespacedStateBag(nil, global)
+	return NewNamespacedStateBag(nil, global), nil
 }
 
 // snapshotJournal projects the live workflow tree into a *Journal (the top-level
 // node). It is the writer counterpart of the journal schema (durability-spec
 // §3.3/§3.8) and is recomputed at every persist point.
-func (w *workflow) snapshotJournal() *Journal {
+func (w *workflow) snapshotJournal() (*Journal, error) {
+	shared, err := w.sharedSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	steps, err := w.snapshotSteps()
+	if err != nil {
+		return nil, err
+	}
 	return &Journal{
 		Version:       JournalVersion,
 		WorkflowID:    w.id,
 		ExecutionMode: w.executionMode,
 		RollbackMode:  w.rollbackMode,
 		Cursor:        w.nodeCursor(),
-		Shared:        w.sharedSnapshot(),
-		Steps:         w.snapshotSteps(),
-	}
+		Shared:        shared,
+		Steps:         steps,
+	}, nil
 }
 
 // snapshotSteps projects this node's step entries in topology order. A step that
 // is itself a workflow contributes its own recursive run-state trio
 // (cursor/shared/steps); a leaf contributes its optional snapshot and report.
 // The projection is nil-tolerant so a not-yet-run node reads as all pending.
-func (w *workflow) snapshotSteps() []*StepJournal {
+func (w *workflow) snapshotSteps() ([]*StepJournal, error) {
 	out := make([]*StepJournal, len(w.steps))
 	for i, s := range w.steps {
 		e := &StepJournal{ID: s.Id(), State: w.stepStateAt(i)}
 		if child, ok := s.(*workflow); ok {
-			cursor := child.nodeCursor()
-			e.Cursor = &cursor
-			e.Shared = child.sharedSnapshot()
-			e.Steps = child.snapshotSteps()
+			childJournal, err := child.snapshotJournal()
+			if err != nil {
+				return nil, err
+			}
+			e.Cursor = &childJournal.Cursor
+			e.Shared = childJournal.Shared
+			e.Steps = childJournal.Steps
 		} else {
 			if i < len(w.jStepSnapshots) {
 				e.Snapshot = w.jStepSnapshots[i]
@@ -119,7 +131,7 @@ func (w *workflow) snapshotSteps() []*StepJournal {
 		}
 		out[i] = e
 	}
-	return out
+	return out, nil
 }
 
 // stepStateAt returns the recorded state of the step at index i, defaulting to

--- a/journal_runtime_test.go
+++ b/journal_runtime_test.go
@@ -1,0 +1,24 @@
+package automa
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type cloneErrStateBag struct{ *SyncStateBag }
+
+func (b *cloneErrStateBag) Clone() (StateBag, error) { return nil, errors.New("clone failed") }
+
+func TestWorkflow_SnapshotJournalFailsWhenGlobalCloneFails(t *testing.T) {
+	wf := &workflow{
+		id:    "wf",
+		state: NewNamespacedStateBag(nil, &cloneErrStateBag{SyncStateBag: &SyncStateBag{}}),
+		steps: []Step{&defaultStep{id: "s"}},
+	}
+
+	j, err := wf.snapshotJournal()
+	require.Error(t, err)
+	require.Nil(t, j)
+}

--- a/journal_test.go
+++ b/journal_test.go
@@ -190,6 +190,21 @@ func TestLoadJournal_MissingFileIsNotExist(t *testing.T) {
 		"missing journal must be detectable with errors.Is(os.ErrNotExist) for the fresh-run case")
 }
 
+// TestLoadJournal_NullStepEntryFailsLoudly verifies a null element in a steps
+// array (`"steps": [null]`) is treated as corruption and fails loudly on load,
+// rather than panicking on a nil *StepJournal dereference.
+func TestLoadJournal_NullStepEntryFailsLoudly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wf.journal")
+	raw := `{"version":1,"workflow_id":"wf","execution_mode":"rollback","rollback_mode":"continue",` +
+		`"cursor":{"phase":"forward","index":0},"shared":{"local":{},"global":{}},"steps":[null]}`
+	require.NoError(t, os.WriteFile(path, []byte(raw), 0o600))
+
+	_, err := loadJournal(path)
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, JournalCorrupt),
+		"a null step entry must fail as JournalCorrupt, got %v", err)
+}
+
 func TestLoadJournal_CorruptFailsLoudly(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "corrupt.journal")

--- a/journal_test.go
+++ b/journal_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,37 +127,60 @@ func TestJournal_PersistIsAtomic(t *testing.T) {
 	var stop atomic.Bool
 	var wg sync.WaitGroup
 
+	// Failures are reported back to the test goroutine via channels: calling
+	// require.* (t.FailNow) from a non-test goroutine is unsafe.
+	writerErr := make(chan error, 1)
+	readerErr := make(chan error, 1)
+
 	// Writer: rewrite the journal repeatedly.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		defer stop.Store(true)
 		for i := 0; i < writes; i++ {
 			j := sampleJournal()
 			j.Cursor.Index = i % 2 // vary the content between writes
-			require.NoError(t, j.persist(path))
+			if err := j.persist(path); err != nil {
+				writerErr <- fmt.Errorf("persist %d: %w", i, err)
+				return
+			}
 		}
-		stop.Store(true)
 	}()
 
-	// Reader: every read must decode to a complete, valid journal.
+	// Reader: every read must decode to a complete, valid journal. Because the
+	// rename is atomic, the target always exists — the old file survives until the
+	// new one replaces it — so ANY read error (including os.ErrNotExist) is an
+	// atomicity violation, and a decode failure means the reader saw a torn file.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		for !stop.Load() {
 			data, err := os.ReadFile(path)
 			if err != nil {
-				// A missing target would violate atomicity (rename is atomic;
-				// the old file exists until the new one replaces it).
-				assert.Truef(t, errors.Is(err, os.ErrNotExist), "unexpected read error: %v", err)
-				continue
+				readerErr <- fmt.Errorf("read observed a missing/unreadable target (atomicity violation): %w", err)
+				return
 			}
 			var j Journal
-			require.NoErrorf(t, json.Unmarshal(data, &j), "reader observed a torn file")
-			assert.Equal(t, JournalVersion, j.Version)
+			if err := json.Unmarshal(data, &j); err != nil {
+				readerErr <- fmt.Errorf("reader observed a torn file: %w", err)
+				return
+			}
+			if j.Version != JournalVersion {
+				readerErr <- fmt.Errorf("reader observed version %d, want %d", j.Version, JournalVersion)
+				return
+			}
 		}
 	}()
 
 	wg.Wait()
+	close(writerErr)
+	close(readerErr)
+	for err := range writerErr {
+		t.Errorf("writer goroutine: %v", err)
+	}
+	for err := range readerErr {
+		t.Errorf("reader goroutine: %v", err)
+	}
 }
 
 func TestLoadJournal_MissingFileIsNotExist(t *testing.T) {

--- a/journal_test.go
+++ b/journal_test.go
@@ -239,6 +239,21 @@ func TestJournal_ValidateStructure_Invariants(t *testing.T) {
 	}{
 		{name: "valid", mutate: func(*Journal) {}, wantErr: false},
 		{
+			name:    "top-level cursor out of range",
+			mutate:  func(j *Journal) { j.Cursor.Index = 100 },
+			wantErr: true,
+		},
+		{
+			name:    "top-level cursor unknown phase",
+			mutate:  func(j *Journal) { j.Cursor.Phase = Phase("garbage") },
+			wantErr: true,
+		},
+		{
+			name:    "top-level shared missing",
+			mutate:  func(j *Journal) { j.Shared = nil },
+			wantErr: true,
+		},
+		{
 			name:    "leaf carries a cursor",
 			mutate:  func(j *Journal) { j.Steps[0].Cursor = &Cursor{Phase: PhaseForward} },
 			wantErr: true,
@@ -256,6 +271,33 @@ func TestJournal_ValidateStructure_Invariants(t *testing.T) {
 		{
 			name:    "empty step id",
 			mutate:  func(j *Journal) { j.Steps[0].ID = "" },
+			wantErr: true,
+		},
+		{
+			name:    "leaf has unknown state",
+			mutate:  func(j *Journal) { j.Steps[0].State = StepState("quantum") },
+			wantErr: true,
+		},
+		{
+			name: "done cursor ignores index",
+			mutate: func(j *Journal) {
+				j.Cursor.Phase = PhaseDone
+				j.Cursor.Index = 100
+			},
+			wantErr: false,
+		},
+		{
+			name: "nested workflow cursor out of range",
+			mutate: func(j *Journal) {
+				j.Steps[1].Cursor.Index = 99
+			},
+			wantErr: true,
+		},
+		{
+			name: "nested workflow step has unknown state",
+			mutate: func(j *Journal) {
+				j.Steps[1].Steps[0].State = StepState("quantum")
+			},
 			wantErr: true,
 		},
 	}
@@ -279,6 +321,17 @@ func TestValidateTopology_MatchAndMismatch(t *testing.T) {
 
 	// Exact match succeeds.
 	require.NoError(t, validateTopology(wf, sampleJournal()))
+
+	t.Run("pending workflow may be leaf-shaped", func(t *testing.T) {
+		j := sampleJournal()
+		j.Steps[1] = &StepJournal{
+			ID:       "sub",
+			State:    StepPending,
+			Snapshot: &SyncNamespacedStateBag{},
+			Report:   SuccessReport(&defaultStep{id: "sub"}),
+		}
+		require.NoError(t, validateTopology(wf, j))
+	})
 
 	tests := []struct {
 		name   string

--- a/journal_test.go
+++ b/journal_test.go
@@ -1,0 +1,270 @@
+package automa
+
+// Unit tests for the durability journal foundation (Story 1): journal types and
+// the atomic persist / load / validateTopology primitives. These are internal
+// (package automa) because they exercise unexported helpers; the cross-language
+// round-trip guarantees live in the conformance harness (conformance_test.go).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func noopExec(_ context.Context, stp Step) *Report { return SuccessReport(stp) }
+
+// sampleJournal returns a small but structurally complete journal: a top-level
+// workflow with one leaf step and one nested workflow step.
+func sampleJournal() *Journal {
+	return &Journal{
+		Version:       JournalVersion,
+		WorkflowID:    "wf",
+		ExecutionMode: RollbackOnError,
+		RollbackMode:  ContinueOnError,
+		Cursor:        Cursor{Phase: PhaseForward, Index: 1},
+		Shared:        &SyncNamespacedStateBag{},
+		Steps: []*StepJournal{
+			{ID: "a", State: StepCompleted, Snapshot: &SyncNamespacedStateBag{}},
+			{
+				ID:     "sub",
+				State:  StepStarted,
+				Cursor: &Cursor{Phase: PhaseForward, Index: 0},
+				Shared: &SyncNamespacedStateBag{},
+				Steps: []*StepJournal{
+					{ID: "x", State: StepCompleted},
+					{ID: "y", State: StepPending},
+				},
+			},
+		},
+	}
+}
+
+// sampleWorkflow builds the workflow definition that matches sampleJournal.
+func sampleWorkflow(t *testing.T) *workflow {
+	t.Helper()
+	sub := NewWorkflowBuilder().WithId("sub").
+		WithExecutionMode(RollbackOnError).WithRollbackMode(ContinueOnError).
+		Steps(
+			NewStepBuilder().WithId("x").WithExecute(noopExec),
+			NewStepBuilder().WithId("y").WithExecute(noopExec),
+		)
+	wb := NewWorkflowBuilder().WithId("wf").
+		WithExecutionMode(RollbackOnError).WithRollbackMode(ContinueOnError).
+		Steps(
+			NewStepBuilder().WithId("a").WithExecute(noopExec),
+			sub,
+		)
+	step, err := wb.Build()
+	require.NoError(t, err)
+	wf, ok := step.(*workflow)
+	require.True(t, ok, "expected a *workflow")
+	return wf
+}
+
+func TestJournal_JSONRoundTripsLosslessly(t *testing.T) {
+	j := sampleJournal()
+	data, err := json.Marshal(j)
+	require.NoError(t, err)
+
+	var got Journal
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	// Re-serialize and compare structurally: a lossless round-trip.
+	again, err := json.Marshal(&got)
+	require.NoError(t, err)
+
+	var a, b interface{}
+	require.NoError(t, json.Unmarshal(data, &a))
+	require.NoError(t, json.Unmarshal(again, &b))
+	assert.Equal(t, a, b, "journal did not round-trip losslessly")
+
+	// Spot-check that the recursive structure survived.
+	require.Len(t, got.Steps, 2)
+	assert.False(t, got.Steps[0].IsWorkflow(), "leaf step must not be a workflow node")
+	assert.True(t, got.Steps[1].IsWorkflow(), "nested step must be a workflow node")
+	require.NotNil(t, got.Steps[1].Cursor)
+	assert.Equal(t, PhaseForward, got.Steps[1].Cursor.Phase)
+}
+
+func TestJournal_PersistThenLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wf-run1.journal")
+
+	require.NoError(t, sampleJournal().persist(path))
+
+	loaded, err := loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, "wf", loaded.WorkflowID)
+	assert.Equal(t, RollbackOnError, loaded.ExecutionMode)
+	require.Len(t, loaded.Steps, 2)
+
+	// No stray temp files were left behind.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "persist must leave only the target file")
+}
+
+// TestJournal_PersistIsAtomic verifies the all-or-nothing guarantee (§3.6): a
+// concurrent reader always observes a complete journal, never a torn file, even
+// while the writer rewrites the snapshot many times.
+func TestJournal_PersistIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wf-run1.journal")
+	require.NoError(t, sampleJournal().persist(path))
+
+	const writes = 200
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+
+	// Writer: rewrite the journal repeatedly.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < writes; i++ {
+			j := sampleJournal()
+			j.Cursor.Index = i % 2 // vary the content between writes
+			require.NoError(t, j.persist(path))
+		}
+		stop.Store(true)
+	}()
+
+	// Reader: every read must decode to a complete, valid journal.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				// A missing target would violate atomicity (rename is atomic;
+				// the old file exists until the new one replaces it).
+				assert.Truef(t, errors.Is(err, os.ErrNotExist), "unexpected read error: %v", err)
+				continue
+			}
+			var j Journal
+			require.NoErrorf(t, json.Unmarshal(data, &j), "reader observed a torn file")
+			assert.Equal(t, JournalVersion, j.Version)
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestLoadJournal_MissingFileIsNotExist(t *testing.T) {
+	_, err := loadJournal(filepath.Join(t.TempDir(), "does-not-exist.journal"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrNotExist),
+		"missing journal must be detectable with errors.Is(os.ErrNotExist) for the fresh-run case")
+}
+
+func TestLoadJournal_CorruptFailsLoudly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.journal")
+	require.NoError(t, os.WriteFile(path, []byte("{not valid json"), 0o600))
+
+	_, err := loadJournal(path)
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, JournalCorrupt), "corrupt journal must fail as JournalCorrupt, got %v", err)
+}
+
+func TestLoadJournal_UnsupportedVersionFailsLoudly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "future.journal")
+	j := sampleJournal()
+	data, err := json.Marshal(j)
+	require.NoError(t, err)
+	// Rewrite the version to an unsupported one.
+	bumped := strings.Replace(string(data), `"version":1`, `"version":999`, 1)
+	require.NoError(t, os.WriteFile(path, []byte(bumped), 0o600))
+
+	_, err = loadJournal(path)
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, JournalUnsupportedVersion),
+		"unsupported version must fail as JournalUnsupportedVersion, got %v", err)
+}
+
+func TestJournal_ValidateStructure_Invariants(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(j *Journal)
+		wantErr bool
+	}{
+		{name: "valid", mutate: func(*Journal) {}, wantErr: false},
+		{
+			name:    "leaf carries a cursor",
+			mutate:  func(j *Journal) { j.Steps[0].Cursor = &Cursor{Phase: PhaseForward} },
+			wantErr: true,
+		},
+		{
+			name:    "workflow step missing shared",
+			mutate:  func(j *Journal) { j.Steps[1].Shared = nil },
+			wantErr: true,
+		},
+		{
+			name:    "workflow step carries a leaf snapshot",
+			mutate:  func(j *Journal) { j.Steps[1].Snapshot = &SyncNamespacedStateBag{} },
+			wantErr: true,
+		},
+		{
+			name:    "empty step id",
+			mutate:  func(j *Journal) { j.Steps[0].ID = "" },
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			j := sampleJournal()
+			tc.mutate(j)
+			err := j.validateStructure()
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.True(t, errorx.IsOfType(err, JournalCorrupt), "want JournalCorrupt, got %v", err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateTopology_MatchAndMismatch(t *testing.T) {
+	wf := sampleWorkflow(t)
+
+	// Exact match succeeds.
+	require.NoError(t, validateTopology(wf, sampleJournal()))
+
+	tests := []struct {
+		name   string
+		mutate func(j *Journal)
+	}{
+		{"workflow id", func(j *Journal) { j.WorkflowID = "other" }},
+		{"execution mode", func(j *Journal) { j.ExecutionMode = StopOnError }},
+		{"rollback mode", func(j *Journal) { j.RollbackMode = StopOnError }},
+		{"step count", func(j *Journal) { j.Steps = j.Steps[:1] }},
+		{"step order", func(j *Journal) { j.Steps[0].ID, j.Steps[1].ID = j.Steps[1].ID, j.Steps[0].ID }},
+		{"nested step id", func(j *Journal) { j.Steps[1].Steps[0].ID = "zzz" }},
+		{"kind mismatch (leaf vs workflow)", func(j *Journal) {
+			// Make the definition's workflow step appear as a leaf in the journal.
+			j.Steps[1].Steps = nil
+			j.Steps[1].Cursor = nil
+			j.Steps[1].Shared = nil
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			j := sampleJournal()
+			tc.mutate(j)
+			err := validateTopology(wf, j)
+			require.Error(t, err)
+			assert.True(t, errorx.IsOfType(err, JournalTopologyMismatch), "want JournalTopologyMismatch, got %v", err)
+		})
+	}
+}

--- a/resume.go
+++ b/resume.go
@@ -62,9 +62,10 @@ func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string
 	j, err := loadJournal(journalPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			// Missing journal → fresh run, journaled at this path (§6.2).
+			// Missing journal → fresh run, journaled at this path (§6.2). Execute
+			// owns Prepare (see RunWorkflow), so start it directly.
 			wf.journalPath = journalPath
-			return resumeFreshRun(ctx, wf, start)
+			return wf.Execute(ctx)
 		}
 		// Corrupt or unsupported version → fail loudly, never restart (§6.2).
 		return FailureReport(wf,
@@ -111,34 +112,10 @@ func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string
 	case PhaseCompensating:
 		return wf.resumeCompensation(ctx, start)
 	default: // PhaseForward
-		preparedCtx, perr := wf.Prepare(ctx)
-		if perr != nil {
-			return FailureReport(wf,
-				WithWorkflow(wf),
-				WithActionType(ActionPrepare),
-				WithStartTime(start),
-				WithError(StepExecutionError.
-					Wrap(perr, "workflow %q preparation failed on resume", wf.Id()).
-					WithProperty(StepIdProperty, wf.Id())))
-		}
-		return wf.Execute(preparedCtx)
+		// Execute owns Prepare (see RunWorkflow) and is resume-aware via the
+		// progress rehydrated above.
+		return wf.Execute(ctx)
 	}
-}
-
-// resumeFreshRun runs a never-journaled workflow from the start, mirroring
-// RunWorkflow (Prepare then Execute).
-func resumeFreshRun(ctx context.Context, wf *workflow, start time.Time) *Report {
-	preparedCtx, err := wf.Prepare(ctx)
-	if err != nil {
-		return FailureReport(wf,
-			WithWorkflow(wf),
-			WithActionType(ActionPrepare),
-			WithStartTime(start),
-			WithError(StepExecutionError.
-				Wrap(err, "workflow %q preparation failed", wf.Id()).
-				WithProperty(StepIdProperty, wf.Id())))
-	}
-	return wf.Execute(preparedCtx)
 }
 
 // rehydrateInto loads a journal node's recorded progress onto workflow w and

--- a/resume.go
+++ b/resume.go
@@ -98,9 +98,21 @@ func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string
 	// definition (§6.1). Every node shares the one closure, so continued
 	// execution keeps rewriting the single journal file atomically.
 	root := wf
-	persist := func() error { return root.snapshotJournal().persist(journalPath) }
+	persist := func() error {
+		j, err := root.snapshotJournal()
+		if err != nil {
+			return err
+		}
+		return j.persist(journalPath)
+	}
 	wf.journalPath = journalPath
-	rehydrateInto(wf, j.Cursor, j.Shared, j.Steps, persist)
+	if err := rehydrateInto(wf, j.Cursor, j.Shared, j.Steps, persist); err != nil {
+		return FailureReport(wf,
+			WithWorkflow(wf),
+			WithActionType(ActionPrepare),
+			WithStartTime(start),
+			WithError(err))
+	}
 
 	switch j.Cursor.Phase {
 	case PhaseDone:
@@ -108,10 +120,16 @@ func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string
 		return wf.reconstructFinalReport(start)
 	case PhaseCompensating:
 		return wf.resumeCompensation(ctx, start)
-	default: // PhaseForward
+	case PhaseForward:
 		// Execute owns Prepare (see RunWorkflow) and is resume-aware via the
 		// progress rehydrated above.
 		return wf.Execute(ctx)
+	default:
+		return FailureReport(wf,
+			WithWorkflow(wf),
+			WithActionType(ActionPrepare),
+			WithStartTime(start),
+			WithError(JournalCorrupt.New("journal cursor has unknown phase %q", j.Cursor.Phase)))
 	}
 }
 
@@ -120,17 +138,20 @@ func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string
 // installs the shared persist closure, restores the shared (Global) state and
 // the per-step cursor/state/snapshot/report, and rebuilds the executed and
 // compensated sets so a continued forward run or rollback behaves correctly.
-func rehydrateInto(w *workflow, cursor Cursor, shared *SyncNamespacedStateBag, steps []*StepJournal, persist func() error) {
+func rehydrateInto(w *workflow, cursor Cursor, shared *SyncNamespacedStateBag, steps []*StepJournal, persist func() error) error {
 	w.resuming = true
 	w.journalPersist = persist
 	w.jPhase = cursor.Phase
 	w.jIndex = cursor.Index
 
 	// Restore this node's shared (Global) state onto its live bag (§6.1.3).
-	if shared != nil {
-		if g, err := shared.Global().Clone(); err == nil {
-			w.state = NewNamespacedStateBag(nil, g)
-		}
+	if shared == nil {
+		return JournalCorrupt.New("workflow %q is missing shared state", w.id)
+	}
+	if g, err := shared.Global().Clone(); err != nil {
+		return JournalCorrupt.Wrap(err, "workflow %q failed to restore shared state", w.id)
+	} else {
+		w.state = NewNamespacedStateBag(nil, g)
 	}
 
 	n := len(w.steps)
@@ -170,9 +191,12 @@ func rehydrateInto(w *workflow, cursor Cursor, shared *SyncNamespacedStateBag, s
 			if e.Cursor != nil {
 				childCursor = *e.Cursor
 			}
-			rehydrateInto(child, childCursor, e.Shared, e.Steps, persist)
+			if err := rehydrateInto(child, childCursor, e.Shared, e.Steps, persist); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 // resumeChildStep resumes an in-progress sub-workflow by dispatching on its own
@@ -187,8 +211,14 @@ func (w *workflow) resumeChildStep(ctx context.Context, child *workflow) *Report
 	case PhaseDone:
 		// Already terminal (an unusual crash window); return its recorded result.
 		return child.reconstructFinalReport(time.Now())
-	default: // PhaseForward
+	case PhaseForward:
 		return child.Execute(ctx)
+	default:
+		return FailureReport(child,
+			WithWorkflow(w),
+			WithActionType(ActionExecute),
+			WithStartTime(time.Now()),
+			WithError(JournalCorrupt.New("journal cursor has unknown phase %q", child.jPhase)))
 	}
 }
 

--- a/resume.go
+++ b/resume.go
@@ -36,6 +36,18 @@ import (
 func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string) *Report {
 	start := time.Now()
 
+	// An empty path is a programming error: loadJournal("") reports os.ErrNotExist,
+	// which would otherwise be taken as a fresh run and silently execute WITHOUT a
+	// journal (journalPath == "" disables journaling in Execute). Fail fast instead.
+	if journalPath == "" {
+		return NewReport(wb.Id(),
+			WithWorkflow(wb.workflow),
+			WithStatus(StatusFailed),
+			WithActionType(ActionPrepare),
+			WithStartTime(start),
+			WithError(IllegalArgument.New("ResumeWorkflow requires a non-empty journalPath")))
+	}
+
 	built, err := wb.Build()
 	if err != nil {
 		return NewReport(wb.Id(),

--- a/resume.go
+++ b/resume.go
@@ -1,0 +1,292 @@
+package automa
+
+// Resume (Durability Story 3): the public recovery entry point. ResumeWorkflow
+// rehydrates a journal onto a re-supplied workflow definition and continues from
+// where a previous run left off — skipping work already committed, re-running
+// the one ambiguous step, or finishing an interrupted rollback. The behavior is
+// the normative durability spec §6; this is the Go reference implementation.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+)
+
+// ResumeWorkflow recovers a run from its journal at journalPath and continues it
+// (durability-spec §6). The caller MUST re-supply the same workflow definition
+// (the same builder) that produced the original run; the topology and modes are
+// validated against the journal before anything runs.
+//
+//   - Missing journal → a fresh run is started and journaled at journalPath
+//     (resuming a never-started run is a normal start, §6.2).
+//   - Corrupt or unsupported-version journal → fails loudly and runs nothing;
+//     silently restarting could re-execute side effects (§6.2).
+//   - Topology/mode mismatch → refused (§6.2).
+//   - PhaseForward → completed steps are skipped, a started-but-not-completed
+//     step is re-executed once (idempotency contract, §7), execution continues.
+//   - PhaseCompensating → rollback continues from the cursor, skipping steps
+//     already compensated.
+//   - PhaseDone → the recorded final result is returned; nothing runs (§6.5).
+//
+// Limitation (this story): resuming into an in-progress (`started`) sub-workflow
+// — a crash that happened while a nested workflow's forward loop was running — is
+// not yet supported and is refused loudly rather than risking re-execution of
+// the sub-workflow's already-completed inner steps. Fully-completed and
+// not-yet-started sub-workflows resume normally, as does compensation of nested
+// workflows.
+func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string) *Report {
+	start := time.Now()
+
+	built, err := wb.Build()
+	if err != nil {
+		return NewReport(wb.Id(),
+			WithWorkflow(wb.workflow),
+			WithStatus(StatusFailed),
+			WithActionType(ActionPrepare),
+			WithStartTime(start),
+			WithError(StepExecutionError.
+				Wrap(err, "workflow %q build failed", wb.Id()).
+				WithProperty(StepIdProperty, wb.Id()),
+			))
+	}
+	wf, ok := built.(*workflow)
+	if !ok {
+		return NewReport(wb.Id(),
+			WithStatus(StatusFailed),
+			WithActionType(ActionPrepare),
+			WithStartTime(start),
+			WithError(StepExecutionError.New("workflow %q did not build to a *workflow", wb.Id())))
+	}
+
+	j, err := loadJournal(journalPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Missing journal → fresh run, journaled at this path (§6.2).
+			wf.journalPath = journalPath
+			return resumeFreshRun(ctx, wf, start)
+		}
+		// Corrupt or unsupported version → fail loudly, never restart (§6.2).
+		return FailureReport(wf,
+			WithWorkflow(wf),
+			WithActionType(ActionPrepare),
+			WithStartTime(start),
+			WithError(err))
+	}
+
+	// Topology/mode agreement gate (§6.2).
+	if err := validateTopology(wf, j); err != nil {
+		return FailureReport(wf,
+			WithWorkflow(wf),
+			WithActionType(ActionPrepare),
+			WithStartTime(start),
+			WithError(err))
+	}
+
+	// Refuse the one unsupported case up front (see the doc comment): a forward
+	// resume that would descend into a `started` sub-workflow.
+	if j.Cursor.Phase == PhaseForward {
+		if id := firstStartedSubWorkflow(j.Steps); id != "" {
+			return FailureReport(wf,
+				WithWorkflow(wf),
+				WithActionType(ActionPrepare),
+				WithStartTime(start),
+				WithError(JournalError.New(
+					"resuming into in-progress sub-workflow %q is not yet supported", id)))
+		}
+	}
+
+	// Install the root persist closure and rehydrate the whole tree onto the
+	// definition (§6.1). Every node shares the one closure, so continued
+	// execution keeps rewriting the single journal file atomically.
+	root := wf
+	persist := func() error { return root.snapshotJournal().persist(journalPath) }
+	wf.journalPath = journalPath
+	rehydrateInto(wf, j.Cursor, j.Shared, j.Steps, persist)
+
+	switch j.Cursor.Phase {
+	case PhaseDone:
+		// Terminal: return the recorded result, run nothing (§6.5).
+		return wf.reconstructFinalReport(start)
+	case PhaseCompensating:
+		return wf.resumeCompensation(ctx, start)
+	default: // PhaseForward
+		preparedCtx, perr := wf.Prepare(ctx)
+		if perr != nil {
+			return FailureReport(wf,
+				WithWorkflow(wf),
+				WithActionType(ActionPrepare),
+				WithStartTime(start),
+				WithError(StepExecutionError.
+					Wrap(perr, "workflow %q preparation failed on resume", wf.Id()).
+					WithProperty(StepIdProperty, wf.Id())))
+		}
+		return wf.Execute(preparedCtx)
+	}
+}
+
+// resumeFreshRun runs a never-journaled workflow from the start, mirroring
+// RunWorkflow (Prepare then Execute).
+func resumeFreshRun(ctx context.Context, wf *workflow, start time.Time) *Report {
+	preparedCtx, err := wf.Prepare(ctx)
+	if err != nil {
+		return FailureReport(wf,
+			WithWorkflow(wf),
+			WithActionType(ActionPrepare),
+			WithStartTime(start),
+			WithError(StepExecutionError.
+				Wrap(err, "workflow %q preparation failed", wf.Id()).
+				WithProperty(StepIdProperty, wf.Id())))
+	}
+	return wf.Execute(preparedCtx)
+}
+
+// rehydrateInto loads a journal node's recorded progress onto workflow w and
+// recurses into sub-workflow steps (durability-spec §6.1). It marks w resuming,
+// installs the shared persist closure, restores the shared (Global) state and
+// the per-step cursor/state/snapshot/report, and rebuilds the executed and
+// compensated sets so a continued forward run or rollback behaves correctly.
+func rehydrateInto(w *workflow, cursor Cursor, shared *SyncNamespacedStateBag, steps []*StepJournal, persist func() error) {
+	w.resuming = true
+	w.journalPersist = persist
+	w.jPhase = cursor.Phase
+	w.jIndex = cursor.Index
+
+	// Restore this node's shared (Global) state onto its live bag (§6.1.3).
+	if shared != nil {
+		if g, err := shared.Global().Clone(); err == nil {
+			w.state = NewNamespacedStateBag(nil, g)
+		}
+	}
+
+	n := len(w.steps)
+	w.jStepStates = make([]StepState, n)
+	w.jStepSnapshots = make([]*SyncNamespacedStateBag, n)
+	w.jStepReports = make([]*Report, n)
+	if w.compensatedStepIDs == nil {
+		w.compensatedStepIDs = make(map[string]struct{})
+	}
+	w.lastExecutedStepIDs = make(map[string]struct{})
+	w.lastExecutionStates = make(map[string]NamespacedStateBag)
+
+	for i := 0; i < n && i < len(steps); i++ {
+		e := steps[i]
+		w.jStepStates[i] = e.State
+		if e.Snapshot != nil {
+			w.jStepSnapshots[i] = e.Snapshot
+			w.lastExecutionStates[e.ID] = e.Snapshot
+		}
+		if e.Report != nil {
+			w.jStepReports[i] = e.Report
+		}
+		switch e.State {
+		case StepCompleted, StepFailed, StepCompensated:
+			// These states all imply the step reached Execute, so it is eligible
+			// for compensation (D5 / §5.3).
+			w.lastExecutedStepIDs[e.ID] = struct{}{}
+		}
+		if e.State == StepCompensated {
+			w.compensatedStepIDs[e.ID] = struct{}{}
+		}
+
+		// Recurse into a sub-workflow step so nested compensation resumes with the
+		// child's own state, executed set, and already-compensated set.
+		if child, ok := w.steps[i].(*workflow); ok && e.IsWorkflow() {
+			childCursor := Cursor{Phase: PhaseForward}
+			if e.Cursor != nil {
+				childCursor = *e.Cursor
+			}
+			rehydrateInto(child, childCursor, e.Shared, e.Steps, persist)
+		}
+	}
+}
+
+// resumeCompensation continues an interrupted rollback from the recorded cursor
+// (durability-spec §6.4). Already-compensated steps are skipped (their IDs are
+// in compensatedStepIDs, rehydrated above); rollbackFrom journals each remaining
+// compensation. The run is then marked terminal.
+func (w *workflow) resumeCompensation(ctx context.Context, start time.Time) *Report {
+	rollbackReports := w.rollbackFrom(ctx, w.jIndex, w.lastExecutionStates, w.lastExecutedStepIDs)
+
+	stepReports := make([]*Report, 0, len(w.steps))
+	for i, s := range w.steps {
+		rep := w.jStepReports[i]
+		if rep == nil {
+			rep = FailureReport(s, WithWorkflow(w), WithActionType(ActionExecute), WithStartTime(start))
+		}
+		if rb, ok := rollbackReports[s.Id()]; ok {
+			rep.Rollback = rb
+		}
+		stepReports = append(stepReports, rep)
+	}
+
+	w.journalDone()
+
+	return FailureReport(w,
+		WithWorkflow(w),
+		WithActionType(ActionExecute),
+		WithStartTime(start),
+		WithStepReports(stepReports...),
+		WithError(StepExecutionError.New("workflow %q resumed and completed compensation", w.id)))
+}
+
+// reconstructFinalReport rebuilds a terminal run's report from the journal
+// (durability-spec §6.5). The journal records per-step outcomes but not a single
+// top-level report, so the workflow status is derived: success iff every step is
+// completed; otherwise failed (a fully-compensated run is a failure that rolled
+// back cleanly).
+func (w *workflow) reconstructFinalReport(start time.Time) *Report {
+	stepReports := make([]*Report, 0, len(w.steps))
+	anyNotCompleted := false
+	for i, s := range w.steps {
+		state := w.stepStateAt(i)
+		if state != StepCompleted {
+			anyNotCompleted = true
+		}
+		rep := w.jStepReports[i]
+		if rep == nil {
+			switch state {
+			case StepCompleted:
+				rep = SuccessReport(s, WithWorkflow(w), WithActionType(ActionExecute), WithStartTime(start))
+			case StepFailed:
+				rep = FailureReport(s, WithWorkflow(w), WithActionType(ActionExecute), WithStartTime(start))
+			default:
+				rep = SkippedReport(s, WithWorkflow(w), WithActionType(ActionExecute), WithStartTime(start))
+			}
+		}
+		stepReports = append(stepReports, rep)
+	}
+
+	if anyNotCompleted {
+		return FailureReport(w,
+			WithWorkflow(w),
+			WithActionType(ActionExecute),
+			WithStartTime(start),
+			WithStepReports(stepReports...),
+			WithError(StepExecutionError.New("workflow %q resumed from a terminal (non-success) journal", w.id)))
+	}
+	return SuccessReport(w,
+		WithWorkflow(w),
+		WithActionType(ActionExecute),
+		WithStartTime(start),
+		WithStepReports(stepReports...))
+}
+
+// firstStartedSubWorkflow returns the ID of the first sub-workflow step (at any
+// depth) recorded as `started`, or "" if none. Such a step would require
+// descending into an in-progress nested forward loop, which resume does not yet
+// support.
+func firstStartedSubWorkflow(steps []*StepJournal) string {
+	for _, e := range steps {
+		if !e.IsWorkflow() {
+			continue
+		}
+		if e.State == StepStarted {
+			return e.ID
+		}
+		if id := firstStartedSubWorkflow(e.Steps); id != "" {
+			return id
+		}
+	}
+	return ""
+}

--- a/resume.go
+++ b/resume.go
@@ -29,12 +29,10 @@ import (
 //     already compensated.
 //   - PhaseDone → the recorded final result is returned; nothing runs (§6.5).
 //
-// Limitation (this story): resuming into an in-progress (`started`) sub-workflow
-// — a crash that happened while a nested workflow's forward loop was running — is
-// not yet supported and is refused loudly rather than risking re-execution of
-// the sub-workflow's already-completed inner steps. Fully-completed and
-// not-yet-started sub-workflows resume normally, as does compensation of nested
-// workflows.
+// Sub-workflows resume recursively (§3.8): a nested workflow that was in
+// progress at the crash is resumed by dispatching on its own cursor phase
+// (forward, compensating, or done), so its already-completed inner steps are not
+// re-executed.
 func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string) *Report {
 	start := time.Now()
 
@@ -82,19 +80,6 @@ func ResumeWorkflow(ctx context.Context, wb *WorkflowBuilder, journalPath string
 			WithActionType(ActionPrepare),
 			WithStartTime(start),
 			WithError(err))
-	}
-
-	// Refuse the one unsupported case up front (see the doc comment): a forward
-	// resume that would descend into a `started` sub-workflow.
-	if j.Cursor.Phase == PhaseForward {
-		if id := firstStartedSubWorkflow(j.Steps); id != "" {
-			return FailureReport(wf,
-				WithWorkflow(wf),
-				WithActionType(ActionPrepare),
-				WithStartTime(start),
-				WithError(JournalError.New(
-					"resuming into in-progress sub-workflow %q is not yet supported", id)))
-		}
 	}
 
 	// Install the root persist closure and rehydrate the whole tree onto the
@@ -178,6 +163,23 @@ func rehydrateInto(w *workflow, cursor Cursor, shared *SyncNamespacedStateBag, s
 	}
 }
 
+// resumeChildStep resumes an in-progress sub-workflow by dispatching on its own
+// cursor phase (durability-spec §3.8, §6.4). The child was already rehydrated by
+// rehydrateInto, so this continues it from where it crashed: forward execution,
+// an interrupted compensation, or (defensively) a terminal node.
+func (w *workflow) resumeChildStep(ctx context.Context, child *workflow) *Report {
+	switch child.jPhase {
+	case PhaseCompensating:
+		// The child was rolling itself back when the crash hit; finish it.
+		return child.resumeCompensation(ctx, time.Now())
+	case PhaseDone:
+		// Already terminal (an unusual crash window); return its recorded result.
+		return child.reconstructFinalReport(time.Now())
+	default: // PhaseForward
+		return child.Execute(ctx)
+	}
+}
+
 // resumeCompensation continues an interrupted rollback from the recorded cursor
 // (durability-spec §6.4). Already-compensated steps are skipped (their IDs are
 // in compensatedStepIDs, rehydrated above); rollbackFrom journals each remaining
@@ -247,23 +249,4 @@ func (w *workflow) reconstructFinalReport(start time.Time) *Report {
 		WithActionType(ActionExecute),
 		WithStartTime(start),
 		WithStepReports(stepReports...))
-}
-
-// firstStartedSubWorkflow returns the ID of the first sub-workflow step (at any
-// depth) recorded as `started`, or "" if none. Such a step would require
-// descending into an in-progress nested forward loop, which resume does not yet
-// support.
-func firstStartedSubWorkflow(steps []*StepJournal) string {
-	for _, e := range steps {
-		if !e.IsWorkflow() {
-			continue
-		}
-		if e.State == StepStarted {
-			return e.ID
-		}
-		if id := firstStartedSubWorkflow(e.Steps); id != "" {
-			return id
-		}
-	}
-	return ""
 }

--- a/workflow.go
+++ b/workflow.go
@@ -105,6 +105,30 @@ type workflow struct {
 	// when Execute is called via RunWorkflow (which calls Prepare explicitly before Execute).
 	prepared bool
 
+	// --- durability journaling (opt-in via WithJournal; Durability Story 2) ---
+	//
+	// journalPath is the on-disk journal file path. It is set only on the root
+	// workflow (via WithJournal); an empty path disables journaling. Sub-workflows
+	// never carry a path — they persist through the root's closure (below).
+	journalPath string
+
+	// journalPersist writes the entire root journal atomically (durability-spec
+	// §3.6). The root installs this closure at the start of Execute; every
+	// sub-workflow inherits the same closure, so any node's transition rewrites
+	// the single shared file. A nil closure means journaling is off for this
+	// instance, and every journal* transition is a no-op.
+	journalPersist func() error
+
+	// jPhase/jIndex are this node's cursor (durability-spec §3.4); the per-step
+	// slices are aligned with steps by index and record each step's journal state,
+	// its rollback snapshot (leaf steps only), and its report. They are populated
+	// as the node runs and read by snapshotJournal to project the on-disk tree.
+	jPhase         Phase
+	jIndex         int
+	jStepStates    []StepState
+	jStepSnapshots []*SyncNamespacedStateBag
+	jStepReports   []*Report
+
 	// callbacks and hooks
 	prepare      PrepareFunc
 	rollback     RollbackFunc // optional user-defined rollback function for the entire workflow
@@ -178,6 +202,12 @@ func (w *workflow) rollbackFrom(ctx context.Context, index int, states map[strin
 	// map panics); the compensate-once set (D10) must always be usable.
 	if w.compensatedStepIDs == nil {
 		w.compensatedStepIDs = make(map[string]struct{})
+	}
+
+	// Entering the compensating phase (durability-spec §5). Set here in addition
+	// to Execute's F5 so a manually-invoked Rollback also records the phase.
+	if w.journaling() {
+		w.jPhase = PhaseCompensating
 	}
 
 	for i := index; i >= 0; i-- {
@@ -255,6 +285,11 @@ func (w *workflow) rollbackFrom(ctx context.Context, index int, states map[strin
 		// a manual Rollback after an automatic one) does not compensate it again
 		// (spec §5.3.5 / D10).
 		w.compensatedStepIDs[step.Id()] = struct{}{}
+
+		// C3 (durability-spec §5): record this step compensated with the cursor at
+		// i, persisted before compensation proceeds to a lower index so an
+		// interrupted rollback does not repeat it.
+		w.journalStepCompensated(i)
 
 		if rollbackReport.IsFailed() {
 			w.log().Warn("step rollback failed",
@@ -422,6 +457,24 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		"rollbackMode", w.rollbackMode.String(),
 	)
 
+	// Install journaling for this run (durability-spec §5). The root workflow —
+	// the one given a path via WithJournal — installs the persist closure that
+	// rewrites the whole journal atomically; sub-workflows inherit it (attached at
+	// their write-ahead point below), so any node's transition rewrites the single
+	// shared file.
+	if w.journalPath != "" && w.journalPersist == nil {
+		root := w
+		w.journalPersist = func() error { return root.snapshotJournal().persist(root.journalPath) }
+	}
+	if w.journaling() {
+		w.initJournalProgress()
+		// Write the initial forward/0 journal from the root so a crash before the
+		// first step still leaves a complete, valid journal on disk.
+		if w.journalPath != "" {
+			w.persistJournal()
+		}
+	}
+
 	var stepReports []*Report
 	var hasFailed bool
 
@@ -434,6 +487,17 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 	for index, step := range w.steps {
 		var report *Report
 		stepStart := time.Now()
+
+		// F1 write-ahead (durability-spec §5): record `started` and the forward
+		// cursor and persist BEFORE any side effect runs. A sub-workflow step
+		// inherits the root persist closure here so its own transitions journal
+		// inline under this entry (§3.8).
+		if w.journaling() {
+			if child, ok := step.(*workflow); ok {
+				child.journalPersist = w.journalPersist
+			}
+			w.journalStepStarted(index)
+		}
 
 		stepCtx := ctx
 		var stepState NamespacedStateBag
@@ -550,6 +614,23 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		// collect step report
 		stepReports = append(stepReports, report)
 
+		// F4 commit (durability-spec §5): record the step's outcome, its rollback
+		// snapshot (leaf steps only), and its report, persisted AFTER the side
+		// effect returns and before the next step's write-ahead.
+		if w.journaling() {
+			stepState := StepCompleted
+			if report.IsFailed() {
+				stepState = StepFailed
+			}
+			var snapshot *SyncNamespacedStateBag
+			if _, isWorkflowStep := step.(*workflow); !isWorkflowStep {
+				if s, ok := stepStates[step.Id()].(*SyncNamespacedStateBag); ok {
+					snapshot = s
+				}
+			}
+			w.journalStepCommitted(index, stepState, snapshot, report)
+		}
+
 		// check for step failure
 		if report.IsFailed() {
 			hasFailed = true
@@ -570,6 +651,10 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 					"fromIndex", index,
 					"rollbackMode", w.rollbackMode.String(),
 				)
+
+				// F5 (durability-spec §5): flip the phase to compensating with the
+				// cursor at the failed step, persisted before compensation begins.
+				w.journalEnterCompensating(index)
 
 				// Perform rollback using recorded per-step states
 				// Rollback from index (include the failed step for cleanup)
@@ -621,6 +706,9 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 			)),
 			WithStepReports(stepReports...))
 
+		// D1 (durability-spec §5): the run is terminal.
+		w.journalDone()
+
 		w.handleFailure(ctx, workflowReport)
 
 		return workflowReport
@@ -637,6 +725,9 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		WithStartTime(startTime),
 		WithActionType(ActionExecute),
 		WithStepReports(stepReports...))
+
+	// D1 (durability-spec §5): the run is terminal.
+	w.journalDone()
 
 	w.handleCompletion(ctx, workflowReport)
 

--- a/workflow.go
+++ b/workflow.go
@@ -465,7 +465,13 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 	// shared file.
 	if w.journalPath != "" && w.journalPersist == nil {
 		root := w
-		w.journalPersist = func() error { return root.snapshotJournal().persist(root.journalPath) }
+		w.journalPersist = func() error {
+			j, err := root.snapshotJournal()
+			if err != nil {
+				return err
+			}
+			return j.persist(root.journalPath)
+		}
 	}
 	if w.journaling() && !w.resuming {
 		w.initJournalProgress()

--- a/workflow.go
+++ b/workflow.go
@@ -506,6 +506,54 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 			continue
 		}
 
+		// Resume descent (durability-spec §3.8/§6.4): a sub-workflow recorded
+		// in progress (`started`) is resumed by dispatching on its OWN cursor
+		// phase — never re-run from scratch, which would re-execute its completed
+		// inner steps. It keeps the state rehydrated onto it (re-cloning the
+		// parent's global here would discard the divergence its inner steps
+		// produced), so this bypasses the normal per-step state prep below. A
+		// `started` leaf is not handled here — it falls through and re-runs.
+		if w.resuming && w.stepStateAt(index) == StepStarted {
+			if child, isWorkflowStep := step.(*workflow); isWorkflowStep {
+				w.journalStepStarted(index) // re-affirm started; brackets the descent
+				report = w.resumeChildStep(ctx, child)
+				if report == nil {
+					report = FailureReport(child,
+						WithWorkflow(w), WithActionType(ActionExecute), WithStartTime(stepStart),
+						WithError(StepExecutionError.New("workflow %q sub-workflow %q returned nil report on resume", w.id, child.Id())))
+				}
+				stepReports = append(stepReports, report)
+				executedStepIDs[step.Id()] = struct{}{}
+
+				// F4 commit for the sub-workflow step (no leaf snapshot for a workflow).
+				committed := StepCompleted
+				if report.IsFailed() {
+					committed = StepFailed
+				}
+				w.journalStepCommitted(index, committed, nil, report)
+
+				if report.IsFailed() {
+					hasFailed = true
+					w.log().Warn("sub-workflow failed on resume",
+						"workflowId", w.id, "stepId", step.Id(), "index", index,
+						"executionMode", w.executionMode.String())
+					if w.executionMode == StopOnError {
+						break
+					} else if w.executionMode == RollbackOnError {
+						w.journalEnterCompensating(index)
+						rollbackReports := w.rollbackFrom(ctx, index, stepStates, executedStepIDs)
+						for _, sr := range stepReports {
+							if rollback, ok := rollbackReports[sr.Id]; ok {
+								sr.Rollback = rollback
+							}
+						}
+						break
+					}
+				}
+				continue
+			}
+		}
+
 		// F1 write-ahead (durability-spec §5): record `started` and the forward
 		// cursor and persist BEFORE any side effect runs. A sub-workflow step
 		// inherits the root persist closure here so its own transitions journal

--- a/workflow.go
+++ b/workflow.go
@@ -180,19 +180,12 @@ func RunWorkflow(ctx context.Context, wb *WorkflowBuilder) *Report {
 			))
 	}
 
-	preparedCtx, err := wf.Prepare(ctx)
-	if err != nil {
-		return FailureReport(wf,
-			WithWorkflow(wb.workflow),
-			WithActionType(ActionPrepare),
-			WithStartTime(start),
-			WithError(StepExecutionError.
-				Wrap(err, "workflow %q preparation failed: %v", wf.Id(), err).
-				WithProperty(StepIdProperty, wf.Id()),
-			))
-	}
-
-	return wf.Execute(preparedCtx)
+	// Execute owns preparation: it invokes Prepare, returns an ActionPrepare
+	// failure report (carrying this workflow's actual modes) on error, and resets
+	// the prepared flag for reuse. Calling Prepare here as well would be redundant
+	// — and, because Build has already reset wb.workflow to a fresh default, would
+	// attach the wrong (default) modes to the error report.
+	return wf.Execute(ctx)
 }
 
 // rollbackFrom rollbacks the workflow backward from the given index to the start.

--- a/workflow.go
+++ b/workflow.go
@@ -925,6 +925,13 @@ func (w *workflow) Rollback(ctx context.Context) *Report {
 		stepReports = append(stepReports, report)
 	}
 
+	// Mark the run terminal (§5 D1) so a later ResumeWorkflow recognises the
+	// rollback as finished (`done`) instead of finding the journal stuck in
+	// `compensating` and re-entering compensation.
+	if w.journaling() {
+		w.journalDone()
+	}
+
 	return SuccessReport(w,
 		WithWorkflow(w),
 		WithActionType(ActionRollback),

--- a/workflow.go
+++ b/workflow.go
@@ -129,6 +129,12 @@ type workflow struct {
 	jStepSnapshots []*SyncNamespacedStateBag
 	jStepReports   []*Report
 
+	// resuming is set by rehydrate (via ResumeWorkflow) so Execute continues an
+	// existing journal instead of starting a fresh one: it keeps the rehydrated
+	// progress rather than resetting it, and skips steps already recorded
+	// completed rather than re-executing them (durability-spec §6.3).
+	resuming bool
+
 	// callbacks and hooks
 	prepare      PrepareFunc
 	rollback     RollbackFunc // optional user-defined rollback function for the entire workflow
@@ -466,7 +472,7 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		root := w
 		w.journalPersist = func() error { return root.snapshotJournal().persist(root.journalPath) }
 	}
-	if w.journaling() {
+	if w.journaling() && !w.resuming {
 		w.initJournalProgress()
 		// Write the initial forward/0 journal from the root so a crash before the
 		// first step still leaves a complete, valid journal on disk.
@@ -487,6 +493,25 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 	for index, step := range w.steps {
 		var report *Report
 		stepStart := time.Now()
+
+		// Resume: a step recorded `completed` before a crash MUST NOT be
+		// re-executed (durability-spec §6.3.4). Reuse its recorded report and
+		// rollback snapshot, count it as executed, and carry on. A `started` leaf
+		// (the ambiguous case) is not skipped here — it falls through and re-runs,
+		// which is why steps must be idempotent (§7).
+		if w.resuming && index < len(w.jStepStates) && w.jStepStates[index] == StepCompleted {
+			rep := w.jStepReports[index]
+			if rep == nil {
+				rep = SuccessReport(step, WithWorkflow(w), WithActionType(ActionExecute), WithStartTime(stepStart))
+			}
+			stepReports = append(stepReports, rep)
+			executedStepIDs[step.Id()] = struct{}{}
+			if snap := w.jStepSnapshots[index]; snap != nil {
+				stepStates[step.Id()] = snap
+			}
+			w.log().Debug("resume: skipping already-completed step", "workflowId", w.id, "stepId", step.Id(), "index", index)
+			continue
+		}
 
 		// F1 write-ahead (durability-spec §5): record `started` and the forward
 		// cursor and persist BEFORE any side effect runs. A sub-workflow step

--- a/workflow.go
+++ b/workflow.go
@@ -203,8 +203,10 @@ func (w *workflow) rollbackFrom(ctx context.Context, index int, states map[strin
 		w.compensatedStepIDs = make(map[string]struct{})
 	}
 
-	// Entering the compensating phase (durability-spec §5). Set here in addition
-	// to Execute's F5 so a manually-invoked Rollback also records the phase.
+	// Keep the in-memory phase consistent so the projection reads as compensating.
+	// The DURABLE flip (write-ahead, §5 F5) is owned by the caller — Execute's
+	// failure path or Rollback — which persists it before any compensation side
+	// effect; this method does not persist on entry.
 	if w.journaling() {
 		w.jPhase = PhaseCompensating
 	}
@@ -515,7 +517,19 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		// `started` leaf is not handled here — it falls through and re-runs.
 		if w.resuming && w.stepStateAt(index) == StepStarted {
 			if child, isWorkflowStep := step.(*workflow); isWorkflowStep {
-				w.journalStepStarted(index) // re-affirm started; brackets the descent
+				// Re-affirm started; brackets the descent (write-ahead, §5 F1). If it
+				// cannot be persisted we do not descend — failing loudly beats running
+				// the child with no durable record.
+				if err := w.journalStepStarted(index); err != nil {
+					report = FailureReport(child,
+						WithWorkflow(w), WithActionType(ActionExecute), WithStartTime(stepStart),
+						WithError(JournalError.
+							Wrap(err, "workflow %q sub-workflow %q: failed to persist write-ahead journal on resume; not descending", w.id, child.Id()).
+							WithProperty(StepIdProperty, child.Id())))
+					stepReports = append(stepReports, report)
+					hasFailed = true
+					break
+				}
 				report = w.resumeChildStep(ctx, child)
 				if report == nil {
 					report = FailureReport(child,
@@ -540,7 +554,11 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 					if w.executionMode == StopOnError {
 						break
 					} else if w.executionMode == RollbackOnError {
-						w.journalEnterCompensating(index)
+						if err := w.journalEnterCompensating(index); err != nil {
+							w.log().Error("failed to persist compensating-phase journal on resume; skipping rollback to keep resume safe",
+								"workflowId", w.id, "index", index, "error", err)
+							break
+						}
 						rollbackReports := w.rollbackFrom(ctx, index, stepStates, executedStepIDs)
 						for _, sr := range stepReports {
 							if rollback, ok := rollbackReports[sr.Id]; ok {
@@ -552,17 +570,6 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 				}
 				continue
 			}
-		}
-
-		// F1 write-ahead (durability-spec §5): record `started` and the forward
-		// cursor and persist BEFORE any side effect runs. A sub-workflow step
-		// inherits the root persist closure here so its own transitions journal
-		// inline under this entry (§3.8).
-		if w.journaling() {
-			if child, ok := step.(*workflow); ok {
-				child.journalPersist = w.journalPersist
-			}
-			w.journalStepStarted(index)
 		}
 
 		stepCtx := ctx
@@ -608,11 +615,39 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		}
 
 		// make sure step has its state before calling Prepare so Prepare can access it.
-		// It also ensures during Execute the step has the correct state
+		// It also ensures during Execute the step has the correct state. For a
+		// sub-workflow this MUST happen before the F1 write-ahead below so the
+		// persisted `started` snapshot records the child's real shared (cloned
+		// Global) state, not an empty one (durability-spec §3.8); WithState mutates
+		// the stored node, so the projection sees it.
 		step = step.WithState(stepState)
 
+		// F1 write-ahead (durability-spec §5): record `started` and the forward
+		// cursor and persist BEFORE any side effect runs. A sub-workflow step
+		// inherits the root persist closure here so its own transitions journal
+		// inline under this entry (§3.8). The record MUST be durable before the
+		// side effect: if the persist fails we fail the step without executing it,
+		// so a crash can never strand an effect that resume cannot compensate.
+		var journalStartErr error
+		if statePrepError == nil && w.journaling() {
+			if child, ok := step.(*workflow); ok {
+				child.journalPersist = w.journalPersist
+			}
+			journalStartErr = w.journalStepStarted(index)
+			if journalStartErr != nil {
+				report = FailureReport(step,
+					WithWorkflow(w),
+					WithStartTime(stepStart),
+					WithActionType(ActionExecute),
+					WithError(JournalError.
+						Wrap(journalStartErr, "workflow %q step %q: failed to persist write-ahead journal; step not executed", w.id, step.Id()).
+						WithProperty(StepIdProperty, step.Id()),
+					))
+			}
+		}
+
 		// prepare step context
-		if statePrepError == nil {
+		if statePrepError == nil && journalStartErr == nil {
 			w.log().Debug("executing step", "workflowId", w.id, "stepId", step.Id(), "index", index)
 			stepCtx, ctxPrepError = step.Prepare(ctx)
 			if ctxPrepError != nil {
@@ -633,7 +668,7 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		}
 
 		// execute step if preparation succeeded
-		if statePrepError == nil && ctxPrepError == nil {
+		if statePrepError == nil && ctxPrepError == nil && journalStartErr == nil {
 			executedStepIDs[step.Id()] = struct{}{}
 			report = step.Execute(stepCtx)
 			if report == nil {
@@ -682,8 +717,10 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 
 		// F4 commit (durability-spec §5): record the step's outcome, its rollback
 		// snapshot (leaf steps only), and its report, persisted AFTER the side
-		// effect returns and before the next step's write-ahead.
-		if w.journaling() {
+		// effect returns and before the next step's write-ahead. Skipped when the
+		// write-ahead itself failed (journalStartErr): the step never ran and the
+		// journal write is already broken, so there is nothing to commit.
+		if w.journaling() && journalStartErr == nil {
 			stepState := StepCompleted
 			if report.IsFailed() {
 				stepState = StepFailed
@@ -720,7 +757,15 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 
 				// F5 (durability-spec §5): flip the phase to compensating with the
 				// cursor at the failed step, persisted before compensation begins.
-				w.journalEnterCompensating(index)
+				// This is a write-ahead point: if it cannot be made durable we do
+				// NOT compensate, because a crash mid-rollback would leave a journal
+				// that still reads as forward and resume would re-execute instead of
+				// continuing. Resume retries the whole compensation once it is durable.
+				if err := w.journalEnterCompensating(index); err != nil {
+					w.log().Error("failed to persist compensating-phase journal; skipping rollback to keep resume safe",
+						"workflowId", w.id, "index", index, "error", err)
+					break
+				}
 
 				// Perform rollback using recorded per-step states
 				// Rollback from index (include the failed step for cleanup)
@@ -844,6 +889,22 @@ func (w *workflow) Rollback(ctx context.Context) *Report {
 	startTime := time.Now()
 
 	w.log().Info("starting workflow rollback", "workflowId", w.id, "steps", len(w.steps))
+
+	// A directly-invoked Rollback of a durable workflow must persist the
+	// compensating-phase flip before any compensation side effect (durability-spec
+	// §5 F5), exactly as Execute's failure path does. Bail out loudly if it cannot
+	// be made durable rather than compensate against a journal that still reads
+	// forward.
+	if w.journaling() && len(w.steps) > 0 {
+		if err := w.journalEnterCompensating(len(w.steps) - 1); err != nil {
+			return FailureReport(w,
+				WithWorkflow(w),
+				WithActionType(ActionRollback),
+				WithStartTime(startTime),
+				WithError(JournalError.
+					Wrap(err, "workflow %q: failed to persist compensating-phase journal; rollback not started", w.id)))
+		}
+	}
 
 	// Use preserved states and executed-step set from last execution.
 	rollbackReports := w.rollbackFrom(ctx, len(w.steps)-1, w.lastExecutionStates, w.lastExecutedStepIDs)

--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -49,6 +49,13 @@ type WorkflowBuilder struct {
 	// so the error is recorded here and surfaced by Validate/Build. Per core-spec
 	// §3.1 a duplicate step ID is a build-time failure, not a silent drop.
 	idErrs []error
+
+	// journalErr records a misuse of WithJournal (an empty path). Like idErrs it
+	// cannot be returned through the fluent API, so it is surfaced by
+	// Validate/Build. An empty journalPath cannot be rejected at Build time on its
+	// own — it is also the valid "journaling off" default — so the error must be
+	// captured at the WithJournal call site.
+	journalErr error
 }
 
 // Id returns the workflow ID that has been configured so far.
@@ -201,6 +208,11 @@ func (wb *WorkflowBuilder) Validate() error {
 		return fmt.Errorf("invalid step ids: %v", wb.idErrs)
 	}
 
+	// Surface a WithJournal misuse (empty path) recorded at the call site.
+	if wb.journalErr != nil {
+		return wb.journalErr
+	}
+
 	if len(wb.stepBuilders) == 0 {
 		return StepNotFound.New("no steps provided for workflow")
 	}
@@ -301,7 +313,16 @@ func (wb *WorkflowBuilder) WithRollbackMode(mode TypeMode) *WorkflowBuilder {
 //
 // A journal written here is resumed with [ResumeWorkflow], which replays the
 // forward or compensating phase after a crash.
+//
+// path MUST be non-empty: calling WithJournal("") is a misuse (it would leave the
+// workflow silently non-durable) and makes the subsequent Build/Validate fail with
+// IllegalArgument. To build a non-durable workflow, simply do not call WithJournal.
 func (wb *WorkflowBuilder) WithJournal(path string) *WorkflowBuilder {
+	if path == "" {
+		wb.journalErr = IllegalArgument.New("WithJournal requires a non-empty path; omit WithJournal for a non-durable workflow")
+		return wb
+	}
+	wb.journalErr = nil
 	wb.workflow.journalPath = path
 	return wb
 }

--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -289,6 +289,23 @@ func (wb *WorkflowBuilder) WithRollbackMode(mode TypeMode) *WorkflowBuilder {
 	return wb
 }
 
+// WithJournal makes the workflow durable by writing a crash-recovery journal to
+// path as it runs (durability-spec §3, §5). It is opt-in: without it a workflow
+// writes nothing to disk and behaves exactly as before. path is the full journal
+// file path; the enclosing directory must already exist.
+//
+// The journal is a snapshot rewritten atomically at each step boundary (§3.6),
+// so a reader always sees a complete journal. Set this only on the top-level
+// workflow: nested sub-workflows are journaled inline under the same file
+// automatically (§3.8) and do not need their own path.
+//
+// This story (#87) only writes the journal; resuming from it is a later addition
+// ([ResumeWorkflow], #88).
+func (wb *WorkflowBuilder) WithJournal(path string) *WorkflowBuilder {
+	wb.workflow.journalPath = path
+	return wb
+}
+
 // WithOnCompletion sets a callback that is invoked after the workflow completes
 // successfully. The callback receives the execution context, the workflow as a
 // [Step], and the final [Report]. When [WithAsyncCallbacks] is enabled the

--- a/workflow_builder.go
+++ b/workflow_builder.go
@@ -299,8 +299,8 @@ func (wb *WorkflowBuilder) WithRollbackMode(mode TypeMode) *WorkflowBuilder {
 // workflow: nested sub-workflows are journaled inline under the same file
 // automatically (§3.8) and do not need their own path.
 //
-// This story (#87) only writes the journal; resuming from it is a later addition
-// ([ResumeWorkflow], #88).
+// A journal written here is resumed with [ResumeWorkflow], which replays the
+// forward or compensating phase after a crash.
 func (wb *WorkflowBuilder) WithJournal(path string) *WorkflowBuilder {
 	wb.workflow.journalPath = path
 	return wb

--- a/workflow_builder_test.go
+++ b/workflow_builder_test.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/joomcode/errorx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // minimal Builder for testing
@@ -180,6 +182,26 @@ func TestWorkflowBuilder_Steps_DuplicateStepId(t *testing.T) {
 	wb.Steps(b1, b2)
 	// Only one step with the same id should be added
 	assert.Equal(t, []string{"step"}, wb.stepSequence)
+}
+
+// TestWorkflowBuilder_WithJournal_EmptyPathFailsBuild verifies WithJournal("") is
+// rejected at Build/Validate (symmetric with ResumeWorkflow's empty-path guard),
+// rather than silently producing a non-durable workflow.
+func TestWorkflowBuilder_WithJournal_EmptyPathFailsBuild(t *testing.T) {
+	wb := NewWorkflowBuilder().WithId("wf").
+		WithJournal("").
+		Steps(&mockStepBuilder{id: "step", valid: true})
+
+	_, err := wb.Build()
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, IllegalArgument),
+		"WithJournal(\"\") must fail Build with IllegalArgument, got %v", err)
+
+	// A non-durable workflow (no WithJournal) must still build fine.
+	ok, err := NewWorkflowBuilder().WithId("wf").
+		Steps(&mockStepBuilder{id: "step", valid: true}).Build()
+	require.NoError(t, err)
+	assert.False(t, ok.(*workflow).journaling(), "omitting WithJournal must leave journaling off")
 }
 
 func TestWorkflowBuilder_Validate_EmptyWorkflowId(t *testing.T) {


### PR DESCRIPTION
## Description

This pull request implements and documents durable workflow (crash recovery) support in the Automa project, and introduces a comprehensive conformance test suite for the durability feature. The most important changes include making durability an opt-in, production-ready feature, updating documentation, and adding conformance fixtures and tests to ensure correct behavior and cross-language compatibility.

**Durability (Crash Recovery) Feature Release**

* `README.md`, `docs/durability.md`: Durability (crash recovery) is now implemented and documented as a production feature, not just a proposal. Workflows can opt in to durability by specifying a journal path and using `ResumeWorkflow` to recover from crashes, restarts, or power loss. The documentation now explains the durability API, design rationale, and step author contract. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R74) [[3]](diffhunk://#diff-eef95cc35414311be7abec988101dd5e7324a9b09d826d8f72026b9cba44c97eL3-R10) [[4]](diffhunk://#diff-eef95cc35414311be7abec988101dd5e7324a9b09d826d8f72026b9cba44c97eL198-R205) [[5]](diffhunk://#diff-eef95cc35414311be7abec988101dd5e7324a9b09d826d8f72026b9cba44c97eR241-R247)

* `README.md`, `docs/durability.md`: The durability section now details how to use the feature, the requirements for step authors, and the guarantees provided. The design doc is updated to match the implemented API and references the normative durability spec. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R74) [[2]](diffhunk://#diff-eef95cc35414311be7abec988101dd5e7324a9b09d826d8f72026b9cba44c97eL3-R10) [[3]](diffhunk://#diff-eef95cc35414311be7abec988101dd5e7324a9b09d826d8f72026b9cba44c97eL198-R205) [[4]](diffhunk://#diff-eef95cc35414311be7abec988101dd5e7324a9b09d826d8f72026b9cba44c97eR241-R247)

**Conformance Testing for Durability**

* [`conformance_test.go`](diffhunk://#diff-be4d99d66262dc3750603ef688c69733cfb5ee8f882144967fcf6272da7b080eR26): Adds a suite of conformance tests that load durability journal fixtures (both roundtrip and resume-classification), verifying that the implementation matches the durability spec for serialization and resume behavior. The tests cover both schema round-trip and correct resume logic (which steps re-execute, which compensate, and final workflow status). [[1]](diffhunk://#diff-be4d99d66262dc3750603ef688c69733cfb5ee8f882144967fcf6272da7b080eR26) [[2]](diffhunk://#diff-be4d99d66262dc3750603ef688c69733cfb5ee8f882144967fcf6272da7b080eR314-R418)

* [`docs/spec/conformance/README.md`](diffhunk://#diff-9ffa6d01e3f43e638efc9d400be76cfd736e43000933b779035d472833a40cc6L22-R22): Documents the new `journal/` conformance fixtures, explaining their structure, purpose, and how they verify schema and resume decision agreement. [[1]](diffhunk://#diff-9ffa6d01e3f43e638efc9d400be76cfd736e43000933b779035d472833a40cc6L22-R22) [[2]](diffhunk://#diff-9ffa6d01e3f43e638efc9d400be76cfd736e43000933b779035d472833a40cc6R109-R159)

* [`docs/spec/conformance/journal/*.json`](diffhunk://#diff-beda2a584a20e6afdc575e1db354ba1c1fa7cacfb7f5c0185a47de925e8110c9R1-R30): Adds a comprehensive set of durability journal fixtures, including both roundtrip (schema) and resume (behavioral) cases, covering forward progress, compensation, nested workflows, and terminal states. [[1]](diffhunk://#diff-beda2a584a20e6afdc575e1db354ba1c1fa7cacfb7f5c0185a47de925e8110c9R1-R30) [[2]](diffhunk://#diff-1a4f40c8a461f6f322c8f0411ce2ad5218fbd397f1ce2189c564705fe1bc5457R1-R19) [[3]](diffhunk://#diff-909a3a696407a928e3d0ab2c72f80e67e967a325562a8717766d6cc4810f3824R1-R23) [[4]](diffhunk://#diff-e65e18d735cb6aa39bbb2f907e794a7f072e75acc566b72ff9d4242acb1d8bd6R1-R37) [[5]](diffhunk://#diff-1e62b5529bbd3d519292cc9198256db97cc2e013e9e88841b4d244b4b52403afR1-R24) [[6]](diffhunk://#diff-7f4be03b532832705a548872dbdb262cb488c6a6ec69429a34ac644014173ebeR1-R23)

**Resolved Design Questions**

* [`docs/durability.md`](diffhunk://#diff-eef95cc35414311be7abec988101dd5e7324a9b09d826d8f72026b9cba44c97eL323-R358): Updates the design doc to clarify and resolve previously open questions about storage backend, journal lifecycle, path namespacing, and topology validation. The only deferred extension is robust forward resume for nested workflows across schema changes.

---

These changes ensure that Automa's durability feature is robust, well-documented, and verifiable against a normative spec, with a test suite that can be used for cross-language compatibility.

### Related Issues

* Closes #85 
* Closes #86 
* Closes #87 
* Closes #88 
* Closes #89 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
