### PR TITLE
fix: improve durability correctness

### DIFF
--- a/automa_steps/step_bash.go
+++ b/automa_steps/step_bash.go
@@ -11,7 +11,19 @@ import (
 // RunBashScript executes a list of bash scripts in the specified working directory.
 // It captures the combined output of all commands and returns it as a string.
 // If any command fails, it returns an error immediately.
+//
+// It does not observe context cancellation; callers running inside a workflow
+// step should prefer RunBashScriptContext so a cancelled/expired workflow context
+// stops the shell command. This wrapper is retained for backward compatibility and
+// runs with a background context.
 func RunBashScript(scripts []string, workDir string) (string, error) {
+	return RunBashScriptContext(context.Background(), scripts, workDir)
+}
+
+// RunBashScriptContext is RunBashScript with context propagation: each command is
+// started with exec.CommandContext(ctx, ...), so cancelling or timing out ctx
+// terminates the running command instead of letting it run to completion.
+func RunBashScriptContext(ctx context.Context, scripts []string, workDir string) (string, error) {
 	var outputs bytes.Buffer // To capture combined output of all scripts
 
 	if len(scripts) == 0 {
@@ -19,7 +31,7 @@ func RunBashScript(scripts []string, workDir string) (string, error) {
 	}
 
 	for _, script := range scripts {
-		c := exec.Command("bash", "-c", script)
+		c := exec.CommandContext(ctx, "bash", "-c", script)
 		if workDir != "" {
 			c.Dir = workDir
 		}
@@ -50,7 +62,7 @@ func BashScriptStep(id string, scripts []string, workDir string) *automa.StepBui
 	return automa.NewStepBuilder().
 		WithId(id).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
-			output, err := RunBashScript(scripts, workDir)
+			output, err := RunBashScriptContext(ctx, scripts, workDir)
 			if err != nil {
 				return automa.StepFailureReport(id, automa.WithError(err), automa.WithMetadata(automa.StringMap{
 					"output": output,

--- a/automa_steps/step_bash.go
+++ b/automa_steps/step_bash.go
@@ -22,7 +22,10 @@ func RunBashScript(scripts []string, workDir string) (string, error) {
 
 // RunBashScriptContext is RunBashScript with context propagation: each command is
 // started with exec.CommandContext(ctx, ...), so cancelling or timing out ctx
-// terminates the running command instead of letting it run to completion.
+// kills the command instead of letting it run to completion. Note the signal is
+// delivered to the `bash -c` process itself; grandchild processes it spawned are
+// not killed as a process group and may survive, so scripts that fork long-running
+// children should arrange their own cleanup.
 func RunBashScriptContext(ctx context.Context, scripts []string, workDir string) (string, error) {
 	var outputs bytes.Buffer // To capture combined output of all scripts
 

--- a/automa_steps/step_bash_test.go
+++ b/automa_steps/step_bash_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/automa-saga/automa"
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,20 @@ func TestRunBashScript_EmptyScripts(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, output)
 	assert.Contains(t, err.Error(), "no scripts provided")
+}
+
+func TestRunBashScriptContext_CancelledContextStopsCommand(t *testing.T) {
+	// A cancelled context must terminate the running command rather than let it
+	// sleep to completion; exec.CommandContext kills the process on ctx.Done().
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := RunBashScriptContext(ctx, []string{"sleep 5"}, "")
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a context-cancelled command must fail, not run to completion")
+	assert.Less(t, elapsed, 4*time.Second, "command should be killed shortly after ctx expiry, not after the full sleep")
 }
 
 func TestRunBashScript_WorkDir(t *testing.T) {

--- a/automa_steps/step_bash_test.go
+++ b/automa_steps/step_bash_test.go
@@ -2,7 +2,6 @@ package automa_steps
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/automa-saga/automa"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRunBashScript_Success(t *testing.T) {

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -168,6 +168,20 @@ func (j *Journal) persist(path string) error {
 always observes either the previous complete journal or the new complete
 journal, never a partial one.
 
+> **Orphaned temp files after a hard crash.** Each snapshot is written to a
+> uniquely-named temp file (`.journal-*.tmp`) in the journal's directory, fsynced,
+> then renamed over the target. A clean write consumes the temp (the rename moves
+> it); an ordinary write error removes it. But a **hard** crash (power loss,
+> `kill -9`, `os.Exit`) in the window between creating the temp and the rename
+> leaves that temp file behind — and because the names are unique, such orphans are
+> never reused and can slowly accumulate across repeated crashes. This never
+> affects correctness: the real journal is always a complete file, since only an
+> atomic rename ever publishes it. It is purely a housekeeping concern. automa does
+> not sweep these itself — multiple journals may share a directory, so a blanket
+> delete could race another run's in-flight temp. Cleanup is the caller's
+> responsibility, like journal [pruning](#resolved-questions): remove stale
+> `.journal-*.tmp` files from the journal directory when no run is live for it.
+
 ## Write points in the execution loop
 
 The persist calls slot into the existing `Execute` loop

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -37,6 +37,12 @@ Durability earns its (small) complexity when **all** of the following hold:
 
 - The workflow runs in a **single process** and is **short-to-medium length**
   (tens of steps, not thousands).
+- The journal has a **single owner at a time**. A given journal file is written
+  and resumed by **one process at a time**; automa does **not** lock the file or
+  guard against two processes resuming the same journal concurrently. Running two
+  resumes against one journal path races the persist and can double-execute every
+  remaining step — the caller is responsible for ensuring only one owner is live
+  (e.g. a supervisor that never starts a second instance for the same run).
 - Steps are **expensive, slow, or externally observable** — redoing them from
   scratch is costly or unsafe (e.g. provisioning cloud resources, running a
   multi-stage data migration, an installer that mutates a machine).

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -318,6 +318,34 @@ These obligations must be documented prominently and, where feasible, enforced:
    produced by the caller's code at resume time. If steps are derived from
    runtime data, that data must itself be persisted (e.g. in global state) so the
    topology is deterministic across restarts.
+5. **The workflow `prepare` hook must be idempotent too.** A forward resume goes
+   through `Execute`, which runs the workflow-level `prepare` hook again — the
+   same requirement stated for steps applies to it. Do not perform
+   non-idempotent, one-time setup in a durable workflow's `prepare` hook.
+
+## Caveats and fidelity notes
+
+These are known, intentional limitations — not bugs. Author around them.
+
+- **Snapshot rollback is immutable only for `Cloner` values.** In-memory rollback
+  snapshots are taken with `Clone()`, which deep-copies values implementing a
+  `Clone` method and shallow-copies everything else. A bare `map`/`slice`/pointer
+  stored in state is shared with the snapshot, so a later in-place mutation is
+  visible through an earlier step's snapshot. Store `Cloner` values (or treat
+  state as copy-on-write) when relying on snapshot rollback. The journaled path is
+  unaffected: the commit point serializes the snapshot to JSON (a true deep copy)
+  before any later step runs.
+- **Reaching `Execute` implies compensation.** Any step that reaches `Execute` —
+  including one whose `Execute` returns a skipped/no-op outcome — is treated as
+  executed and has its `Rollback` invoked during compensation. Keep such
+  rollbacks strict no-ops. (Steps that fail *before* `Execute` are not
+  compensated; see durability-spec §4.2.)
+- **Error type/properties are not preserved across a resume.** A step report's
+  `Error` is serialized to its message string and rehydrated as a plain error, so
+  the `errorx` type and properties (e.g. `StepIdProperty`) are lost after a
+  resume. Logic that branches on error *type* must not assume type fidelity for
+  reports reconstructed from a journal; branch on data kept in the state bag
+  instead.
 
 ## Non-goals
 

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -354,12 +354,15 @@ These are known, intentional limitations — not bugs. Author around them.
   executed and has its `Rollback` invoked during compensation. Keep such
   rollbacks strict no-ops. (Steps that fail *before* `Execute` are not
   compensated; see durability-spec §4.2.)
-- **Error type/properties are not preserved across a resume.** A step report's
-  `Error` is serialized to its message string and rehydrated as a plain error, so
-  the `errorx` type and properties (e.g. `StepIdProperty`) are lost after a
-  resume. Logic that branches on error *type* must not assume type fidelity for
-  reports reconstructed from a journal; branch on data kept in the state bag
-  instead.
+- **Error type/properties are not preserved for journal-replayed reports.** A
+  report reconstructed from the journal (a step that completed or failed *before*
+  the crash) has its `Error` serialized to its message string and rehydrated as a
+  plain error, so the `errorx` type and custom properties are lost. This applies
+  only to replayed reports: a step that *re-executes* on resume produces a live,
+  full-fidelity error. Logic must not assume error *type* fidelity for
+  reports reconstructed from a journal; branch on `Status`, on `report.Id`, or on
+  data kept in the state bag instead. Note the step ID specifically is not lost —
+  it is preserved structurally as `report.Id`, independent of the error.
 
 ## Non-goals
 

--- a/docs/spec/durability-spec.md
+++ b/docs/spec/durability-spec.md
@@ -372,6 +372,14 @@ pending ──▶ started ──▶ completed ──┐
 - A step found in `started` but not `completed` after a crash is the **ambiguous
   case**: its side effect's completion is unknown. It MUST be re-executed on
   resume (§6.3), which is why §7 requires step idempotency.
+- `failed` means **Execute** failed — the side effect ran and returned an error.
+  A step that fails **before reaching Execute** (e.g. its per-step preparation or
+  a state-setup error) MUST NOT be recorded as `failed`, because on resume a
+  `failed` step is treated as executed and therefore eligible for compensation
+  (§5.3 / D5). Such a step MUST retain its pre-execute state — `started` if the
+  write-ahead record (F1) was written, otherwise `pending` — so resume does not
+  compensate a step whose side effect never ran. This matches live execution,
+  which excludes pre-execute failures from the executed set.
 - A `skipped` outcome (e.g. a step the engine deliberately did not run) MAY be
   represented; if so it MUST be treated as not requiring compensation. (Skip
   semantics are governed by the engine's execution-mode rules and are not

--- a/docs/spec/durability-spec.md
+++ b/docs/spec/durability-spec.md
@@ -196,6 +196,19 @@ that preserves the all-or-nothing guarantee.
   way a prior journal is consulted; it is intentional, never accidental, when the
   runID convention above is followed.
 
+#### 3.7.5 Single owner per journal
+
+- A journal MUST have at most **one live owner at a time**: at most one process
+  may be executing or resuming a given journal path at any moment. The caller is
+  responsible for enforcing this (e.g. a supervisor that never launches a second
+  instance for the same runID).
+- An implementation is **not required** to lock the journal file or otherwise
+  detect concurrent owners. Two owners resuming the same journal concurrently
+  races the durable write (§3.6) and defeats the idempotency contract (§7), which
+  covers a single sequential retry — not simultaneous re-execution — and MAY
+  double-execute every step from the crash point onward. This is undefined
+  behavior, not a supported mode.
+
 #### 3.7.2 Resume of a terminal journal is a safe no-op
 
 - A resume against a journal already in `phase: done` MUST return the recorded

--- a/docs/spec/durability-spec.md
+++ b/docs/spec/durability-spec.md
@@ -196,19 +196,6 @@ that preserves the all-or-nothing guarantee.
   way a prior journal is consulted; it is intentional, never accidental, when the
   runID convention above is followed.
 
-#### 3.7.5 Single owner per journal
-
-- A journal MUST have at most **one live owner at a time**: at most one process
-  may be executing or resuming a given journal path at any moment. The caller is
-  responsible for enforcing this (e.g. a supervisor that never launches a second
-  instance for the same runID).
-- An implementation is **not required** to lock the journal file or otherwise
-  detect concurrent owners. Two owners resuming the same journal concurrently
-  races the durable write (§3.6) and defeats the idempotency contract (§7), which
-  covers a single sequential retry — not simultaneous re-execution — and MAY
-  double-execute every step from the crash point onward. This is undefined
-  behavior, not a supported mode.
-
 #### 3.7.2 Resume of a terminal journal is a safe no-op
 
 - A resume against a journal already in `phase: done` MUST return the recorded
@@ -249,6 +236,19 @@ fully compensated, or terminally failed):
   self-contained file.
 - Implementations MUST document that journals accumulate under `retain` until
   pruned, so operators size storage accordingly.
+
+#### 3.7.5 Single owner per journal
+
+- A journal MUST have at most **one live owner at a time**: at most one process
+  may be executing or resuming a given journal path at any moment. The caller is
+  responsible for enforcing this (e.g. a supervisor that never launches a second
+  instance for the same runID).
+- An implementation is **not required** to lock the journal file or otherwise
+  detect concurrent owners. Two owners resuming the same journal concurrently
+  races the durable write (§3.6) and defeats the idempotency contract (§7), which
+  covers a single sequential retry — not simultaneous re-execution — and MAY
+  double-execute every step from the crash point onward. This is undefined
+  behavior, not a supported mode.
 
 ### 3.8 Sub-workflow nesting (inline, recursive)
 

--- a/docs/spec/durability-spec.md
+++ b/docs/spec/durability-spec.md
@@ -545,6 +545,10 @@ prominently.
    the same modes) MUST be produced by the caller's code at resume time. If steps
    are derived from runtime data, that data MUST itself be persisted so the
    topology is deterministic across restarts.
+5. **Workflow-level preparation MUST be idempotent.** A forward resume re-runs the
+   workflow's own preparation hook (if the implementation exposes one), just as it
+   re-runs a `started` step. Any workflow-level preparation MUST therefore be safe
+   to run more than once across a crash.
 
 ## 8. Conformance
 

--- a/journal_execution_test.go
+++ b/journal_execution_test.go
@@ -353,3 +353,74 @@ func TestJournal_WriteAheadFailureAbortsStep(t *testing.T) {
 	}
 	assert.True(t, carriesJournalError(report), "failure must carry a JournalError")
 }
+
+// TestJournal_SkippedRollbackStaysResumable verifies that when a RollbackOnError
+// failure cannot durably record its compensating-phase flip (§5 F5) — so rollback
+// is skipped to stay crash-safe — the run does NOT finalize the journal as `done`.
+// Marking it `done` while executed steps went uncompensated would strand them
+// behind a terminal cursor, and ResumeWorkflow (which no-ops a `done` journal)
+// could never retry. The durable journal must instead stay `forward`, so a later
+// healthy resume re-enters, re-runs the failed step, and completes compensation.
+func TestJournal_SkippedRollbackStaysResumable(t *testing.T) {
+	path := journalPath(t)
+
+	newBuilder := func() *WorkflowBuilder {
+		return NewWorkflowBuilder().WithId("wf").
+			WithExecutionMode(RollbackOnError).
+			WithJournal(path).
+			Steps(
+				NewStepBuilder().WithId("a").
+					WithExecute(func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }),
+				NewStepBuilder().WithId("b").
+					WithExecute(func(ctx context.Context, stp Step) *Report {
+						return FailureReport(stp, WithError(StepExecutionError.New("boom")))
+					}),
+			)
+	}
+
+	// --- Run 1: forward persists succeed, but the compensating-phase flip (F5)
+	// fails. Pre-installing journalPersist makes Execute reuse this injector instead
+	// of installing its own. The injector fails only when the projected cursor is
+	// `compensating`; journalDone projects `done`, so without the fix a terminal
+	// journal would reach disk — exactly the stranding we assert against.
+	built, err := newBuilder().Build()
+	require.NoError(t, err)
+	wf := built.(*workflow)
+
+	var f5Attempts int
+	wf.journalPersist = func() error {
+		j, err := wf.snapshotJournal()
+		if err != nil {
+			return err
+		}
+		if j.Cursor.Phase == PhaseCompensating {
+			f5Attempts++
+			return StepExecutionError.New("injected persist failure at compensating flip")
+		}
+		return j.persist(path)
+	}
+
+	r1 := wf.Execute(context.Background())
+	require.True(t, r1.IsFailed(), "run must fail")
+	require.Equal(t, 1, f5Attempts, "the compensating-phase flip must have been attempted (and injected to fail)")
+
+	j, err := loadJournal(path)
+	require.NoError(t, err)
+	require.Equal(t, PhaseForward, j.Cursor.Phase,
+		"a run that skipped rollback due to a failed compensating-phase persist must NOT be journaled `done`")
+	require.Len(t, j.Steps, 2)
+	assert.Equal(t, StepCompleted, j.Steps[0].State, "the earlier step is still recorded completed (and uncompensated) on disk")
+	assert.Equal(t, StepFailed, j.Steps[1].State, "the failed step's last durable state is `failed`")
+
+	// --- Run 2: resume with a healthy persist. The non-terminal journal lets the
+	// run re-enter forward, re-run the failed step, and this time complete
+	// compensation — proving the skipped state was recoverable, not stranded.
+	r2 := ResumeWorkflow(context.Background(), newBuilder(), path)
+	require.True(t, r2.IsFailed(), "the resumed run still fails (the step fails again)")
+
+	j2, err := loadJournal(path)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseDone, j2.Cursor.Phase, "a healthy resume finalizes the journal terminal")
+	assert.Equal(t, StepCompensated, j2.Steps[0].State, "the earlier step is compensated on the healthy resume")
+	assert.Equal(t, StepCompensated, j2.Steps[1].State, "the failed step is compensated too")
+}

--- a/journal_execution_test.go
+++ b/journal_execution_test.go
@@ -105,6 +105,49 @@ func TestJournal_FailureRollback(t *testing.T) {
 	assert.Equal(t, StepCompensated, j.Steps[1].State, "b (failed) must be compensated for cleanup")
 }
 
+// TestJournal_PrepareFailedStepRecordedStartedNotFailed verifies that a step
+// which fails in its Prepare hook — before ever reaching Execute — is journaled
+// as `started`, not `failed` (durability-spec §4.2). `failed` means "Execute
+// failed" and marks a step as executed/compensable on resume; recording a
+// prepare failure as `failed` would make resume compensate a step whose side
+// effect never ran (correctness review 2.1). The live run already skips it via
+// D5, and the journal must record the same fact.
+func TestJournal_PrepareFailedStepRecordedStartedNotFailed(t *testing.T) {
+	path := journalPath(t)
+
+	var aRolledBack, bRolledBack bool
+	step, err := NewWorkflowBuilder().WithId("wf").
+		WithExecutionMode(RollbackOnError).
+		WithJournal(path).
+		Steps(
+			NewStepBuilder().WithId("a").
+				WithExecute(func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }).
+				WithRollback(func(ctx context.Context, stp Step) *Report { aRolledBack = true; return SuccessReport(stp) }),
+			NewStepBuilder().WithId("b").
+				WithPrepare(func(ctx context.Context, stp Step) (context.Context, error) {
+					return ctx, StepExecutionError.New("b prepare failed")
+				}).
+				WithExecute(func(ctx context.Context, stp Step) *Report { return SuccessReport(stp) }).
+				WithRollback(func(ctx context.Context, stp Step) *Report { bRolledBack = true; return SuccessReport(stp) }),
+		).Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+	require.True(t, report.IsFailed(), "workflow should fail when b's Prepare fails")
+
+	// Live D5: b never executed, so its rollback is not invoked; a is compensated.
+	assert.True(t, aRolledBack, "a (completed) must be compensated on the live path")
+	assert.False(t, bRolledBack, "b failed in Prepare and never executed; its rollback must NOT run")
+
+	j, err := loadJournal(path)
+	require.NoError(t, err)
+	require.Len(t, j.Steps, 2)
+	assert.Equal(t, StepCompensated, j.Steps[0].State, "a must be recorded compensated")
+	assert.Equal(t, StepStarted, j.Steps[1].State,
+		"b failed in Prepare: it must stay `started`, not be recorded `failed` (else resume would compensate it)")
+	assert.NotEqual(t, StepFailed, j.Steps[1].State, "a pre-execute failure must not be journaled as `failed`")
+}
+
 // TestJournal_Disabled_WritesNothing verifies WithJournal is opt-in: a workflow
 // built without it has journaling switched off (no persist closure), so every
 // transition is inert and nothing is written to disk (backward compatibility).

--- a/journal_resume_test.go
+++ b/journal_resume_test.go
@@ -179,8 +179,8 @@ func TestResume_CompletingCompensationFiresOnFailure(t *testing.T) {
 
 // TestResume_TerminalJournalDoesNotRefireCallbacks: resuming an already-terminal
 // (`done`) journal is a pure replay (spec §3.7.2) and must NOT re-fire
-// onCompletion/onFailure — the original run already fired them (correctness
-// review 2.2).
+// onCompletion/onFailure — re-firing on replay would duplicate the callbacks' side
+// effects, since the live run fires them exactly once (correctness review 2.2).
 func TestResume_TerminalJournalDoesNotRefireCallbacks(t *testing.T) {
 	path := journalPath(t)
 	craftJournal(t, path, RollbackOnError, ContinueOnError, PhaseDone, 1, []*StepJournal{

--- a/journal_resume_test.go
+++ b/journal_resume_test.go
@@ -126,6 +126,31 @@ func TestResume_StartedStepRerunsOnce(t *testing.T) {
 	assert.Equal(t, []string{"b"}, rec.exec, "b must re-run exactly once; a skipped")
 }
 
+// TestResume_PrepareFailedStepNotCompensated: a step that failed before reaching
+// Execute is journaled `started` (see the F4 write-ahead handling and
+// durability-spec §4.2), not `failed`. On resume of a compensating journal it
+// MUST NOT be compensated — its side effect never ran (correctness review 2.1).
+// Here b is `started` (prepare-failed) at the compensating cursor; only the
+// earlier completed step a is rolled back.
+func TestResume_PrepareFailedStepNotCompensated(t *testing.T) {
+	path := journalPath(t)
+	craftJournal(t, path, RollbackOnError, ContinueOnError, PhaseCompensating, 1, []*StepJournal{
+		{ID: "a", State: StepCompleted},
+		{ID: "b", State: StepStarted}, // failed in Prepare before Execute; never ran
+	})
+
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		Steps(recStep(rec, "a", false), recStep(rec, "b", false))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsFailed(), "a compensated run is a failure outcome")
+	assert.Equal(t, []string{"a"}, rec.rollback,
+		"only a is compensated; b never executed (started, not failed) so it must be skipped")
+	assert.NotContains(t, rec.rollback, "b", "a pre-execute-failed step must never be compensated on resume")
+	assert.Empty(t, rec.exec, "no forward execution during compensation resume")
+}
+
 // TestResume_ContinuesCompensation: a crash mid-compensation resumes the
 // rollback from the cursor, skipping already-compensated steps.
 func TestResume_ContinuesCompensation(t *testing.T) {

--- a/journal_resume_test.go
+++ b/journal_resume_test.go
@@ -151,6 +151,56 @@ func TestResume_PrepareFailedStepNotCompensated(t *testing.T) {
 	assert.Empty(t, rec.exec, "no forward execution during compensation resume")
 }
 
+// TestResume_CompletingCompensationFiresOnFailure: a run that finishes an
+// interrupted rollback on resume fires onFailure, mirroring Execute's failure
+// path (correctness review 2.2). A `compensating` journal means the original
+// crashed mid-rollback before it could fire the callback, so resume is the first
+// and only firing.
+func TestResume_CompletingCompensationFiresOnFailure(t *testing.T) {
+	path := journalPath(t)
+	craftJournal(t, path, RollbackOnError, ContinueOnError, PhaseCompensating, 1, []*StepJournal{
+		{ID: "a", State: StepCompleted},
+		{ID: "b", State: StepFailed},
+	})
+
+	var onFailureFired bool
+	var onCompletionFired bool
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		WithOnFailure(func(ctx context.Context, stp Step, r *Report) { onFailureFired = true }).
+		WithOnCompletion(func(ctx context.Context, stp Step, r *Report) { onCompletionFired = true }).
+		Steps(recStep(rec, "a", false), recStep(rec, "b", true))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsFailed(), "a compensated run is a failure outcome")
+	assert.True(t, onFailureFired, "resuming a completed compensation must fire onFailure")
+	assert.False(t, onCompletionFired, "onCompletion must not fire for a compensated (failure) run")
+}
+
+// TestResume_TerminalJournalDoesNotRefireCallbacks: resuming an already-terminal
+// (`done`) journal is a pure replay (spec §3.7.2) and must NOT re-fire
+// onCompletion/onFailure — the original run already fired them (correctness
+// review 2.2).
+func TestResume_TerminalJournalDoesNotRefireCallbacks(t *testing.T) {
+	path := journalPath(t)
+	craftJournal(t, path, RollbackOnError, ContinueOnError, PhaseDone, 1, []*StepJournal{
+		{ID: "a", State: StepCompleted},
+		{ID: "b", State: StepCompleted},
+	})
+
+	var fired bool
+	rec := &resumeRecorder{}
+	wb := NewWorkflowBuilder().WithId("wf").WithExecutionMode(RollbackOnError).
+		WithOnCompletion(func(ctx context.Context, stp Step, r *Report) { fired = true }).
+		WithOnFailure(func(ctx context.Context, stp Step, r *Report) { fired = true }).
+		Steps(recStep(rec, "a", false), recStep(rec, "b", false))
+
+	report := ResumeWorkflow(context.Background(), wb, path)
+	require.True(t, report.IsSuccess(), "all-completed terminal journal replays as success")
+	assert.False(t, fired, "a terminal replay must not re-fire lifecycle callbacks")
+	assert.Empty(t, rec.exec, "a terminal resume runs nothing")
+}
+
 // TestResume_ContinuesCompensation: a crash mid-compensation resumes the
 // rollback from the cursor, skipping already-compensated steps.
 func TestResume_ContinuesCompensation(t *testing.T) {

--- a/resume.go
+++ b/resume.go
@@ -243,12 +243,21 @@ func (w *workflow) resumeCompensation(ctx context.Context, start time.Time) *Rep
 
 	w.journalDone()
 
-	return FailureReport(w,
+	report := FailureReport(w,
 		WithWorkflow(w),
 		WithActionType(ActionExecute),
 		WithStartTime(start),
 		WithStepReports(stepReports...),
 		WithError(StepExecutionError.New("workflow %q resumed and completed compensation", w.id)))
+
+	// Fire onFailure, mirroring Execute's failure path. A `compensating` journal
+	// means the original run crashed mid-rollback, BEFORE it reached journalDone
+	// and its own handleFailure — so this is the first and only firing for the
+	// run (no double-fire). Terminal (`done`) resumes go through
+	// reconstructFinalReport instead, which deliberately does not re-fire.
+	w.handleFailure(ctx, report)
+
+	return report
 }
 
 // reconstructFinalReport rebuilds a terminal run's report from the journal
@@ -256,6 +265,13 @@ func (w *workflow) resumeCompensation(ctx context.Context, start time.Time) *Rep
 // top-level report, so the workflow status is derived: success iff every step is
 // completed; otherwise failed (a fully-compensated run is a failure that rolled
 // back cleanly).
+//
+// This is a pure replay of an already-terminal (`done`) journal and MUST run
+// nothing (§3.7.2). In particular it does NOT fire onCompletion/onFailure: the
+// original run already fired them before writing `done`, so re-firing here would
+// duplicate the callback (and any side effect it performs) on every terminal
+// resume. The live-completing paths (Execute, and resumeCompensation for an
+// interrupted rollback) are the ones that fire the callbacks.
 func (w *workflow) reconstructFinalReport(start time.Time) *Report {
 	stepReports := make([]*Report, 0, len(w.steps))
 	anyNotCompleted := false

--- a/resume.go
+++ b/resume.go
@@ -267,11 +267,13 @@ func (w *workflow) resumeCompensation(ctx context.Context, start time.Time) *Rep
 // back cleanly).
 //
 // This is a pure replay of an already-terminal (`done`) journal and MUST run
-// nothing (§3.7.2). In particular it does NOT fire onCompletion/onFailure: the
-// original run already fired them before writing `done`, so re-firing here would
-// duplicate the callback (and any side effect it performs) on every terminal
-// resume. The live-completing paths (Execute, and resumeCompensation for an
-// interrupted rollback) are the ones that fire the callbacks.
+// nothing (§3.7.2). In particular it does NOT fire onCompletion/onFailure. Those
+// callbacks are fired exactly once by the live-completing paths — Execute, and
+// resumeCompensation for an interrupted rollback — so re-firing them on a terminal
+// replay would duplicate the callback and any side effect it performs. (Execute
+// writes `done` and then fires its callback, so a crash in that narrow window can
+// drop the callback; the replay still deliberately does not re-fire, preferring a
+// possibly-missed callback over ever double-firing.)
 func (w *workflow) reconstructFinalReport(start time.Time) *Report {
 	stepReports := make([]*Report, 0, len(w.steps))
 	anyNotCompleted := false

--- a/state.go
+++ b/state.go
@@ -88,6 +88,11 @@ func (s *SyncStateBag) init() {
 //     return), that method is called and the result is stored.
 //   - All other values are shallow-copied (the same pointer/value is stored).
 //
+// Consequence for rollback snapshots: a snapshot taken via Clone is immutable
+// only for Cloner values. A bare map/slice/pointer stored in state is shared with
+// the snapshot, so a later in-place mutation is visible through an earlier step's
+// snapshot. Store Cloner values when relying on snapshot-based rollback.
+//
 // Clone acquires no lock of its own; it delegates to Items() which takes a
 // read lock. This avoids re-entrant locking on Go's non-reentrant RWMutex.
 //

--- a/workflow.go
+++ b/workflow.go
@@ -485,6 +485,16 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 	var stepReports []*Report
 	var hasFailed bool
 
+	// rollbackSkippedUnpersisted records that a RollbackOnError failure could not
+	// durably record its compensating-phase flip (§5 F5) and therefore skipped
+	// rollback. When set, the run MUST NOT be journaled `done` at the terminal
+	// block below: the last durable journal still reads `forward` with the failed
+	// step, and finalizing it `done` here — if this later persist happens to
+	// succeed while the F5 persist failed — would strand executed-but-uncompensated
+	// steps that a resume could otherwise retry. Leaving the journal non-terminal
+	// lets ResumeWorkflow re-enter forward and retry compensation once writable.
+	var rollbackSkippedUnpersisted bool
+
 	// capture per-step state snapshots for rollback
 	stepStates := make(map[string]NamespacedStateBag, len(w.steps))
 
@@ -563,6 +573,7 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 						if err := w.journalEnterCompensating(index); err != nil {
 							w.log().Error("failed to persist compensating-phase journal on resume; skipping rollback to keep resume safe",
 								"workflowId", w.id, "index", index, "error", err)
+							rollbackSkippedUnpersisted = true
 							break
 						}
 						rollbackReports := w.rollbackFrom(ctx, index, stepStates, executedStepIDs)
@@ -793,6 +804,7 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 				if err := w.journalEnterCompensating(index); err != nil {
 					w.log().Error("failed to persist compensating-phase journal; skipping rollback to keep resume safe",
 						"workflowId", w.id, "index", index, "error", err)
+					rollbackSkippedUnpersisted = true
 					break
 				}
 
@@ -846,8 +858,17 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 			)),
 			WithStepReports(stepReports...))
 
-		// D1 (durability-spec §5): the run is terminal.
-		w.journalDone()
+		// D1 (durability-spec §5): the run is terminal — but only mark it `done`
+		// when compensation was NOT skipped due to a failed compensating-phase
+		// persist. In that skipped case the last durable journal still reads
+		// `forward` with the failed step; leaving it non-terminal lets a resume
+		// re-enter forward and retry compensation instead of stranding
+		// executed-but-uncompensated steps behind a `done` cursor (see
+		// rollbackSkippedUnpersisted). The in-memory report is still a failure and
+		// onFailure still fires, so the caller is notified either way.
+		if !rollbackSkippedUnpersisted {
+			w.journalDone()
+		}
 
 		w.handleFailure(ctx, workflowReport)
 

--- a/workflow.go
+++ b/workflow.go
@@ -727,9 +727,26 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 		// write-ahead itself failed (journalStartErr): the step never ran and the
 		// journal write is already broken, so there is nothing to commit.
 		if w.journaling() && journalStartErr == nil {
+			// reachedExecute mirrors the executedStepIDs guard above: the step ran
+			// its side effect iff state prep, the write-ahead persist, and Prepare
+			// all succeeded.
+			reachedExecute := statePrepError == nil && ctxPrepError == nil && journalStartErr == nil
+
 			stepState := StepCompleted
 			if report.IsFailed() {
-				stepState = StepFailed
+				if reachedExecute {
+					stepState = StepFailed
+				} else {
+					// Failed before reaching Execute (state prep or the Prepare hook):
+					// no side effect ran, so per the spec `failed` — which means
+					// "Execute failed" and implies compensation on resume (§4.2) —
+					// MUST NOT be recorded. Preserve the pre-execute state (`started`
+					// if the write-ahead ran, else `pending`) so rehydrateInto does not
+					// add this step to lastExecutedStepIDs and resume does not
+					// compensate a step that never executed. This matches the live D5
+					// skip, which excludes prepare-failed steps from executedStepIDs.
+					stepState = w.stepStateAt(index)
+				}
 			}
 			var snapshot *SyncNamespacedStateBag
 			if _, isWorkflowStep := step.(*workflow); !isWorkflowStep {

--- a/workflow.go
+++ b/workflow.go
@@ -904,6 +904,16 @@ func (w *workflow) invokeRollbackFunc(ctx context.Context) *Report {
 	)
 }
 
+// Rollback compensates the workflow's executed steps in reverse order. It is the
+// manual/explicit compensation entry point, distinct from the automatic rollback
+// that Execute drives on failure under RollbackOnError.
+//
+// Rollback does NOT fire the onCompletion/onFailure callbacks: those are
+// Execute-lifecycle callbacks (they report the outcome of an execution attempt),
+// whereas a caller-invoked Rollback is a separate, intentional compensation
+// action that may well be a deliberate teardown rather than a failure. Firing
+// onFailure for an intentional rollback would be surprising. Callers that want to
+// observe manual rollback should use the returned report.
 func (w *workflow) Rollback(ctx context.Context) *Report {
 	if w.rollback != nil {
 		return w.invokeRollbackFunc(ctx)

--- a/workflow.go
+++ b/workflow.go
@@ -693,9 +693,15 @@ func (w *workflow) Execute(ctx context.Context) *Report {
 			}
 		}
 
-		// Capture state snapshot after step processing (successful or failed)
-		// Clone() creates an immutable snapshot by deep-cloning all namespaces (local, global).
-		// This ensures later steps cannot mutate earlier snapshots, enabling deterministic rollback.
+		// Capture a state snapshot after step processing (successful or failed) for
+		// deterministic rollback. Clone() deep-copies only values that implement a
+		// Clone method (the Cloner contract); plain map/slice/pointer values are
+		// copied by reference (state.go), so this snapshot is immutable ONLY for
+		// Cloner values. If a step stores a bare map/slice/pointer in state and a
+		// later step mutates it in place, this snapshot observes that mutation. Store
+		// Cloner values (or copy-on-write) when relying on snapshot rollback. Note the
+		// journaled path is unaffected: F4 serializes the snapshot to JSON at commit
+		// time (a true deep copy) before any later step runs.
 		// State preservation can be disabled via preserveStatesForRollback to reduce memory overhead.
 		if w.preserveStatesForRollback {
 			if state := step.State(); state != nil {


### PR DESCRIPTION
## Description

This pull request introduces several important durability and correctness improvements to the workflow engine, especially around step execution, compensation, and journaling. The changes clarify and enforce the idempotency and compensation contracts, ensure correct behavior on workflow resume, and improve documentation and test coverage for subtle edge cases.

**Durability and Compensation Semantics:**

* Steps that fail before reaching `Execute` (e.g., in their `Prepare` hook) are now correctly journaled as `started`, not `failed`, preventing erroneous compensation on resume and matching the intended live execution semantics. [[1]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafR736-R755) [[2]](diffhunk://#diff-d6d4f00537cc19676e63096154b65ce2b14900dcdab1ffa6da7858d57ff3db75R108-R150) [[3]](diffhunk://#diff-83bd7d80ab91891fbc5e922e353dcdb362298c35600fe6dfb227049c6df067f7R129-R203)
* The workflow engine now explicitly documents and enforces that only one process may own a journal at a time; concurrent resumes against the same journal are unsupported and may cause double-execution. [[1]](diffhunk://#diff-eef95cc35414311be7abec988101dd5e7324a9b09d826d8f72026b9cba44c97eR40-R45) [[2]](diffhunk://#diff-79f27547bbbd3f5a98d1a83e3ef7dca2416ea28db7792013ee569ac424126924R199-R211)
* The onCompletion/onFailure callbacks are now only fired once per run: never during a pure replay of a terminal (`done`) journal, and correctly fired when resuming and completing an interrupted compensation. [[1]](diffhunk://#diff-aaf0d788c9b131c2e412b76f9d035f172fb4d4561ede4462fdf0727a064b8994L246-R274) [[2]](diffhunk://#diff-83bd7d80ab91891fbc5e922e353dcdb362298c35600fe6dfb227049c6df067f7R129-R203)

**State and Rollback Fidelity:**

* Documentation and code comments clarify that state snapshots for rollback are deeply cloned only for types implementing the `Cloner` interface; plain maps/slices/pointers are shallow-copied, so in-place mutations after snapshot can affect rollback fidelity. [[1]](diffhunk://#diff-320959764bfa2277e0bdd4eaa741f02891d123c42150d4ccb76de0bdbf6e591aR91-R95) [[2]](diffhunk://#diff-f789a7245fb48ae3d30877bd241f7a279a2eec3b4de705284a3e39d3f0cd9dafL696-R704)

**Bash Step Improvements:**

* The Bash script step now supports context cancellation, ensuring that long-running scripts can be terminated if the workflow context is cancelled or times out. Tests verify that cancellation works as expected. [[1]](diffhunk://#diff-35b024487ffec02b64e31ad18427d1a6c1fb716a5ce14b40bcd4ba07b1646317R14-R34) [[2]](diffhunk://#diff-35b024487ffec02b64e31ad18427d1a6c1fb716a5ce14b40bcd4ba07b1646317L53-R65) [[3]](diffhunk://#diff-cee840219198fa7097f00572c555b32924a82f37b64ce846d42263476341a634R36-R49) [[4]](diffhunk://#diff-cee840219198fa7097f00572c555b32924a82f37b64ce846d42263476341a634R9)

**Documentation:**

* The durability specification and user documentation are updated to clarify idempotency requirements, compensation rules, and known limitations such as error type fidelity and snapshot mutability. [[1]](diffhunk://#diff-eef95cc35414311be7abec988101dd5e7324a9b09d826d8f72026b9cba44c97eR321-R348) [[2]](diffhunk://#diff-79f27547bbbd3f5a98d1a83e3ef7dca2416ea28db7792013ee569ac424126924R375-R382) [[3]](diffhunk://#diff-79f27547bbbd3f5a98d1a83e3ef7dca2416ea28db7792013ee569ac424126924R548-R551)

**Testing:**

* New tests cover edge cases for compensation, step state recording, context cancellation, and callback firing on resume, ensuring the new semantics are robustly enforced. [[1]](diffhunk://#diff-d6d4f00537cc19676e63096154b65ce2b14900dcdab1ffa6da7858d57ff3db75R108-R150) [[2]](diffhunk://#diff-83bd7d80ab91891fbc5e922e353dcdb362298c35600fe6dfb227049c6df067f7R129-R203) [[3]](diffhunk://#diff-cee840219198fa7097f00572c555b32924a82f37b64ce846d42263476341a634R36-R49)

These changes collectively improve the reliability, predictability, and observability of durable workflows, especially in failure and resume scenarios.

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
